### PR TITLE
Update IKEA E1812 blueprint to support native controller double press

### DIFF
--- a/blueprints/controllers/ikea_e1812/ikea_e1812.yaml
+++ b/blueprints/controllers/ikea_e1812/ikea_e1812.yaml
@@ -4,7 +4,8 @@ blueprint:
   description: |
     # Controller - IKEA E1812 TRÅDFRI Shortcut button
 
-    Controller automation for executing any kind of action triggered by the provided IKEA E1812 TRÅDFRI Shortcut button. Allows to optionally loop an action on a button long press.
+    Controller automation for executing any kind of action triggered by the provided IKEA E1812 TRÅDFRI Shortcut button. 
+    Allows to optionally loop an action on a button long press as well as built-in double-click.
     Supports deCONZ, ZHA, Zigbee2MQTT.
 
     Automations created with this blueprint can be connected with one or more [Hooks](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/hooks) supported by this controller.
@@ -15,7 +16,7 @@ blueprint:
 
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
-    ℹ️ Version 2021.10.26
+    ℹ️ Version 2022.01.02
   source_url: https://github.com/EPMatt/awesome-ha-blueprints/blob/main/blueprints/controllers/ikea_e1812/ikea_e1812.yaml
   domain: automation
   input:
@@ -41,13 +42,6 @@ blueprint:
       selector:
         entity:
           domain: sensor
-    helper_last_controller_event:
-      name: (Required) Helper - Last Controller Event
-      description: Input Text used to store the last event fired by the controller. You will need to manually create a text input entity for this, please read the blueprint Additional Notes for more info.
-      default: ''
-      selector:
-        entity:
-          domain: input_text
     # inputs for custom actions
     action_button_short:
       name: (Optional) Button short press
@@ -92,25 +86,7 @@ blueprint:
           max: 5000
           mode: slider
           step: 1
-    # inputs for enabling double press events
-    button_double_press:
-      name: (Optional) Expose button double press event
-      description: Choose whether or not to expose the virtual double press event for the button. Turn this on if you are providing an action for the button double press event.
-      default: false
-      selector:
-        boolean:
     # helpers used to properly recognize the remote button events
-    helper_double_press_delay:
-      name: (Optional) Helper - Double Press delay
-      description: Max delay between the first and the second button press for the double press event. Provide a value only if you are using a double press action. Increase this value if you notice that the double press action is not triggered properly.
-      default: 500
-      selector:
-        number:
-          min: 100
-          max: 5000
-          unit_of_measurement: milliseconds
-          mode: box
-          step: 10
     helper_debounce_delay:
       name: (Optional) Helper - Debounce delay
       description:
@@ -130,34 +106,34 @@ variables:
   integration: !input integration
   button_long_loop: !input button_long_loop
   button_long_max_loop_repeats: !input button_long_max_loop_repeats
-  button_double_press: !input button_double_press
-  helper_last_controller_event: !input helper_last_controller_event
-  helper_double_press_delay: !input helper_double_press_delay
   helper_debounce_delay: !input helper_debounce_delay
   # integration id used to select items in the action mapping
   integration_id: '{{ integration | lower }}'
   # adjusted debounce delay so that the resulting double press delay is exactly as specified by the user when running the action, taking also account of debouncing
   # make sure it never goes below the minimum double press delay
-  adjusted_double_press_delay: '{{ [helper_double_press_delay - helper_debounce_delay, 100] | max }}'
   # mapping between actions and integrations
   actions_mapping:
     deconz:
       button_short: ['1002']
       button_long: ['1001']
       button_release: ['1003']
+      button_double: ['1004']
     zha:
       button_short: ['on']
       button_long: [move_with_on_off_0_83]
       button_release: [stop]
+      button_double: ['off']   # UNTESTED
     zigbee2mqtt:
       button_short: ['on']
       button_long: [brightness_move_up]
       button_release: [brightness_stop]
+      button_double: ['off']
   # pre-choose actions for buttons based on configured integration
   # no need to perform this task at automation runtime
   button_short: '{{ actions_mapping[integration_id]["button_short"] }}'
   button_long: '{{ actions_mapping[integration_id]["button_long"] }}'
   button_release: '{{ actions_mapping[integration_id]["button_release"] }}'
+  button_double: '{{ actions_mapping[integration_id]["button_double"] }}'
   # build data to send within a controller event
   controller_entity: !input controller_entity
   controller_device: !input controller_device
@@ -212,67 +188,19 @@ action:
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
         {%- endif -%}
-      trigger_delta: '{{ (as_timestamp(now()) - as_timestamp((states(helper_last_controller_event) | from_json).last_triggered if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{(\".*\": \".*\"(, )?)*\}$")) else "1970-01-01 00:00:00")) * 1000 }}'
-  # update helper
-  - service: input_text.set_value
-    data:
-      entity_id: !input helper_last_controller_event
-      value: '{{ {"trigger_action":trigger_action,"last_triggered":now()|string} | to_json }}'
   # choose the sequence to run based on the received button event
   - choose:
       - conditions: '{{ trigger_action | string in button_short }}'
         sequence:
+          # fire the event
+          - event: ahb_controller_event
+            event_data:
+              controller: '{{ controller_id }}'
+              action: button_short
+          # run the custom action
           - choose:
-              # if double press event is enabled
-              - conditions: '{{ button_double_press }}'
-                sequence:
-                  - choose:
-                      # if previous event was a short press
-                      - conditions: '{{ trigger_action | string in states(helper_last_controller_event) and trigger_delta | int <= helper_double_press_delay | int }}'
-                        sequence:
-                          # store the double press event in the last controller event helper
-                          - service: input_text.set_value
-                            data:
-                              entity_id: !input helper_last_controller_event
-                              value: '{{ {"trigger_action":"double_press","last_triggered":now() | string} | to_json }}'
-                          # run the double press action
-                          # fire the event
-                          - event: ahb_controller_event
-                            event_data:
-                              controller: '{{ controller_id }}'
-                              action: button_double
-                          # run the custom action
-                          - choose:
-                              - conditions: []
-                                sequence: !input action_button_double
-                    # previous event was not a short press
-                    default:
-                      # wait for the double press event to occur, within the provided delay
-                      # if the second press is received, automation is restarted
-                      - delay:
-                          milliseconds: '{{ adjusted_double_press_delay }}'
-                      # if delay expires, no second press was received, therefore run the short press action
-                      # run the short press action
-                      # fire the event
-                      - event: ahb_controller_event
-                        event_data:
-                          controller: '{{ controller_id }}'
-                          action: button_short
-                      # run the custom action
-                      - choose:
-                          - conditions: []
-                            sequence: !input action_button_short
-            # if double press event is disabled run the action for the single short press
-            default:
-              # fire the event
-              - event: ahb_controller_event
-                event_data:
-                  controller: '{{ controller_id }}'
-                  action: button_short
-              # run the custom action
-              - choose:
-                  - conditions: []
-                    sequence: !input action_button_short
+              - conditions: []
+                sequence: !input action_button_short
       - conditions: '{{ trigger_action | string in button_long }}'
         sequence:
           # fire the event only once before looping the action
@@ -300,3 +228,14 @@ action:
           - choose:
               - conditions: []
                 sequence: !input action_button_release
+      - conditions: '{{ trigger_action | string in button_double }}'
+        sequence:
+          # fire the event
+          - event: ahb_controller_event
+            event_data:
+              controller: '{{ controller_id }}'
+              action: button_double
+          # run the custom action
+          - choose:
+              - conditions: []
+                sequence: !input action_button_double

--- a/website/docs/blueprints/controllers/ikea_e1812.mdx
+++ b/website/docs/blueprints/controllers/ikea_e1812.mdx
@@ -19,7 +19,7 @@ This blueprint provides universal support for running any custom action when a b
 
 In addition of being able to provide custom actions for every kind of button press supported by the remote, the blueprint allows to loop the long press actions while the corresponding button is being held. Once released, the loop stops. This is useful when holding down a button should result in a continuous action (such as lowering the volume of a media player, or controlling a light brightness).
 
-The blueprint also adds support for virtual double button press events, which are not exposed by the controller itself.
+The blueprint also adds support for hardware double button press events, exposed by the controller itself.
 
 :::tip
 Automations created with this blueprint can be connected with one or more [Hooks](/docs/blueprints/hooks) supported by this controller.
@@ -32,12 +32,6 @@ Hooks allow to easily create controller-based automations for interacting with m
 <Requirement id='zha'/>
 <Requirement id='zigbee2mqtt'/>
 <Requirement name='Input Text Integration' required>
-
-This integration provides the entity which must be provided to the blueprint in the **Helper - Last Controller Event** input. Learn more about this helper by reading the dedicated section in the [Additional Notes](#helper---last-controller-event).
-
-[Input Text Integration Docs](https://www.home-assistant.io/integrations/input_text/)
-
-</Requirement>
 
 ## Inputs
 
@@ -96,27 +90,12 @@ This integration provides the entity which must be provided to the blueprint in 
   selector='number'
 />
 <Input
-  name='Expose button double press event'
-  description='Choose whether or not to expose the virtual double press event for the button. Turn this on if you are providing an action for the button double press event.'
-  selector='boolean'
-/>
-<Input
-  name='Helper - Double Press delay'
-  description='Max delay between the first and the second button press for the double press event. Provide a value only if you are using a double press action. Increase this value if you notice that the double press action is not triggered properly.'
-  selector='number'
-/>
-<Input
   name='Helper - Debounce delay'
   description='Delay used for debouncing RAW controller events, by default set to 0. A value of 0 disables the debouncing feature. Increase this value if you notice custom actions or linked Hooks running multiple times when interacting with the device. When the controller needs to be debounced, usually a value of 100 is enough to remove all duplicate events.'
   selector='number'
 />
 
 ## Available Hooks
-
-:::note Virtual double press actions
-Some of the following mappings might include actions for virtual double press events, which are disabled by default.
-If you are using a hook mapping which provides an action for a virtual double press event, please make sure to enable support for virtual double press on the corresponding buttons with the corresponding blueprint input.
-:::
 
 ### Light
 
@@ -159,10 +138,6 @@ This Hook blueprint allows to build a controller-based automation to control a c
 
 The `helper_last_controller_event` (Helper - Last Controller Event) input serves as a permanent storage area for the automation. The stored info is used to implement the blueprint's core functionality. To learn more about the helper, how it's used and why it's required, you can read the dedicated section in the [Controllers-Hooks Ecosystem documentation](/docs/controllers-hooks-ecosystem#helper---last-controller-event-input).
 
-### Virtual double press events
-
-It's also important to note that the controller doesn't natively support double press events. Instead , this blueprint provides virtual double press events. You can read more about them in the [general Controllers-Hooks Ecosystem documentation](/docs/controllers-hooks-ecosystem#virtual-events).
-
 ## Changelog
 
 - **2021-03-14**: first blueprint version :tada:
@@ -191,3 +166,4 @@ It's also important to note that the controller doesn't natively support double 
 - **2021-05-26**: Fix for Zigbee2MQTT reporting null state changes
 - **2021-08-02**: Improve inputs documentation and organization
 - **2021-10-26**: Standardize blueprints structure and inputs naming across the whole collection. Improve blueprint documentation. No functionality change.
+- **2022-01-02**: Support E1812 native double-click support introduced by IKEA in 2021. Removed need of helper for storing last action.


### PR DESCRIPTION
As IKEA introduced support of double-click in both E1812 and Gateway, I examined the actions sent by the E1812 and found that for Zigbee2MQTT this is treated as "off", and (from memory) in deCONZ as "1004".

Note on testing: This PR has so far ONLY been tested on:

- [ ] deCONZ
- [X] ZHA [comment](https://github.com/EPMatt/awesome-ha-blueprints/issues/168#issuecomment-1025105621)
- [X] Zigbee2MQTT 

## Proposed change\*

1. Add support of native double-press events from IKEA E1812. 
2. At the same time, removing support of virtual double press events as these are redundant.
3. Following that, removed the need of the helper input text and user declaration of double-press support.

This likely closes #168 

## Checklist\*

- [X] I followed sections of the [Contribution Guidelines](https://github.com/EPMatt/awesome-ha-blueprints/blob/main/CONTRIBUTING.md) relevant to changes I'm proposing.
- [X] I properly tested proposed changes on my system and confirm that they are working as expected.
- [ ] I formatted files with Prettier using the command `npm run format` before submitting my Pull Request.

