### PR TITLE
Adds two new loop pause inputs

### DIFF
--- a/blueprints/controllers/ikea_e1744/ikea_e1744.yaml
+++ b/blueprints/controllers/ikea_e1744/ikea_e1744.yaml
@@ -96,6 +96,17 @@ blueprint:
           max: 5000
           mode: slider
           step: 1
+    rotate_left_loop_pause_length:
+      name: (Optional) Rotate left - Loop pause length
+      description: >-
+        The time to pause before looping again
+      default: 200
+      selector:
+        number:
+          min: 0
+          max: 2000
+          mode: slider
+          step: 1
     rotate_right_loop:
       name: (Optional) Rotate right - loop until stop
       description: Loop the rotate right action until the rotation is stopped.
@@ -112,6 +123,17 @@ blueprint:
         number:
           min: 1
           max: 5000
+          mode: slider
+          step: 1
+    rotate_right_loop_pause_length:
+      name: (Optional) Rotate right - Loop pause length
+      description: >-
+        The time to pause before looping again
+      default: 200
+      selector:
+        number:
+          min: 0
+          max: 2000
           mode: slider
           step: 1
     # helpers used to properly recognize the remote button events
@@ -255,7 +277,12 @@ action:
                 sequence:
                   - repeat:
                       while: '{{ repeat.index < rotate_left_max_loop_repeats | int }}'
-                      sequence: !input action_rotate_left
+                      sequence:
+                        - choose:
+                          default: !input action_rotate_left
+                        - delay:
+                            milliseconds: !input rotate_left_loop_pause_length
+
             # if looping is not enabled run the custom action only once
             default: !input action_rotate_left
       - conditions:
@@ -285,7 +312,11 @@ action:
                 sequence:
                   - repeat:
                       while: '{{ repeat.index < rotate_right_max_loop_repeats | int }}'
-                      sequence: !input action_rotate_right
+                      sequence:
+                        - choose:
+                          default: !input action_rotate_right
+                        - delay:
+                            milliseconds: !input rotate_right_loop_pause_length
             # if looping is not enabled run the custom action only once
             default: !input action_rotate_right
       - conditions:


### PR DESCRIPTION


## Proposed change\*
closes EPMatt/awesome-ha-blueprints#101

When the volume control is used and looping is enabled, with some media players the volume change happens too rapidly and the result is that the rotary controller is overly sensitive, making it difficult for end-users to accurately change the volume.

The cause is that the loops to change the volume have no delays programmed in, triggering volume changes events immediately one after the other. 

The solution proposed in this PR is as follows:
* Adds two new inputs to hold a time value which will be used for adding a pause in each rotation loop
* Enables customisations to how quickly the volume changes when turning the rotary dial

## Checklist\*

- [x] I followed sections of the [Contribution Guidelines](https://github.com/EPMatt/awesome-ha-blueprints/blob/main/CONTRIBUTING.md) relevant to changes I'm proposing.
- [x] I properly tested proposed changes on my system and confirm that they are working as expected.
- [x] I formatted files with Prettier using the command `npm run format` before submitting my Pull Request.
