### PR TITLE
Add blueprint for LK FUGA Wiser 550D6001 4-button controller

### DIFF
--- a/blueprints/controllers/lk_fuga_wiser_550d6001/lk_fuga_wiser_550d6001.yaml
+++ b/blueprints/controllers/lk_fuga_wiser_550d6001/lk_fuga_wiser_550d6001.yaml
@@ -410,11 +410,11 @@ action:
                           - event: ahb_controller_event
                             event_data:
                               controller: '{{ controller_id }}'
-                              action: button_top_left_short
+                              action: button_top_left_double
                           # run the custom action
                           - choose:
                               - conditions: []
-                                sequence: !input action_button_top_left_short
+                                sequence: !input action_button_top_left_double
                     # previous event was not a short press
                     default:
                       # wait for the double press event to occur, within the provided delay
@@ -496,11 +496,11 @@ action:
                           - event: ahb_controller_event
                             event_data:
                               controller: '{{ controller_id }}'
-                              action: button_top_right_short
+                              action: button_top_right_double
                           # run the custom action
                           - choose:
                               - conditions: []
-                                sequence: !input action_button_top_right_short
+                                sequence: !input action_button_top_right_double
                     # previous event was not a short press
                     default:
                       # wait for the double press event to occur, within the provided delay
@@ -582,11 +582,11 @@ action:
                           - event: ahb_controller_event
                             event_data:
                               controller: '{{ controller_id }}'
-                              action: button_bottom_left_short
+                              action: button_bottom_left_double
                           # run the custom action
                           - choose:
                               - conditions: []
-                                sequence: !input action_button_bottom_left_short
+                                sequence: !input action_button_bottom_left_double
                     # previous event was not a short press
                     default:
                       # wait for the double press event to occur, within the provided delay
@@ -668,11 +668,11 @@ action:
                           - event: ahb_controller_event
                             event_data:
                               controller: '{{ controller_id }}'
-                              action: button_bottom_right_short
+                              action: button_bottom_right_double
                           # run the custom action
                           - choose:
                               - conditions: []
-                                sequence: !input action_button_bottom_right_short
+                                sequence: !input action_button_bottom_right_double
                     # previous event was not a short press
                     default:
                       # wait for the double press event to occur, within the provided delay

--- a/blueprints/controllers/lk_fuga_wiser_550d6001/lk_fuga_wiser_550d6001.yaml
+++ b/blueprints/controllers/lk_fuga_wiser_550d6001/lk_fuga_wiser_550d6001.yaml
@@ -1,0 +1,735 @@
+# Blueprint metadata
+blueprint:
+  name: Controller - LK FUGA Wiser 550D6001 On/Off Switch & Dimmer
+  description: |
+    # Controller - LK FUGA Wiser 550D6001 On/Off Switch & Dimmer
+
+    Controller automation for executing any kind of action triggered by the provided LK FUGA Wiser 550D6001 On/Off Switch & Dimmer. Allows to optionally loop an action on a button long press.
+    Supports Zigbee2MQTT.
+
+    Automations created with this blueprint can be connected with one or more [Hooks](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/hooks) supported by this controller.
+    Hooks allow to easily create controller-based automations for interacting with media players, lights, covers and more.
+    See the list of [Hooks available for this controller](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/controllers/lk_fuga_wiser_550d6001#available-hooks) for additional details.
+
+    📕 Full documentation regarding this blueprint is available [here](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/controllers/lk_fuga_wiser_550d6001).
+
+    🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
+
+    ℹ️ Version 2021.11.06
+  # source_url: https://github.com/EPMatt/awesome-ha-blueprints/blob/main/blueprints/controllers/lk_fuga_wiser_550d6001/lk_fuga_wiser_550d6001.yaml
+  domain: automation
+  input:
+    integration:
+      name: (Required) Integration
+      description: Integration used for connecting the remote with Home Assistant. Select one of the available values.
+      selector:
+        select:
+          options:
+            - Zigbee2MQTT
+    controller_entity:
+      name: (Zigbee2MQTT) Controller Entity
+      description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
+      default: ''
+      selector:
+        entity:
+          domain: sensor
+    helper_last_controller_event:
+      name: (Required) Helper - Last Controller Event
+      description: Input Text used to store the last event fired by the controller. You will need to manually create a text input entity for this, please read the blueprint Additional Notes for more info.
+      default: ''
+      selector:
+        entity:
+          domain: input_text
+
+    # inputs for custom actions
+    action_button_top_left_short:
+      name: (Optional) Top left button short press
+      description: Action to run on short top left button press.
+      default: []
+      selector:
+        action:
+    action_button_top_left_long:
+      name: (Optional) Top left button long press
+      description: Action to run on top left long button press.
+      default: []
+      selector:
+        action:
+    action_button_top_left_release:
+      name: (Optional) Top left button release
+      description: Action to run on top left button release after long press.
+      default: []
+      selector:
+        action:
+    action_button_top_left_double:
+      name: (Optional) Top left button double press
+      description: Action to run on double top left button press.
+      default: []
+      selector:
+        action:
+
+    action_button_top_right_short:
+      name: (Optional) Top right button short press
+      description: Action to run on short top right button press.
+      default: []
+      selector:
+        action:
+    action_button_top_right_long:
+      name: (Optional) Top right button long press
+      description: Action to run on long top right button press.
+      default: []
+      selector:
+        action:
+    action_button_top_right_release:
+      name: (Optional) Top right button release
+      description: Action to run on top right button release after long press.
+      default: []
+      selector:
+        action:
+    action_button_top_right_double:
+      name: (Optional) Top right button double press
+      description: Action to run on double top right button press.
+      default: []
+      selector:
+        action:
+
+    action_button_bottom_left_short:
+      name: (Optional) Bottom left button short press
+      description: Action to run on short bottom left button press.
+      default: []
+      selector:
+        action:
+    action_button_bottom_left_long:
+      name: (Optional) Bottom left button long press
+      description: Action to run on bottom left long button press.
+      default: []
+      selector:
+        action:
+    action_button_bottom_left_release:
+      name: (Optional) Bottom left button release
+      description: Action to run on bottom left button release after long press.
+      default: []
+      selector:
+        action:
+    action_button_bottom_left_double:
+      name: (Optional) Bottom left button double press
+      description: Action to run on double bottom left button press.
+      default: []
+      selector:
+        action:
+
+    action_button_bottom_right_short:
+      name: (Optional) Bottom right button short press
+      description: Action to run on short bottom right button press.
+      default: []
+      selector:
+        action:
+    action_button_bottom_right_long:
+      name: (Optional) Bottom right button long press
+      description: Action to run on long bottom right button press.
+      default: []
+      selector:
+        action:
+    action_button_bottom_right_release:
+      name: (Optional) Bottom right button release
+      description: Action to run on bottom right button release after long press.
+      default: []
+      selector:
+        action:
+    action_button_bottom_right_double:
+      name: (Optional) Bottom right button double press
+      description: Action to run on double bottom right button press.
+      default: []
+      selector:
+        action:
+
+    # inputs for looping custom actions on long button press events until the corresponding release event is received
+    button_top_left_long_loop:
+      name: (Optional) Top left button long press - loop until release
+      description: Loop the top left button action until the button is released.
+      default: false
+      selector:
+        boolean:
+    button_top_left_long_max_loop_repeats:
+      name: (Optional) Top left button long press - Maximum loop repeats
+      description: >-
+        Maximum number of repeats for the custom action, when looping is enabled.
+        Use it as a safety limit to prevent an endless loop in case the corresponding stop event is not received.
+      default: 500
+      selector:
+        number:
+          min: 1
+          max: 5000
+          mode: slider
+          step: 1
+
+    button_top_right_long_loop:
+      name: (Optional) Top right button long press - loop until release
+      description: Loop the top right button action until the button is released.
+      default: false
+      selector:
+        boolean:
+    button_top_right_long_max_loop_repeats:
+      name: (Optional) Top right button long press - Maximum loop repeats
+      description: >-
+        Maximum number of repeats for the custom action, when looping is enabled.
+        Use it as a safety limit to prevent an endless loop in case the corresponding stop event is not received.
+      default: 500
+      selector:
+        number:
+          min: 1
+          max: 5000
+          mode: slider
+          step: 1
+
+    button_bottom_left_long_loop:
+      name: (Optional) Bottom left button long press - loop until release
+      description: Loop the bottom left button action until the button is released.
+      default: false
+      selector:
+        boolean:
+    button_bottom_left_long_max_loop_repeats:
+      name: (Optional) Bottom left button long press - Maximum loop repeats
+      description: >-
+        Maximum number of repeats for the custom action, when looping is enabled.
+        Use it as a safety limit to prevent an endless loop in case the corresponding stop event is not received.
+      default: 500
+      selector:
+        number:
+          min: 1
+          max: 5000
+          mode: slider
+          step: 1
+
+    button_bottom_right_long_loop:
+      name: (Optional) Bottom right button long press - loop until release
+      description: Loop the bottom right button action until the button is released.
+      default: false
+      selector:
+        boolean:
+    button_bottom_right_long_max_loop_repeats:
+      name: (Optional) Bottom right button long press - Maximum loop repeats
+      description: >-
+        Maximum number of repeats for the custom action, when looping is enabled.
+        Use it as a safety limit to prevent an endless loop in case the corresponding stop event is not received.
+      default: 500
+      selector:
+        number:
+          min: 1
+          max: 5000
+          mode: slider
+          step: 1
+
+    # inputs for enabling double press events
+    button_top_left_double_press:
+      name: (Optional) Expose top left button double press event
+      description: Choose whether or not to expose the virtual double press event for the top left button. Turn this on if you are providing an action for the top left button double press event.
+      default: false
+      selector:
+        boolean:
+
+    button_top_right_double_press:
+      name: (Optional) Expose top right button double press event
+      description: Choose whether or not to expose the virtual double press event for the top right button. Turn this on if you are providing an action for the top right button double press event.
+      default: false
+      selector:
+        boolean:
+
+    button_bottom_left_double_press:
+      name: (Optional) Expose bottom left button double press event
+      description: Choose whether or not to expose the virtual double press event for the bottom left button. Turn this on if you are providing an action for the bottom left button double press event.
+      default: false
+      selector:
+        boolean:
+
+    button_bottom_right_double_press:
+      name: (Optional) Expose bottom right button double press event
+      description: Choose whether or not to expose the virtual double press event for the bottom right button. Turn this on if you are providing an action for the bottom right button double press event.
+      default: false
+      selector:
+        boolean:
+
+    # helpers used to properly recognize the remote button events
+    helper_double_press_delay:
+      name: (Optional) Helper - Double Press delay
+      description: Max delay between the first and the second button press for the double press event. Provide a value only if you are using a double press action. Increase this value if you notice that the double press action is not triggered properly.
+      default: 500
+      selector:
+        number:
+          min: 100
+          max: 5000
+          unit_of_measurement: milliseconds
+          mode: box
+          step: 10
+    helper_debounce_delay:
+      name: (Optional) Helper - Debounce delay
+      description:
+        Delay used for debouncing RAW controller events, by default set to 0. A value of 0 disables the debouncing feature. Increase this value if you notice custom actions or linked Hooks running multiple times when interacting with the device. When the controller needs to be debounced,
+        usually a value of 100 is enough to remove all duplicate events.
+      default: 0
+      selector:
+        number:
+          min: 0
+          max: 1000
+          unit_of_measurement: milliseconds
+          mode: box
+          step: 10
+
+# Automation schema
+variables:
+  # convert input tags to variables, to be used in templates
+  integration: !input integration
+  button_top_left_long_loop: !input button_top_left_long_loop
+  button_top_left_long_max_loop_repeats: !input button_top_left_long_max_loop_repeats
+  button_top_left_double_press: !input button_top_left_double_press
+
+  button_top_right_long_loop: !input button_top_right_long_loop
+  button_top_right_long_max_loop_repeats: !input button_top_right_long_max_loop_repeats
+  button_top_right_double_press: !input button_top_right_double_press
+
+  button_bottom_left_long_loop: !input button_bottom_left_long_loop
+  button_bottom_left_long_max_loop_repeats: !input button_bottom_left_long_max_loop_repeats
+  button_bottom_left_double_press: !input button_bottom_left_double_press
+
+  button_bottom_right_long_loop: !input button_bottom_right_long_loop
+  button_bottom_right_long_max_loop_repeats: !input button_bottom_right_long_max_loop_repeats
+  button_bottom_right_double_press: !input button_bottom_right_double_press
+
+  helper_last_controller_event: !input helper_last_controller_event
+  helper_double_press_delay: !input helper_double_press_delay
+  helper_debounce_delay: !input helper_debounce_delay
+
+  # integration id used to select items in the action mapping
+  integration_id: '{{ integration | lower }}'
+
+  # adjusted debounce delay so that the resulting double press delay is exactly
+  # as specified by the user when running the action, taking also account of
+  # debouncing
+  #
+  # make sure it never goes below the minimum double press delay
+  adjusted_double_press_delay: '{{ [helper_double_press_delay - helper_debounce_delay, 100] | max }}'
+  # mapping between actions and integrations
+  actions_mapping:
+    zigbee2mqtt:
+      button_top_left_short: ['on_top']
+      button_top_right_short: ['off_top']
+      button_top_left_long: [brightness_top_increase]
+      button_top_left_release: [brightness_top_stop]
+      button_top_right_long: [brightness_top_decrease]
+      button_top_right_release: [brightness_top_stop]
+      button_bottom_left_short: ['on_bottom']
+      button_bottom_right_short: ['off_bottom']
+      button_bottom_left_long: [brightness_bottom_increase]
+      button_bottom_left_release: [brightness_bottom_stop]
+      button_bottom_right_long: [brightness_bottom_decrease]
+      button_bottom_right_release: [brightness_bottom_stop]
+
+  # pre-choose actions for buttons based on configured integration
+  # no need to perform this task at automation runtime
+  button_top_left_short: '{{ actions_mapping[integration_id]["button_top_left_short"] }}'
+  button_top_right_short: '{{ actions_mapping[integration_id]["button_top_right_short"] }}'
+  button_top_left_long: '{{ actions_mapping[integration_id]["button_top_left_long"] }}'
+  button_top_left_release: '{{ actions_mapping[integration_id]["button_top_left_release"] }}'
+  button_top_right_long: '{{ actions_mapping[integration_id]["button_top_right_long"] }}'
+  button_top_right_release: '{{ actions_mapping[integration_id]["button_top_right_release"] }}'
+  button_bottom_left_short: '{{ actions_mapping[integration_id]["button_bottom_left_short"] }}'
+  button_bottom_right_short: '{{ actions_mapping[integration_id]["button_bottom_right_short"] }}'
+  button_bottom_left_long: '{{ actions_mapping[integration_id]["button_bottom_left_long"] }}'
+  button_bottom_left_release: '{{ actions_mapping[integration_id]["button_bottom_left_release"] }}'
+  button_bottom_right_long: '{{ actions_mapping[integration_id]["button_bottom_right_long"] }}'
+  button_bottom_right_release: '{{ actions_mapping[integration_id]["button_bottom_right_release"] }}'
+
+  # integrations which need to store the previous long press event to determine
+  # which button was released
+  integrations_with_prev_event_storage: [zigbee2mqtt]
+  # build data to send within a controller event
+  controller_entity: !input controller_entity
+  controller_id: '{{controller_entity}}'
+
+mode: restart
+max_exceeded: silent
+trigger:
+  # trigger for zigbee2mqtt
+  - platform: event
+    event_type: state_changed
+    event_data:
+      entity_id: !input controller_entity
+condition:
+  - condition: and
+    conditions:
+      # check that the button event is not empty
+      - >-
+        {%- set trigger_action -%}
+        {{ trigger.event.data.new_state.state }}
+        {%- endset -%}
+        {{ trigger_action not in ["","None"] }}
+      # only for zigbee2mqtt, check if the event is relative to a real state
+      # change, and not only some minor changes in the sensor attributes this is
+      # required since multiple state_changed events are fired for a single
+      # button press, with the result of the automation being triggered multiple
+      # times
+      - '{{ trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+action:
+  # debouncing - when automation is triggered multiple times, the last
+  # automation run is the one which completes execution, due to mode restart
+  # therefore previous runs must wait for the debounce delay before executing
+  # any other action if the delay expires and the automation is still running it
+  # means it's the last run and execution can continue
+  - delay:
+      milliseconds: !input helper_debounce_delay
+  # extract button event from the trigger
+  # provide a single string value to check against
+  - variables:
+      trigger_action: >-
+        {{ trigger.event.data.new_state.state }}
+      trigger_delta: '{{ (as_timestamp(now()) - as_timestamp((states(helper_last_controller_event) | from_json).last_triggered if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{(\".*\": \".*\"(, )?)*\}$")) else "1970-01-01 00:00:00")) * 1000 }}'
+      last_controller_event: '{{ (states(helper_last_controller_event) | from_json).trigger_action if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{(\".*\": \".*\"(, )?)*\}$")) else "" }}'
+  # update helper
+  - service: input_text.set_value
+    data:
+      entity_id: !input helper_last_controller_event
+      value: '{{ {"trigger_action":trigger_action,"last_triggered":now()|string} | to_json }}'
+  # choose the sequence to run based on the received button event
+  - choose:
+      - conditions: '{{ trigger_action | string in button_top_left_short }}'
+        sequence:
+          - choose:
+              # if double press event is enabled
+              - conditions: '{{ button_top_left_double_press }}'
+                sequence:
+                  - choose:
+                      # if previous event was a short press
+                      - conditions: '{{ trigger_action | string in states(helper_last_controller_event) and trigger_delta | int <= helper_double_press_delay | int }}'
+                        sequence:
+                          # store the double press event in the last controller event helper
+                          - service: input_text.set_value
+                            data:
+                              entity_id: !input helper_last_controller_event
+                              value: '{{ {"trigger_action":"double_press","last_triggered":now() | string} | to_json }}'
+                          # run the double press action
+                          # fire the event
+                          - event: ahb_controller_event
+                            event_data:
+                              controller: '{{ controller_id }}'
+                              action: button_top_left_short
+                          # run the custom action
+                          - choose:
+                              - conditions: []
+                                sequence: !input action_button_top_left_short
+                    # previous event was not a short press
+                    default:
+                      # wait for the double press event to occur, within the provided delay
+                      # if the second press is received, automation is restarted
+                      - delay:
+                          milliseconds: '{{ adjusted_double_press_delay }}'
+                      # if delay expires, no second press was received, therefore run the short press action
+                      # run the short press action
+                      # fire the event
+                      - event: ahb_controller_event
+                        event_data:
+                          controller: '{{ controller_id }}'
+                          action: button_top_left_short
+                      # run the custom action
+                      - choose:
+                          - conditions: []
+                            sequence: !input action_button_top_left_short
+            # if double press event is disabled run the action for the single short press
+            default:
+              # fire the event
+              - event: ahb_controller_event
+                event_data:
+                  controller: '{{ controller_id }}'
+                  action: button_top_left_short
+              # run the custom action
+              - choose:
+                  - conditions: []
+                    sequence: !input action_button_top_left_short
+
+      - conditions: '{{ trigger_action | string in button_top_left_long }}'
+        sequence:
+          # fire the event only once before looping the action
+          - event: ahb_controller_event
+            event_data:
+              controller: '{{ controller_id }}'
+              action: button_top_left_long
+          - choose:
+              # if looping is enabled, loop the action for a finite number of iterations
+              - conditions: '{{ button_top_left_long_loop }}'
+                sequence:
+                  - repeat:
+                      while: '{{ repeat.index < button_top_left_long_max_loop_repeats | int }}'
+                      sequence: !input action_button_top_left_long
+            # if looping is not enabled run the custom action only once
+            default: !input action_button_top_left_long
+
+      - conditions:
+          - '{{ trigger_action | string in button_top_left_release }}'
+          # for integrations which need to store the last controller event, need to check the previous button event, stored in the provided input_text
+          - '{{ not integration_id in integrations_with_prev_event_storage or last_controller_event | string in button_top_left_long }}'
+        sequence:
+          # fire the event
+          - event: ahb_controller_event
+            event_data:
+              controller: '{{ controller_id }}'
+              action: button_top_left_release
+          # run the custom action
+          - choose:
+              - conditions: []
+                sequence: !input action_button_top_left_release
+
+      - conditions: '{{ trigger_action | string in button_top_right_short }}'
+        sequence:
+          - choose:
+              # if double press event is enabled
+              - conditions: '{{ button_top_right_double_press }}'
+                sequence:
+                  - choose:
+                      # if previous event was a short press
+                      - conditions: '{{ trigger_action | string in states(helper_last_controller_event) and trigger_delta | int <= helper_double_press_delay | int }}'
+                        sequence:
+                          # store the double press event in the last controller event helper
+                          - service: input_text.set_value
+                            data:
+                              entity_id: !input helper_last_controller_event
+                              value: '{{ {"trigger_action":"double_press","last_triggered":now() | string} | to_json }}'
+                          # run the double press action
+                          # fire the event
+                          - event: ahb_controller_event
+                            event_data:
+                              controller: '{{ controller_id }}'
+                              action: button_top_right_short
+                          # run the custom action
+                          - choose:
+                              - conditions: []
+                                sequence: !input action_button_top_right_short
+                    # previous event was not a short press
+                    default:
+                      # wait for the double press event to occur, within the provided delay
+                      # if the second press is received, automation is restarted
+                      - delay:
+                          milliseconds: '{{ adjusted_double_press_delay }}'
+                      # if delay expires, no second press was received, therefore run the short press action
+                      # run the short press action
+                      # fire the event
+                      - event: ahb_controller_event
+                        event_data:
+                          controller: '{{ controller_id }}'
+                          action: button_top_right_short
+                      # run the custom action
+                      - choose:
+                          - conditions: []
+                            sequence: !input action_button_top_right_short
+            # if double press event is disabled run the action for the single short press
+            default:
+              # fire the event
+              - event: ahb_controller_event
+                event_data:
+                  controller: '{{ controller_id }}'
+                  action: button_top_right_short
+              # run the custom action
+              - choose:
+                  - conditions: []
+                    sequence: !input action_button_top_right_short
+
+      - conditions: '{{ trigger_action | string in button_top_right_long }}'
+        sequence:
+          # fire the event only once before looping the action
+          - event: ahb_controller_event
+            event_data:
+              controller: '{{ controller_id }}'
+              action: button_top_right_long
+          - choose:
+              # if looping is enabled, loop the action for a finite number of iterations
+              - conditions: '{{ button_top_right_long_loop }}'
+                sequence:
+                  - repeat:
+                      while: '{{ repeat.index < button_top_right_long_max_loop_repeats | int }}'
+                      sequence: !input action_button_top_right_long
+            # if looping is not enabled run the custom action only once
+            default: !input action_button_top_right_long
+
+      - conditions:
+          - '{{ trigger_action | string in button_top_right_release }}'
+          # for integrations which need to store the last controller event, need to check the previous button event, stored in the provided input_text
+          - '{{ not integration_id in integrations_with_prev_event_storage or last_controller_event | string in button_top_right_long }}'
+        sequence:
+          # fire the event
+          - event: ahb_controller_event
+            event_data:
+              controller: '{{ controller_id }}'
+              action: button_top_right_release
+          # run the custom action
+          - choose:
+              - conditions: []
+                sequence: !input action_button_top_right_release
+
+      - conditions: '{{ trigger_action | string in button_bottom_left_short }}'
+        sequence:
+          - choose:
+              # if double press event is enabled
+              - conditions: '{{ button_bottom_left_double_press }}'
+                sequence:
+                  - choose:
+                      # if previous event was a short press
+                      - conditions: '{{ trigger_action | string in states(helper_last_controller_event) and trigger_delta | int <= helper_double_press_delay | int }}'
+                        sequence:
+                          # store the double press event in the last controller event helper
+                          - service: input_text.set_value
+                            data:
+                              entity_id: !input helper_last_controller_event
+                              value: '{{ {"trigger_action":"double_press","last_triggered":now() | string} | to_json }}'
+                          # run the double press action
+                          # fire the event
+                          - event: ahb_controller_event
+                            event_data:
+                              controller: '{{ controller_id }}'
+                              action: button_bottom_left_short
+                          # run the custom action
+                          - choose:
+                              - conditions: []
+                                sequence: !input action_button_bottom_left_short
+                    # previous event was not a short press
+                    default:
+                      # wait for the double press event to occur, within the provided delay
+                      # if the second press is received, automation is restarted
+                      - delay:
+                          milliseconds: '{{ adjusted_double_press_delay }}'
+                      # if delay expires, no second press was received, therefore run the short press action
+                      # run the short press action
+                      # fire the event
+                      - event: ahb_controller_event
+                        event_data:
+                          controller: '{{ controller_id }}'
+                          action: button_bottom_left_short
+                      # run the custom action
+                      - choose:
+                          - conditions: []
+                            sequence: !input action_button_bottom_left_short
+            # if double press event is disabled run the action for the single short press
+            default:
+              # fire the event
+              - event: ahb_controller_event
+                event_data:
+                  controller: '{{ controller_id }}'
+                  action: button_bottom_left_short
+              # run the custom action
+              - choose:
+                  - conditions: []
+                    sequence: !input action_button_bottom_left_short
+
+      - conditions: '{{ trigger_action | string in button_bottom_left_long }}'
+        sequence:
+          # fire the event only once before looping the action
+          - event: ahb_controller_event
+            event_data:
+              controller: '{{ controller_id }}'
+              action: button_bottom_left_long
+          - choose:
+              # if looping is enabled, loop the action for a finite number of iterations
+              - conditions: '{{ button_bottom_left_long_loop }}'
+                sequence:
+                  - repeat:
+                      while: '{{ repeat.index < button_bottom_left_long_max_loop_repeats | int }}'
+                      sequence: !input action_button_bottom_left_long
+            # if looping is not enabled run the custom action only once
+            default: !input action_button_bottom_left_long
+
+      - conditions:
+          - '{{ trigger_action | string in button_bottom_left_release }}'
+          # for integrations which need to store the last controller event, need to check the previous button event, stored in the provided input_text
+          - '{{ not integration_id in integrations_with_prev_event_storage or last_controller_event | string in button_bottom_left_long }}'
+        sequence:
+          # fire the event
+          - event: ahb_controller_event
+            event_data:
+              controller: '{{ controller_id }}'
+              action: button_bottom_left_release
+          # run the custom action
+          - choose:
+              - conditions: []
+                sequence: !input action_button_bottom_left_release
+
+      - conditions: '{{ trigger_action | string in button_bottom_right_short }}'
+        sequence:
+          - choose:
+              # if double press event is enabled
+              - conditions: '{{ button_bottom_right_double_press }}'
+                sequence:
+                  - choose:
+                      # if previous event was a short press
+                      - conditions: '{{ trigger_action | string in states(helper_last_controller_event) and trigger_delta | int <= helper_double_press_delay | int }}'
+                        sequence:
+                          # store the double press event in the last controller event helper
+                          - service: input_text.set_value
+                            data:
+                              entity_id: !input helper_last_controller_event
+                              value: '{{ {"trigger_action":"double_press","last_triggered":now() | string} | to_json }}'
+                          # run the double press action
+                          # fire the event
+                          - event: ahb_controller_event
+                            event_data:
+                              controller: '{{ controller_id }}'
+                              action: button_bottom_right_short
+                          # run the custom action
+                          - choose:
+                              - conditions: []
+                                sequence: !input action_button_bottom_right_short
+                    # previous event was not a short press
+                    default:
+                      # wait for the double press event to occur, within the provided delay
+                      # if the second press is received, automation is restarted
+                      - delay:
+                          milliseconds: '{{ adjusted_double_press_delay }}'
+                      # if delay expires, no second press was received, therefore run the short press action
+                      # run the short press action
+                      # fire the event
+                      - event: ahb_controller_event
+                        event_data:
+                          controller: '{{ controller_id }}'
+                          action: button_bottom_right_short
+                      # run the custom action
+                      - choose:
+                          - conditions: []
+                            sequence: !input action_button_bottom_right_short
+            # if double press event is disabled run the action for the single short press
+            default:
+              # fire the event
+              - event: ahb_controller_event
+                event_data:
+                  controller: '{{ controller_id }}'
+                  action: button_bottom_right_short
+              # run the custom action
+              - choose:
+                  - conditions: []
+                    sequence: !input action_button_bottom_right_short
+
+      - conditions: '{{ trigger_action | string in button_bottom_right_long }}'
+        sequence:
+          # fire the event only once before looping the action
+          - event: ahb_controller_event
+            event_data:
+              controller: '{{ controller_id }}'
+              action: button_bottom_right_long
+          - choose:
+              # if looping is enabled, loop the action for a finite number of iterations
+              - conditions: '{{ button_bottom_right_long_loop }}'
+                sequence:
+                  - repeat:
+                      while: '{{ repeat.index < button_bottom_right_long_max_loop_repeats | int }}'
+                      sequence: !input action_button_bottom_right_long
+            # if looping is not enabled run the custom action only once
+            default: !input action_button_bottom_right_long
+
+      - conditions:
+          - '{{ trigger_action | string in button_bottom_right_release }}'
+          # for integrations which need to store the last controller event, need to check the previous button event, stored in the provided input_text
+          - '{{ not integration_id in integrations_with_prev_event_storage or last_controller_event | string in button_bottom_right_long }}'
+        sequence:
+          # fire the event
+          - event: ahb_controller_event
+            event_data:
+              controller: '{{ controller_id }}'
+              action: button_bottom_right_release
+          # run the custom action
+          - choose:
+              - conditions: []
+                sequence: !input action_button_bottom_right_release


### PR DESCRIPTION
Thank you for taking the time to work on a Pull Request. Your contribution is really appreciated! :tada:
**Please don't delete any part of the template**, since keeping the provided structure will help maintainers to review your work more rapidly.

Sections marked as \* are required and need to be filled in.

## Proposed change\*

This PR adds Zigbee2MQTT support for Schneider Electric LK FUGA Wiser 550D6001 4-button controllers. See the Zigbee2MQTT page for more information on this controller: https://www.zigbee2mqtt.io/devices/550D6001.html

Currently status is that regular button presses work, but repeat, long press and double press do not -- I could use some help debugging why.

## Checklist\*

- [x] I followed sections of the [Contribution Guidelines](https://github.com/EPMatt/awesome-ha-blueprints/blob/main/CONTRIBUTING.md) relevant to changes I'm proposing.
- [ ] I properly tested proposed changes on my system and confirm that they are working as expected.
- [x] I formatted files with Prettier using the command `npm run format` before submitting my Pull Request.
