### PR TITLE
Fix Philips 929002398602 short press actions not triggered by quick clicks

### DIFF
--- a/blueprints/controllers/philips_929002398602/philips_929002398602.yaml
+++ b/blueprints/controllers/philips_929002398602/philips_929002398602.yaml
@@ -15,7 +15,7 @@ blueprint:
 
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
-    ℹ️ Version 2021.11.21
+    ℹ️ Version 2022.07.22
   source_url: https://github.com/EPMatt/awesome-ha-blueprints/blob/main/blueprints/controllers/philips_929002398602/philips_929002398602.yaml
   domain: automation
   input:
@@ -294,10 +294,10 @@ variables:
   # mapping between actions and integrations
   actions_mapping:
     zha:
-      button_on_short: [on_press]
+      button_on_short: [on_press, on_press_release]
       button_on_long: [on_hold]
       button_on_release: [on_long_release]
-      button_off_short: [off_press]
+      button_off_short: [off_press, off_press_release]
       button_off_long: [off_hold]
       button_off_release: [off_long_release]
       button_up_short: [up_press]
@@ -307,10 +307,10 @@ variables:
       button_down_long: [down_hold]
       button_down_release: [down_long_release]
     zigbee2mqtt:
-      button_on_short: [on_press]
+      button_on_short: [on_press, on_press_release]
       button_on_long: [on_hold]
       button_on_release: [on_hold_release]
-      button_off_short: [off_press]
+      button_off_short: [off_press, off_press_release]
       button_off_long: [off_hold]
       button_off_release: [off_hold_release]
       button_up_short: [up_press]

--- a/website/docs/blueprints/controllers/philips_929002398602.mdx
+++ b/website/docs/blueprints/controllers/philips_929002398602.mdx
@@ -269,3 +269,4 @@ It's also important to note that the controller doesn't natively support double 
 ## Changelog
 
 - **2021-11-21**: first blueprint version :tada:
+- **2022-07-22**: Fix short press actions not being triggered by quick button clicks.


### PR DESCRIPTION
Thank you for taking the time to work on a Pull Request. Your contribution is really appreciated! :tada:
**Please don't delete any part of the template**, since keeping the provided structure will help maintainers to review your work more rapidly.

Sections marked as \* are required and need to be filled in.

## Proposed change\*

This PR solves the issue preventing short press actions being correctly executed by a Philips 929002398602 controller automation when a quick click is performed on the device.

The issue is solved by adding `*_press_release` events to the list of events triggering `button_*_short` actions.
The problem has been reported for Z2M only. However, we assume a similar behavior on controllers integrated with ZHA.
In case custom actions or linked hooks get executed multiple times for a single button press, it is advised to enable debouncing as described in the [controller docs](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/controllers/ikea_e1524_e1810#inputs).

Closes #369.

## Checklist\*

- [X] I followed sections of the [Contribution Guidelines](https://github.com/EPMatt/awesome-ha-blueprints/blob/main/CONTRIBUTING.md) relevant to changes I'm proposing.
- [X] I properly tested proposed changes on my system and confirm that they are working as expected.
- [X] I formatted files with Prettier using the command `npm run format` before submitting my Pull Request.
