### PR TITLE
Made the transition period configurable.

### DIFF
--- a/blueprints/hooks/light/light.yaml
+++ b/blueprints/hooks/light/light.yaml
@@ -63,6 +63,17 @@ blueprint:
           step: 1
           unit_of_measurement: milliseconds
           mode: box
+    step_transition:
+      name: (Optional) Step Transition
+      description: Time in milliseconds the lights takes to tranistion between every step. Use for smoothing the dimming experience.
+      default: 250
+      selector:
+        number:
+          min: 0
+          max: 1000
+          step: 10
+          unit_of_measurement: milliseconds
+          mode: slider
     min_brightness:
       name: (Optional) Light minimum brightness
       description: The minimum brightness the light can be set with this automation.
@@ -138,6 +149,7 @@ variables:
   brightness_steps_long: !input brightness_steps_long
   force_brightness: !input force_brightness
   on_brightness: !input on_brightness
+  step_transition: !input step_transition
   # Blueprint data
   supported_color_modes:
     Auto: auto
@@ -274,14 +286,14 @@ action:
           - service: light.turn_on
             data:
               brightness: '{{ [ [state_attr(light,"brightness")+step_short, min_brightness] | max, max_brightness] | min }}'
-              transition: 0.25
+              transition: '{{ step_transition / 1000 | float }}'
               entity_id: !input light
       - conditions: '{{ action == brightness_down }}'
         sequence:
           - service: light.turn_on
             data:
               brightness: '{{ [ [state_attr(light,"brightness")-step_short, min_brightness] | max, max_brightness] | min }}'
-              transition: 0.25
+              transition: '{{ step_transition / 1000 | float }}'
               entity_id: !input light
       - conditions: '{{ action == brightness_up_repeat }}'
         sequence:
@@ -291,7 +303,7 @@ action:
                 - service: light.turn_on
                   data:
                     brightness: '{{ [ [state_attr(light,"brightness")+step_long, min_brightness] | max, max_brightness] | min }}'
-                    transition: 0.25
+                    transition: '{{ step_transition / 1000 | float }}'
                     entity_id: !input light
                 - delay:
                     milliseconds: 250
@@ -303,7 +315,7 @@ action:
                 - service: light.turn_on
                   data:
                     brightness: '{{ [ [state_attr(light,"brightness")-step_long, min_brightness] | max, max_brightness] | min }}'
-                    transition: 0.25
+                    transition: '{{ step_transition / 1000 | float }}'
                     entity_id: !input light
                 - delay:
                     milliseconds: 250
@@ -315,14 +327,14 @@ action:
                 - service: light.turn_on
                   data:
                     color_temp: '{{ state_attr(light,"color_temp")|int + 50 }}'
-                    transition: 0.25
+                    transition: '{{ step_transition / 1000 | float }}'
                   entity_id: !input light
             - conditions: '{{ light_color_mode_id == "hs_color" }}'
               sequence:
                 - service: light.turn_on
                   data:
                     hs_color: '{{ [((state_attr(light,"hs_color")[0] or 0) + 15) % 360, 100] }}'
-                    transition: 0.25
+                    transition: '{{ step_transition / 1000 | float }}'
                   entity_id: !input light
       - conditions: '{{ action == color_down }}'
         sequence:
@@ -332,14 +344,14 @@ action:
                 - service: light.turn_on
                   data:
                     color_temp: '{{ [state_attr(light,"color_temp")|int - 50, 1]|max }}'
-                    transition: 0.25
+                    transition: '{{ step_transition / 1000 | float }}'
                   entity_id: !input light
             - conditions: '{{ light_color_mode_id == "hs_color" }}'
               sequence:
                 - service: light.turn_on
                   data:
                     hs_color: '{{ [((state_attr(light,"hs_color")[0] or 0) - 15) % 360, 100] }}'
-                    transition: 0.25
+                    transition: '{{ step_transition / 1000 | float }}'
                   entity_id: !input light
       - conditions: '{{ action == color_up_repeat }}'
         sequence:
@@ -352,7 +364,7 @@ action:
                       - service: light.turn_on
                         data:
                           color_temp: '{{ state_attr(light,"color_temp")|int + 50 }}'
-                          transition: 0.25
+                          transition: '{{ step_transition / 1000 | float }}'
                         entity_id: !input light
                       - delay:
                           milliseconds: 250
@@ -364,7 +376,7 @@ action:
                       - service: light.turn_on
                         data:
                           hs_color: '{{ [((state_attr(light,"hs_color")[0] or 0) + 15) % 360, 100] }}'
-                          transition: 0.25
+                          transition: '{{ step_transition / 1000 | float }}'
                         entity_id: !input light
                       - delay:
                           milliseconds: 250
@@ -379,7 +391,7 @@ action:
                       - service: light.turn_on
                         data:
                           color_temp: '{{ [state_attr(light,"color_temp")|int - 50, 1]|max }}'
-                          transition: 0.25
+                          transition: '{{ step_transition / 1000 | float }}'
                         entity_id: !input light
                       - delay:
                           milliseconds: 250
@@ -391,7 +403,7 @@ action:
                       - service: light.turn_on
                         data:
                           hs_color: '{{ [((state_attr(light,"hs_color")[0] or 0) - 15) % 360, 100] }}'
-                          transition: 0.25
+                          transition: '{{ step_transition / 1000 | float }}'
                         entity_id: !input light
                       - delay:
                           milliseconds: 250


### PR DESCRIPTION
Added an option to make the transition period when dimming, configurable.

I encountered the issue that dimming for me was just not smooth, upping it with 10ms fixed this for me.
I can imagine this is also depended on the controller and debounce settings so I made it configurable :)