### PR TITLE
Fix IKEA e1810 long press for media_player

### DIFF
--- a/blueprints/hooks/media_player/media_player.yaml
+++ b/blueprints/hooks/media_player/media_player.yaml
@@ -93,7 +93,7 @@ variables:
       volume_down_repeat: button_down_long
       next_track: button_right_short
       prev_track: button_left_short
-      stop: button_center_hold
+      stop: button_center_long
       play_pause: button_center_short
     ikea_e1743:
       volume_up: button_up_short


### PR DESCRIPTION
Thank you for taking the time to work on a Pull Request. Your contribution is really appreciated! :tada:
**Please don't delete any part of the template**, since keeping the provided structure will help maintainers to review your work more rapidly.

Sections marked as \* are required and need to be filled in.

## Proposed change\*

IKEA e1810 doesn't have button_center_hold, I think this is a typo.
It works better with button_center_long

## Checklist\*

- [x] I followed sections of the [Contribution Guidelines](https://github.com/EPMatt/awesome-ha-blueprints/blob/main/CONTRIBUTING.md) relevant to changes I'm proposing.
- [x] I properly tested proposed changes on my system and confirm that they are working as expected.
- [x] I formatted files with Prettier using the command `npm run format` before submitting my Pull Request.
