### PR TITLE
Helper size reduction

### DIFF
--- a/blueprints/controllers/ikea_e1524_e1810/ikea_e1524_e1810.yaml
+++ b/blueprints/controllers/ikea_e1524_e1810/ikea_e1524_e1810.yaml
@@ -15,7 +15,7 @@ blueprint:
 
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
-    ℹ️ Version 2021.10.26
+    ℹ️ Version 2022.08.08
   source_url: https://github.com/EPMatt/awesome-ha-blueprints/blob/main/blueprints/controllers/ikea_e1524_e1810/ikea_e1524_e1810.yaml
   domain: automation
   input:

--- a/blueprints/controllers/ikea_e1524_e1810/ikea_e1524_e1810.yaml
+++ b/blueprints/controllers/ikea_e1524_e1810/ikea_e1524_e1810.yaml
@@ -380,7 +380,7 @@ variables:
   button_down_release: '{{ actions_mapping[integration_id]["button_down_release"] }}'
   button_center_short: '{{ actions_mapping[integration_id]["button_center_short"] }}'
   button_center_long: '{{ actions_mapping[integration_id]["button_center_long"] }}'
-  # integrations which need to store the previous long press event to determine which button was released
+  # integrations which need to store the previous press event to determine which button was released
   integrations_with_prev_event_storage: [zha]
   # build data to send within a controller event
   controller_entity: !input controller_entity

--- a/blueprints/controllers/ikea_e1524_e1810/ikea_e1524_e1810.yaml
+++ b/blueprints/controllers/ikea_e1524_e1810/ikea_e1524_e1810.yaml
@@ -436,13 +436,13 @@ action:
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
         {%- endif -%}
-      trigger_delta: '{{ (as_timestamp(now()) - as_timestamp((states(helper_last_controller_event) | from_json).last_triggered if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{(\".*\": \".*\"(, )?)*\}$")) else "1970-01-01 00:00:00")) * 1000 }}'
-      last_controller_event: '{{ (states(helper_last_controller_event) | from_json).trigger_action if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{(\".*\": \".*\"(, )?)*\}$")) else "" }}'
+      trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
+      last_controller_event: '{{ (states(helper_last_controller_event) | from_json).a if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else "" }}'
   # update helper
   - service: input_text.set_value
     data:
       entity_id: !input helper_last_controller_event
-      value: '{{ {"trigger_action":trigger_action,"last_triggered":now()|string} | to_json }}'
+      value: '{{ {"a":trigger_action,"t":as_timestamp(now())} | to_json }}'
   # choose the sequence to run based on the received button event
   - choose:
       - conditions: '{{ trigger_action | string in button_left_short }}'
@@ -459,7 +459,7 @@ action:
                           - service: input_text.set_value
                             data:
                               entity_id: !input helper_last_controller_event
-                              value: '{{ {"trigger_action":"double_press","last_triggered":now() | string} | to_json }}'
+                              value: '{{ {"a":"double_press","t":as_timestamp(now())} | to_json }}'
                           # run the double press action
                           # fire the event
                           - event: ahb_controller_event
@@ -542,7 +542,7 @@ action:
                           - service: input_text.set_value
                             data:
                               entity_id: !input helper_last_controller_event
-                              value: '{{ {"trigger_action":"double_press","last_triggered":now() | string} | to_json }}'
+                              value: '{{ {"a":"double_press","t":as_timestamp(now())} | to_json }}'
                           # run the double press action
                           # fire the event
                           - event: ahb_controller_event
@@ -625,7 +625,7 @@ action:
                           - service: input_text.set_value
                             data:
                               entity_id: !input helper_last_controller_event
-                              value: '{{ {"trigger_action":"double_press","last_triggered":now() | string} | to_json }}'
+                              value: '{{ {"a":"double_press","t":as_timestamp(now())} | to_json }}'
                           # run the double press action
                           # fire the event
                           - event: ahb_controller_event
@@ -708,7 +708,7 @@ action:
                           - service: input_text.set_value
                             data:
                               entity_id: !input helper_last_controller_event
-                              value: '{{ {"trigger_action":"double_press","last_triggered":now() | string} | to_json }}'
+                              value: '{{ {"a":"double_press","t":as_timestamp(now())} | to_json }}'
                           # run the double press action
                           # fire the event
                           - event: ahb_controller_event
@@ -791,7 +791,7 @@ action:
                           - service: input_text.set_value
                             data:
                               entity_id: !input helper_last_controller_event
-                              value: '{{ {"trigger_action":"double_press","last_triggered":now() | string} | to_json }}'
+                              value: '{{ {"a":"double_press","t":as_timestamp(now())} | to_json }}'
                           # run the double press action
                           # fire the event
                           - event: ahb_controller_event

--- a/blueprints/controllers/ikea_e1743/ikea_e1743.yaml
+++ b/blueprints/controllers/ikea_e1743/ikea_e1743.yaml
@@ -221,7 +221,7 @@ variables:
   button_down_short: '{{ actions_mapping[integration_id]["button_down_short"] }}'
   button_down_long: '{{ actions_mapping[integration_id]["button_down_long"] }}'
   button_down_release: '{{ actions_mapping[integration_id]["button_down_release"] }}'
-  # integrations which need to store the previous long press event to determine which button was released
+  # integrations which need to store the previous press event to determine which button was released
   integrations_with_prev_event_storage: [zha, zigbee2mqtt]
   # build data to send within a controller event
   controller_entity: !input controller_entity

--- a/blueprints/controllers/ikea_e1743/ikea_e1743.yaml
+++ b/blueprints/controllers/ikea_e1743/ikea_e1743.yaml
@@ -15,7 +15,7 @@ blueprint:
 
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
-    ℹ️ Version 2021.10.26
+    ℹ️ Version 2022.08.08
   source_url: https://github.com/EPMatt/awesome-ha-blueprints/blob/main/blueprints/controllers/ikea_e1743/ikea_e1743.yaml
   domain: automation
   input:

--- a/blueprints/controllers/ikea_e1743/ikea_e1743.yaml
+++ b/blueprints/controllers/ikea_e1743/ikea_e1743.yaml
@@ -277,13 +277,13 @@ action:
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
         {%- endif -%}
-      trigger_delta: '{{ (as_timestamp(now()) - as_timestamp((states(helper_last_controller_event) | from_json).last_triggered if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{(\".*\": \".*\"(, )?)*\}$")) else "1970-01-01 00:00:00")) * 1000 }}'
-      last_controller_event: '{{ (states(helper_last_controller_event) | from_json).trigger_action if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{(\".*\": \".*\"(, )?)*\}$")) else "" }}'
+      trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
+      last_controller_event: '{{ (states(helper_last_controller_event) | from_json).a if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else "" }}'
   # update helper
   - service: input_text.set_value
     data:
       entity_id: !input helper_last_controller_event
-      value: '{{ {"trigger_action":trigger_action,"last_triggered":now()|string} | to_json }}'
+      value: '{{ {"a":trigger_action,"t":as_timestamp(now())} | to_json }}'
   # choose the sequence to run based on the received button event
   - choose:
       - conditions: '{{ trigger_action | string in button_up_short }}'
@@ -300,7 +300,7 @@ action:
                           - service: input_text.set_value
                             data:
                               entity_id: !input helper_last_controller_event
-                              value: '{{ {"trigger_action":"double_press","last_triggered":now() | string} | to_json }}'
+                              value: '{{ {"a":"double_press","t":as_timestamp(now())} | to_json }}'
                           # run the double press action
                           # fire the event
                           - event: ahb_controller_event
@@ -383,7 +383,7 @@ action:
                           - service: input_text.set_value
                             data:
                               entity_id: !input helper_last_controller_event
-                              value: '{{ {"trigger_action":"double_press","last_triggered":now() | string} | to_json }}'
+                              value: '{{ {"a":"double_press","t":as_timestamp(now())} | to_json }}'
                           # run the double press action
                           # fire the event
                           - event: ahb_controller_event

--- a/blueprints/controllers/ikea_e1744/ikea_e1744.yaml
+++ b/blueprints/controllers/ikea_e1744/ikea_e1744.yaml
@@ -15,7 +15,7 @@ blueprint:
 
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
-    ℹ️ Version 2021.10.26
+    ℹ️ Version 2022.08.08
   source_url: https://github.com/EPMatt/awesome-ha-blueprints/blob/main/blueprints/controllers/ikea_e1744/ikea_e1744.yaml
   domain: automation
   input:

--- a/blueprints/controllers/ikea_e1744/ikea_e1744.yaml
+++ b/blueprints/controllers/ikea_e1744/ikea_e1744.yaml
@@ -239,13 +239,13 @@ action:
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
         {%- endif -%}
-      trigger_delta: '{{ (as_timestamp(now()) - as_timestamp((states(helper_last_controller_event) | from_json).last_triggered if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{(\".*\": \".*\"(, )?)*\}$")) else "1970-01-01 00:00:00")) * 1000 }}'
-      last_controller_event: '{{ (states(helper_last_controller_event) | from_json).trigger_action if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{(\".*\": \".*\"(, )?)*\}$")) else "" }}'
+      trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
+      last_controller_event: '{{ (states(helper_last_controller_event) | from_json).a if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else "" }}'
   # update helper
   - service: input_text.set_value
     data:
       entity_id: !input helper_last_controller_event
-      value: '{{ {"trigger_action":trigger_action,"last_triggered":now()|string} | to_json }}'
+      value: '{{ {"a":trigger_action,"t":as_timestamp(now())} | to_json }}'
   # choose the sequence to run based on the received button event
   - choose:
       - conditions: '{{ trigger_action | string in rotate_left }}'

--- a/blueprints/controllers/ikea_e1766/ikea_e1766.yaml
+++ b/blueprints/controllers/ikea_e1766/ikea_e1766.yaml
@@ -15,7 +15,7 @@ blueprint:
 
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
-    ℹ️ Version 2021.10.29
+    ℹ️ Version 2022.08.08
   source_url: https://github.com/EPMatt/awesome-ha-blueprints/blob/main/blueprints/controllers/ikea_e1766/ikea_e1766.yaml
   domain: automation
   input:

--- a/blueprints/controllers/ikea_e1766/ikea_e1766.yaml
+++ b/blueprints/controllers/ikea_e1766/ikea_e1766.yaml
@@ -216,13 +216,13 @@ action:
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
         {%- endif -%}
-      trigger_delta: '{{ (as_timestamp(now()) - as_timestamp((states(helper_last_controller_event) | from_json).last_triggered if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{(\".*\": \".*\"(, )?)*\}$")) else "1970-01-01 00:00:00")) * 1000 }}'
-      last_controller_event: '{{ (states(helper_last_controller_event) | from_json).trigger_action if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{(\".*\": \".*\"(, )?)*\}$")) else "" }}'
+      trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
+      last_controller_event: '{{ (states(helper_last_controller_event) | from_json).a if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else "" }}'
   # update helper
   - service: input_text.set_value
     data:
       entity_id: !input helper_last_controller_event
-      value: '{{ {"trigger_action":trigger_action,"last_triggered":now()|string} | to_json }}'
+      value: '{{ {"a":trigger_action,"t":as_timestamp(now())} | to_json }}'
   # choose the sequence to run based on the received button event
   - choose:
       - conditions: '{{ trigger_action | string in button_up_short }}'
@@ -239,7 +239,7 @@ action:
                           - service: input_text.set_value
                             data:
                               entity_id: !input helper_last_controller_event
-                              value: '{{ {"trigger_action":"double_press","last_triggered":now() | string} | to_json }}'
+                              value: '{{ {"a":"double_press","t":as_timestamp(now())} | to_json }}'
                           # run the double press action
                           # fire the event
                           - event: ahb_controller_event
@@ -306,7 +306,7 @@ action:
                           - service: input_text.set_value
                             data:
                               entity_id: !input helper_last_controller_event
-                              value: '{{ {"trigger_action":"double_press","last_triggered":now() | string} | to_json }}'
+                              value: '{{ {"a":"double_press","t":as_timestamp(now())} | to_json }}'
                           # run the double press action
                           # fire the event
                           - event: ahb_controller_event

--- a/blueprints/controllers/ikea_e1812/ikea_e1812.yaml
+++ b/blueprints/controllers/ikea_e1812/ikea_e1812.yaml
@@ -212,12 +212,12 @@ action:
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
         {%- endif -%}
-      trigger_delta: '{{ (as_timestamp(now()) - as_timestamp((states(helper_last_controller_event) | from_json).last_triggered if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{(\".*\": \".*\"(, )?)*\}$")) else "1970-01-01 00:00:00")) * 1000 }}'
+      trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
   # update helper
   - service: input_text.set_value
     data:
       entity_id: !input helper_last_controller_event
-      value: '{{ {"trigger_action":trigger_action,"last_triggered":now()|string} | to_json }}'
+      value: '{{ {"a":trigger_action,"t":as_timestamp(now())} | to_json }}'
   # choose the sequence to run based on the received button event
   - choose:
       - conditions: '{{ trigger_action | string in button_short }}'
@@ -234,7 +234,7 @@ action:
                           - service: input_text.set_value
                             data:
                               entity_id: !input helper_last_controller_event
-                              value: '{{ {"trigger_action":"double_press","last_triggered":now() | string} | to_json }}'
+                              value: '{{ {"a":"double_press","t":as_timestamp(now())} | to_json }}'
                           # run the double press action
                           # fire the event
                           - event: ahb_controller_event

--- a/blueprints/controllers/ikea_e1812/ikea_e1812.yaml
+++ b/blueprints/controllers/ikea_e1812/ikea_e1812.yaml
@@ -15,7 +15,7 @@ blueprint:
 
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
-    ℹ️ Version 2021.10.26
+    ℹ️ Version 2022.08.08
   source_url: https://github.com/EPMatt/awesome-ha-blueprints/blob/main/blueprints/controllers/ikea_e1812/ikea_e1812.yaml
   domain: automation
   input:

--- a/blueprints/controllers/ikea_e2001_e2002/ikea_e2001_e2002.yaml
+++ b/blueprints/controllers/ikea_e2001_e2002/ikea_e2001_e2002.yaml
@@ -15,7 +15,7 @@ blueprint:
 
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
-    ℹ️ Version 2021.11.07
+    ℹ️ Version 2022.08.08
   source_url: https://github.com/EPMatt/awesome-ha-blueprints/blob/main/blueprints/controllers/ikea_e2001_e2002/ikea_e2001_e2002.yaml
   domain: automation
   input:

--- a/blueprints/controllers/ikea_e2001_e2002/ikea_e2001_e2002.yaml
+++ b/blueprints/controllers/ikea_e2001_e2002/ikea_e2001_e2002.yaml
@@ -403,13 +403,13 @@ action:
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
         {%- endif -%}
-      trigger_delta: '{{ (as_timestamp(now()) - as_timestamp((states(helper_last_controller_event) | from_json).last_triggered if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{(\".*\": \".*\"(, )?)*\}$")) else "1970-01-01 00:00:00")) * 1000 }}'
-      last_controller_event: '{{ (states(helper_last_controller_event) | from_json).trigger_action if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{(\".*\": \".*\"(, )?)*\}$")) else "" }}'
+      trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
+      last_controller_event: '{{ (states(helper_last_controller_event) | from_json).a if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else "" }}'
   # update helper
   - service: input_text.set_value
     data:
       entity_id: !input helper_last_controller_event
-      value: '{{ {"trigger_action":trigger_action,"last_triggered":now()|string} | to_json }}'
+      value: '{{ {"a":trigger_action,"t":as_timestamp(now())} | to_json }}'
   # choose the sequence to run based on the received button event
   - choose:
       - conditions: '{{ trigger_action | string in button_left_short }}'
@@ -426,7 +426,7 @@ action:
                           - service: input_text.set_value
                             data:
                               entity_id: !input helper_last_controller_event
-                              value: '{{ {"trigger_action":"double_press","last_triggered":now() | string} | to_json }}'
+                              value: '{{ {"a":"double_press","t":as_timestamp(now())} | to_json }}'
                           # run the double press action
                           # fire the event
                           - event: ahb_controller_event
@@ -509,7 +509,7 @@ action:
                           - service: input_text.set_value
                             data:
                               entity_id: !input helper_last_controller_event
-                              value: '{{ {"trigger_action":"double_press","last_triggered":now() | string} | to_json }}'
+                              value: '{{ {"a":"double_press","t":as_timestamp(now())} | to_json }}'
                           # run the double press action
                           # fire the event
                           - event: ahb_controller_event
@@ -592,7 +592,7 @@ action:
                           - service: input_text.set_value
                             data:
                               entity_id: !input helper_last_controller_event
-                              value: '{{ {"trigger_action":"double_press","last_triggered":now() | string} | to_json }}'
+                              value: '{{ {"a":"double_press","t":as_timestamp(now())} | to_json }}'
                           # run the double press action
                           # fire the event
                           - event: ahb_controller_event
@@ -675,7 +675,7 @@ action:
                           - service: input_text.set_value
                             data:
                               entity_id: !input helper_last_controller_event
-                              value: '{{ {"trigger_action":"double_press","last_triggered":now() | string} | to_json }}'
+                              value: '{{ {"a":"double_press","t":as_timestamp(now())} | to_json }}'
                           # run the double press action
                           # fire the event
                           - event: ahb_controller_event

--- a/blueprints/controllers/ikea_ictc_g_1/ikea_ictc_g_1.yaml
+++ b/blueprints/controllers/ikea_ictc_g_1/ikea_ictc_g_1.yaml
@@ -209,13 +209,13 @@ action:
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
         {%- endif -%}
-      trigger_delta: '{{ (as_timestamp(now()) - as_timestamp((states(helper_last_controller_event) | from_json).last_triggered if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{(\".*\": \".*\"(, )?)*\}$")) else "1970-01-01 00:00:00")) * 1000 }}'
-      last_controller_event: '{{ (states(helper_last_controller_event) | from_json).trigger_action if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{(\".*\": \".*\"(, )?)*\}$")) else "" }}'
+      trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
+      last_controller_event: '{{ (states(helper_last_controller_event) | from_json).a if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else "" }}'
   # update helper
   - service: input_text.set_value
     data:
       entity_id: !input helper_last_controller_event
-      value: '{{ {"trigger_action":trigger_action,"last_triggered":now()|string} | to_json }}'
+      value: '{{ {"a":trigger_action,"t":as_timestamp(now())} | to_json }}'
   # choose the sequence to run based on the received button event
   - choose:
       - conditions: '{{ trigger_action | string in rotate_left }}'

--- a/blueprints/controllers/ikea_ictc_g_1/ikea_ictc_g_1.yaml
+++ b/blueprints/controllers/ikea_ictc_g_1/ikea_ictc_g_1.yaml
@@ -15,7 +15,7 @@ blueprint:
 
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
-    ℹ️ Version 2021.10.26
+    ℹ️ Version 2022.08.08
   source_url: https://github.com/EPMatt/awesome-ha-blueprints/blob/main/blueprints/controllers/ikea_ictc_g_1/ikea_ictc_g_1.yaml
   domain: automation
   input:

--- a/blueprints/controllers/osram_ac025xx00nj/osram_ac025xx00nj.yaml
+++ b/blueprints/controllers/osram_ac025xx00nj/osram_ac025xx00nj.yaml
@@ -15,7 +15,7 @@ blueprint:
 
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
-    ℹ️ Version 2021.10.26
+    ℹ️ Version 2022.08.08
   source_url: https://github.com/EPMatt/awesome-ha-blueprints/blob/main/blueprints/controllers/osram_ac025xx00nj/osram_ac025xx00nj.yaml
   domain: automation
   input:

--- a/blueprints/controllers/osram_ac025xx00nj/osram_ac025xx00nj.yaml
+++ b/blueprints/controllers/osram_ac025xx00nj/osram_ac025xx00nj.yaml
@@ -338,12 +338,12 @@ action:
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}
         {%- endif -%}
-      trigger_delta: '{{ (as_timestamp(now()) - as_timestamp((states(helper_last_controller_event) | from_json).last_triggered if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{(\".*\": \".*\"(, )?)*\}$")) else "1970-01-01 00:00:00")) * 1000 }}'
+      trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
   # update helper
   - service: input_text.set_value
     data:
       entity_id: !input helper_last_controller_event
-      value: '{{ {"trigger_action":trigger_action,"last_triggered":now()|string} | to_json }}'
+      value: '{{ {"a":trigger_action,"t":as_timestamp(now())} | to_json }}'
   # choose the sequence to run based on the received button event
   - choose:
       - conditions: '{{ trigger_action | string in button_up_short }}'
@@ -360,7 +360,7 @@ action:
                           - service: input_text.set_value
                             data:
                               entity_id: !input helper_last_controller_event
-                              value: '{{ {"trigger_action":"double_press","last_triggered":now() | string} | to_json }}'
+                              value: '{{ {"a":"double_press","t":as_timestamp(now())} | to_json }}'
                           # run the double press action
                           # fire the event
                           - event: ahb_controller_event
@@ -440,7 +440,7 @@ action:
                           - service: input_text.set_value
                             data:
                               entity_id: !input helper_last_controller_event
-                              value: '{{ {"trigger_action":"double_press","last_triggered":now() | string} | to_json }}'
+                              value: '{{ {"a":"double_press","t":as_timestamp(now())} | to_json }}'
                           # run the double press action
                           # fire the event
                           - event: ahb_controller_event
@@ -520,7 +520,7 @@ action:
                           - service: input_text.set_value
                             data:
                               entity_id: !input helper_last_controller_event
-                              value: '{{ {"trigger_action":"double_press","last_triggered":now() | string} | to_json }}'
+                              value: '{{ {"a":"double_press","t":as_timestamp(now())} | to_json }}'
                           # run the double press action
                           # fire the event
                           - event: ahb_controller_event

--- a/blueprints/controllers/philips_324131092621/philips_324131092621.yaml
+++ b/blueprints/controllers/philips_324131092621/philips_324131092621.yaml
@@ -401,12 +401,12 @@ action:
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}
         {%- endif -%}
-      trigger_delta: '{{ (as_timestamp(now()) - as_timestamp((states(helper_last_controller_event) | from_json).last_triggered if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{(\".*\": \".*\"(, )?)*\}$")) else "1970-01-01 00:00:00")) * 1000 }}'
+      trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
   # update helper
   - service: input_text.set_value
     data:
       entity_id: !input helper_last_controller_event
-      value: '{{ {"trigger_action":trigger_action,"last_triggered":now()|string} | to_json }}'
+      value: '{{ {"a":trigger_action,"t":as_timestamp(now())} | to_json }}'
   # choose the sequence to run based on the received button event
   - choose:
       - conditions: '{{ trigger_action | string in button_on_short }}'
@@ -423,7 +423,7 @@ action:
                           - service: input_text.set_value
                             data:
                               entity_id: !input helper_last_controller_event
-                              value: '{{ {"trigger_action":"double_press","last_triggered":now() | string} | to_json }}'
+                              value: '{{ {"a":"double_press","t":as_timestamp(now())} | to_json }}'
                           # run the double press action
                           # fire the event
                           - event: ahb_controller_event
@@ -503,7 +503,7 @@ action:
                           - service: input_text.set_value
                             data:
                               entity_id: !input helper_last_controller_event
-                              value: '{{ {"trigger_action":"double_press","last_triggered":now() | string} | to_json }}'
+                              value: '{{ {"a":"double_press","t":as_timestamp(now())} | to_json }}'
                           # run the double press action
                           # fire the event
                           - event: ahb_controller_event
@@ -583,7 +583,7 @@ action:
                           - service: input_text.set_value
                             data:
                               entity_id: !input helper_last_controller_event
-                              value: '{{ {"trigger_action":"double_press","last_triggered":now() | string} | to_json }}'
+                              value: '{{ {"a":"double_press","t":as_timestamp(now())} | to_json }}'
                           # run the double press action
                           # fire the event
                           - event: ahb_controller_event
@@ -663,7 +663,7 @@ action:
                           - service: input_text.set_value
                             data:
                               entity_id: !input helper_last_controller_event
-                              value: '{{ {"trigger_action":"double_press","last_triggered":now() | string} | to_json }}'
+                              value: '{{ {"a":"double_press","t":as_timestamp(now())} | to_json }}'
                           # run the double press action
                           # fire the event
                           - event: ahb_controller_event

--- a/blueprints/controllers/philips_324131092621/philips_324131092621.yaml
+++ b/blueprints/controllers/philips_324131092621/philips_324131092621.yaml
@@ -15,7 +15,7 @@ blueprint:
 
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
-    ℹ️ Version 2021.11.19
+    ℹ️ Version 2022.08.08
   source_url: https://github.com/EPMatt/awesome-ha-blueprints/blob/main/blueprints/controllers/philips_324131092621/philips_324131092621.yaml
   domain: automation
   input:

--- a/blueprints/controllers/philips_8718699693985/philips_8718699693985.yaml
+++ b/blueprints/controllers/philips_8718699693985/philips_8718699693985.yaml
@@ -189,12 +189,12 @@ action:
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}
         {%- endif -%}
-      trigger_delta: '{{ (as_timestamp(now()) - as_timestamp((states(helper_last_controller_event) | from_json).last_triggered if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{(\".*\": \".*\"(, )?)*\}$")) else "1970-01-01 00:00:00")) * 1000 }}'
+      trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
   # update helper
   - service: input_text.set_value
     data:
       entity_id: !input helper_last_controller_event
-      value: '{{ {"trigger_action":trigger_action,"last_triggered":now()|string} | to_json }}'
+      value: '{{ {"a":trigger_action,"t":as_timestamp(now())} | to_json }}'
   # choose the sequence to run based on the received button event
   - choose:
       - conditions: '{{ trigger_action | string in button_short }}'
@@ -211,7 +211,7 @@ action:
                           - service: input_text.set_value
                             data:
                               entity_id: !input helper_last_controller_event
-                              value: '{{ {"trigger_action":"double_press","last_triggered":now() | string} | to_json }}'
+                              value: '{{ {"a":"double_press","t":as_timestamp(now())} | to_json }}'
                           # run the double press action
                           # fire the event
                           - event: ahb_controller_event

--- a/blueprints/controllers/philips_8718699693985/philips_8718699693985.yaml
+++ b/blueprints/controllers/philips_8718699693985/philips_8718699693985.yaml
@@ -15,7 +15,7 @@ blueprint:
 
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
-    ℹ️ Version 2021.10.26
+    ℹ️ Version 2022.08.08
   source_url: https://github.com/EPMatt/awesome-ha-blueprints/blob/main/blueprints/controllers/philips_8718699693985/philips_8718699693985.yaml
   domain: automation
   input:

--- a/blueprints/controllers/philips_929002398602/philips_929002398602.yaml
+++ b/blueprints/controllers/philips_929002398602/philips_929002398602.yaml
@@ -15,7 +15,7 @@ blueprint:
 
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
-    ℹ️ Version 2022.07.22
+    ℹ️ Version 2022.08.08
   source_url: https://github.com/EPMatt/awesome-ha-blueprints/blob/main/blueprints/controllers/philips_929002398602/philips_929002398602.yaml
   domain: automation
   input:

--- a/blueprints/controllers/philips_929002398602/philips_929002398602.yaml
+++ b/blueprints/controllers/philips_929002398602/philips_929002398602.yaml
@@ -386,12 +386,12 @@ action:
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}
         {%- endif -%}
-      trigger_delta: '{{ (as_timestamp(now()) - as_timestamp((states(helper_last_controller_event) | from_json).last_triggered if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{(\".*\": \".*\"(, )?)*\}$")) else "1970-01-01 00:00:00")) * 1000 }}'
+      trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
   # update helper
   - service: input_text.set_value
     data:
       entity_id: !input helper_last_controller_event
-      value: '{{ {"trigger_action":trigger_action,"last_triggered":now()|string} | to_json }}'
+      value: '{{ {"a":trigger_action,"t":as_timestamp(now())} | to_json }}'
   # choose the sequence to run based on the received button event
   - choose:
       - conditions: '{{ trigger_action | string in button_on_short }}'
@@ -408,7 +408,7 @@ action:
                           - service: input_text.set_value
                             data:
                               entity_id: !input helper_last_controller_event
-                              value: '{{ {"trigger_action":"double_press","last_triggered":now() | string} | to_json }}'
+                              value: '{{ {"a":"double_press","t":as_timestamp(now())} | to_json }}'
                           # run the double press action
                           # fire the event
                           - event: ahb_controller_event
@@ -488,7 +488,7 @@ action:
                           - service: input_text.set_value
                             data:
                               entity_id: !input helper_last_controller_event
-                              value: '{{ {"trigger_action":"double_press","last_triggered":now() | string} | to_json }}'
+                              value: '{{ {"a":"double_press","t":as_timestamp(now())} | to_json }}'
                           # run the double press action
                           # fire the event
                           - event: ahb_controller_event
@@ -568,7 +568,7 @@ action:
                           - service: input_text.set_value
                             data:
                               entity_id: !input helper_last_controller_event
-                              value: '{{ {"trigger_action":"double_press","last_triggered":now() | string} | to_json }}'
+                              value: '{{ {"a":"double_press","t":as_timestamp(now())} | to_json }}'
                           # run the double press action
                           # fire the event
                           - event: ahb_controller_event
@@ -648,7 +648,7 @@ action:
                           - service: input_text.set_value
                             data:
                               entity_id: !input helper_last_controller_event
-                              value: '{{ {"trigger_action":"double_press","last_triggered":now() | string} | to_json }}'
+                              value: '{{ {"a":"double_press","t":as_timestamp(now())} | to_json }}'
                           # run the double press action
                           # fire the event
                           - event: ahb_controller_event

--- a/blueprints/controllers/sonoff_snzb01/sonoff_snzb01.yaml
+++ b/blueprints/controllers/sonoff_snzb01/sonoff_snzb01.yaml
@@ -162,12 +162,12 @@ action:
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
         {%- endif -%}
-      trigger_delta: '{{ (as_timestamp(now()) - as_timestamp((states(helper_last_controller_event) | from_json).last_triggered if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{(\".*\": \".*\"(, )?)*\}$")) else "1970-01-01 00:00:00")) * 1000 }}'
+      trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
   # update helper
   - service: input_text.set_value
     data:
       entity_id: !input helper_last_controller_event
-      value: '{{ {"trigger_action":trigger_action,"last_triggered":now()|string} | to_json }}'
+      value: '{{ {"a":trigger_action,"t":as_timestamp(now())} | to_json }}'
   # choose the sequence to run based on the received button event
   - choose:
       - conditions: '{{ trigger_action | string in button_short }}'

--- a/blueprints/controllers/sonoff_snzb01/sonoff_snzb01.yaml
+++ b/blueprints/controllers/sonoff_snzb01/sonoff_snzb01.yaml
@@ -15,7 +15,7 @@ blueprint:
 
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
-    ℹ️ Version 2022.07.30
+    ℹ️ Version 2022.08.08
   source_url: https://github.com/EPMatt/awesome-ha-blueprints/blob/main/blueprints/controllers/sonoff_snzb01/sonoff_snzb01.yaml
   domain: automation
   input:

--- a/blueprints/controllers/xiaomi_wxcjkg11lm/xiaomi_wxcjkg11lm.yaml
+++ b/blueprints/controllers/xiaomi_wxcjkg11lm/xiaomi_wxcjkg11lm.yaml
@@ -15,7 +15,7 @@ blueprint:
 
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
-    ℹ️ Version 2021.12.03
+    ℹ️ Version 2022.08.08
   source_url: https://github.com/EPMatt/awesome-ha-blueprints/blob/main/blueprints/controllers/xiaomi_wxcjkg11lm/xiaomi_wxcjkg11lm.yaml
   domain: automation
   input:

--- a/blueprints/controllers/xiaomi_wxcjkg11lm/xiaomi_wxcjkg11lm.yaml
+++ b/blueprints/controllers/xiaomi_wxcjkg11lm/xiaomi_wxcjkg11lm.yaml
@@ -273,12 +273,12 @@ action:
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}
         {%- endif -%}
-      trigger_delta: '{{ (as_timestamp(now()) - as_timestamp((states(helper_last_controller_event) | from_json).last_triggered if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{(\".*\": \".*\"(, )?)*\}$")) else "1970-01-01 00:00:00")) * 1000 }}'
+      trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
   # update helper
   - service: input_text.set_value
     data:
       entity_id: !input helper_last_controller_event
-      value: '{{ {"trigger_action":trigger_action,"last_triggered":now()|string} | to_json }}'
+      value: '{{ {"a":trigger_action,"t":as_timestamp(now())} | to_json }}'
   # choose the sequence to run based on the received button event
   - choose:
       - conditions: '{{ trigger_action | string in button_1_short }}'

--- a/blueprints/controllers/xiaomi_wxcjkg12lm/xiaomi_wxcjkg12lm.yaml
+++ b/blueprints/controllers/xiaomi_wxcjkg12lm/xiaomi_wxcjkg12lm.yaml
@@ -413,12 +413,12 @@ action:
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}
         {%- endif -%}
-      trigger_delta: '{{ (as_timestamp(now()) - as_timestamp((states(helper_last_controller_event) | from_json).last_triggered if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{(\".*\": \".*\"(, )?)*\}$")) else "1970-01-01 00:00:00")) * 1000 }}'
+      trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
   # update helper
   - service: input_text.set_value
     data:
       entity_id: !input helper_last_controller_event
-      value: '{{ {"trigger_action":trigger_action,"last_triggered":now()|string} | to_json }}'
+      value: '{{ {"a":trigger_action,"t":as_timestamp(now())} | to_json }}'
   # choose the sequence to run based on the received button event
   - choose:
       - conditions: '{{ trigger_action | string in button_1_short }}'

--- a/blueprints/controllers/xiaomi_wxcjkg12lm/xiaomi_wxcjkg12lm.yaml
+++ b/blueprints/controllers/xiaomi_wxcjkg12lm/xiaomi_wxcjkg12lm.yaml
@@ -15,7 +15,7 @@ blueprint:
 
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
-    ℹ️ Version 2021.12.03
+    ℹ️ Version 2022.08.08
   source_url: https://github.com/EPMatt/awesome-ha-blueprints/blob/main/blueprints/controllers/xiaomi_wxcjkg12lm/xiaomi_wxcjkg12lm.yaml
   domain: automation
   input:

--- a/blueprints/controllers/xiaomi_wxcjkg13lm/xiaomi_wxcjkg13lm.yaml
+++ b/blueprints/controllers/xiaomi_wxcjkg13lm/xiaomi_wxcjkg13lm.yaml
@@ -553,12 +553,12 @@ action:
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}
         {%- endif -%}
-      trigger_delta: '{{ (as_timestamp(now()) - as_timestamp((states(helper_last_controller_event) | from_json).last_triggered if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{(\".*\": \".*\"(, )?)*\}$")) else "1970-01-01 00:00:00")) * 1000 }}'
+      trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
   # update helper
   - service: input_text.set_value
     data:
       entity_id: !input helper_last_controller_event
-      value: '{{ {"trigger_action":trigger_action,"last_triggered":now()|string} | to_json }}'
+      value: '{{ {"a":trigger_action,"t":as_timestamp(now())} | to_json }}'
   # choose the sequence to run based on the received button event
   - choose:
       - conditions: '{{ trigger_action | string in button_1_short }}'

--- a/blueprints/controllers/xiaomi_wxcjkg13lm/xiaomi_wxcjkg13lm.yaml
+++ b/blueprints/controllers/xiaomi_wxcjkg13lm/xiaomi_wxcjkg13lm.yaml
@@ -15,7 +15,7 @@ blueprint:
 
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
-    ℹ️ Version 2021.12.03
+    ℹ️ Version 2022.08.08
   source_url: https://github.com/EPMatt/awesome-ha-blueprints/blob/main/blueprints/controllers/xiaomi_wxcjkg13lm/xiaomi_wxcjkg13lm.yaml
   domain: automation
   input:

--- a/blueprints/controllers/xiaomi_wxkg11lm/xiaomi_wxkg11lm.yaml
+++ b/blueprints/controllers/xiaomi_wxkg11lm/xiaomi_wxkg11lm.yaml
@@ -15,7 +15,7 @@ blueprint:
 
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
-    ℹ️ Version 2022.07.22
+    ℹ️ Version 2022.08.08
   source_url: https://github.com/EPMatt/awesome-ha-blueprints/blob/main/blueprints/controllers/xiaomi_wxkg11lm/xiaomi_wxkg11lm.yaml
   domain: automation
   input:

--- a/blueprints/controllers/xiaomi_wxkg11lm/xiaomi_wxkg11lm.yaml
+++ b/blueprints/controllers/xiaomi_wxkg11lm/xiaomi_wxkg11lm.yaml
@@ -193,12 +193,12 @@ action:
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
         {%- endif -%}
-      trigger_delta: '{{ (as_timestamp(now()) - as_timestamp((states(helper_last_controller_event) | from_json).last_triggered if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{(\".*\": \".*\"(, )?)*\}$")) else "1970-01-01 00:00:00")) * 1000 }}'
+      trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
   # update helper
   - service: input_text.set_value
     data:
       entity_id: !input helper_last_controller_event
-      value: '{{ {"trigger_action":trigger_action,"last_triggered":now()|string} | to_json }}'
+      value: '{{ {"a":trigger_action,"t":as_timestamp(now())} | to_json }}'
   # choose the sequence to run based on the received button event
   - choose:
       - conditions: '{{ trigger_action | string in button_short }}'

--- a/website/docs/blueprints/controllers/ikea_e1524_e1810.mdx
+++ b/website/docs/blueprints/controllers/ikea_e1524_e1810.mdx
@@ -353,3 +353,4 @@ If you notice your controller is not behaving as expected please remove the batt
 - **2021-07-04**: Fix deCONZ button release events not being properly recognized
 - **2021-08-02**: Improve inputs documentation and organization
 - **2021-10-26**: Standardize blueprints structure and inputs naming across the whole collection. Improve blueprint documentation. No functionality change.
+- **2022-08-08**: Optimize characters usage for the `helper_last_controller_event` text input.

--- a/website/docs/blueprints/controllers/ikea_e1743.mdx
+++ b/website/docs/blueprints/controllers/ikea_e1743.mdx
@@ -256,3 +256,4 @@ It's also important to note that the controller doesn't natively support double 
 - **2021-07-04**: Fix deCONZ button release events not being properly recognized
 - **2021-08-02**: Improve inputs documentation and organization
 - **2021-10-26**: Standardize blueprints structure and inputs naming across the whole collection. Improve blueprint documentation. No functionality change.
+- **2022-08-08**: Optimize characters usage for the `helper_last_controller_event` text input.

--- a/website/docs/blueprints/controllers/ikea_e1744.mdx
+++ b/website/docs/blueprints/controllers/ikea_e1744.mdx
@@ -201,3 +201,4 @@ The helper is used to determine stop rotation events when the controller is inte
 - **2021-07-04**: Fix deCONZ rotation stop events not being properly recognized
 - **2021-08-02**: Improve inputs documentation and organization
 - **2021-10-26**: Standardize blueprints structure and inputs naming across the whole collection. Improve blueprint documentation. No functionality change.
+- **2022-08-08**: Optimize characters usage for the `helper_last_controller_event` text input.

--- a/website/docs/blueprints/controllers/ikea_e1766.mdx
+++ b/website/docs/blueprints/controllers/ikea_e1766.mdx
@@ -183,3 +183,4 @@ Due to the controller not exposing long press events but only short and release 
 ## Changelog
 
 - **2021-10-29**: first blueprint version :tada:
+- **2022-08-08**: Optimize characters usage for the `helper_last_controller_event` text input.

--- a/website/docs/blueprints/controllers/ikea_e1812.mdx
+++ b/website/docs/blueprints/controllers/ikea_e1812.mdx
@@ -191,3 +191,4 @@ It's also important to note that the controller doesn't natively support double 
 - **2021-05-26**: Fix for Zigbee2MQTT reporting null state changes
 - **2021-08-02**: Improve inputs documentation and organization
 - **2021-10-26**: Standardize blueprints structure and inputs naming across the whole collection. Improve blueprint documentation. No functionality change.
+- **2022-08-08**: Optimize characters usage for the `helper_last_controller_event` text input.

--- a/website/docs/blueprints/controllers/ikea_e2001_e2002.mdx
+++ b/website/docs/blueprints/controllers/ikea_e2001_e2002.mdx
@@ -289,3 +289,4 @@ If you notice your controller is not behaving as expected please reset the devic
 ## Changelog
 
 - **2021-11-07**: first blueprint version :tada:
+- **2022-08-08**: Optimize characters usage for the `helper_last_controller_event` text input.

--- a/website/docs/blueprints/controllers/ikea_ictc_g_1.mdx
+++ b/website/docs/blueprints/controllers/ikea_ictc_g_1.mdx
@@ -171,3 +171,4 @@ This blueprint provides beta support for controllers integrated with deCONZ, sin
 - **2021-07-04**: Fix deCONZ rotation stop events not being properly recognized
 - **2021-08-02**: Improve inputs documentation and organization
 - **2021-10-26**: Standardize blueprints structure and inputs naming across the whole collection. Improve blueprint documentation. No functionality change.
+- **2022-08-08**: Optimize characters usage for the `helper_last_controller_event` text input.

--- a/website/docs/blueprints/controllers/osram_ac025xx00nj.mdx
+++ b/website/docs/blueprints/controllers/osram_ac025xx00nj.mdx
@@ -239,3 +239,4 @@ This blueprint supports any variant of the Osram SMART+ Switch Mini controller (
 - **2021-05-26**: Fix for Zigbee2MQTT reporting null state changes
 - **2021-08-02**: Improve inputs documentation and organization
 - **2021-10-26**: Standardize blueprints structure and inputs naming across the whole collection. Improve blueprint documentation. No functionality change.
+- **2022-08-08**: Optimize characters usage for the `helper_last_controller_event` text input.

--- a/website/docs/blueprints/controllers/philips_324131092621.mdx
+++ b/website/docs/blueprints/controllers/philips_324131092621.mdx
@@ -290,3 +290,4 @@ It's also important to note that the controller doesn't natively support double 
 - **2021-08-02**: Improve inputs documentation and organization
 - **2021-10-26**: Standardize blueprints structure and inputs naming across the whole collection. Improve blueprint documentation. No functionality change.
 - **2021-11-19**: Fix controller events not being recognized when using ZHA.
+- **2022-08-08**: Optimize characters usage for the `helper_last_controller_event` text input.

--- a/website/docs/blueprints/controllers/philips_8718699693985.mdx
+++ b/website/docs/blueprints/controllers/philips_8718699693985.mdx
@@ -147,3 +147,4 @@ It's also important to note that the controller doesn't natively support double 
 - **2021-07-14**: first blueprint version :tada:
 - **2021-08-02**: Improve inputs documentation and organization
 - **2021-10-26**: Standardize blueprints structure and inputs naming across the whole collection. Improve blueprint documentation. No functionality change.
+- **2022-08-08**: Optimize characters usage for the `helper_last_controller_event` text input.

--- a/website/docs/blueprints/controllers/philips_929002398602.mdx
+++ b/website/docs/blueprints/controllers/philips_929002398602.mdx
@@ -270,3 +270,4 @@ It's also important to note that the controller doesn't natively support double 
 
 - **2021-11-21**: first blueprint version :tada:
 - **2022-07-22**: Fix short press actions not being triggered by quick button clicks.
+- **2022-08-08**: Optimize characters usage for the `helper_last_controller_event` text input.

--- a/website/docs/blueprints/controllers/sonoff_snzb01.mdx
+++ b/website/docs/blueprints/controllers/sonoff_snzb01.mdx
@@ -132,3 +132,4 @@ Please note that the long press action for this controller is triggered after th
 ## Changelog
 
 - **2022-07-30**: first blueprint version :tada:
+- **2022-08-08**: Optimize characters usage for the `helper_last_controller_event` text input.

--- a/website/docs/blueprints/controllers/xiaomi_wxcjkg11lm.mdx
+++ b/website/docs/blueprints/controllers/xiaomi_wxcjkg11lm.mdx
@@ -194,3 +194,4 @@ The `helper_last_controller_event` (Helper - Last Controller Event) input serves
 ## Changelog
 
 - **2021-12-03**: first blueprint version :tada:
+- **2022-08-08**: Optimize characters usage for the `helper_last_controller_event` text input.

--- a/website/docs/blueprints/controllers/xiaomi_wxcjkg12lm.mdx
+++ b/website/docs/blueprints/controllers/xiaomi_wxcjkg12lm.mdx
@@ -290,3 +290,4 @@ The `helper_last_controller_event` (Helper - Last Controller Event) input serves
 ## Changelog
 
 - **2021-12-03**: first blueprint version :tada:
+- **2022-08-08**: Optimize characters usage for the `helper_last_controller_event` text input.

--- a/website/docs/blueprints/controllers/xiaomi_wxcjkg13lm.mdx
+++ b/website/docs/blueprints/controllers/xiaomi_wxcjkg13lm.mdx
@@ -386,3 +386,4 @@ The `helper_last_controller_event` (Helper - Last Controller Event) input serves
 ## Changelog
 
 - **2021-12-03**: first blueprint version :tada:
+- **2022-08-08**: Optimize characters usage for the `helper_last_controller_event` text input.

--- a/website/docs/blueprints/controllers/xiaomi_wxkg11lm.mdx
+++ b/website/docs/blueprints/controllers/xiaomi_wxkg11lm.mdx
@@ -149,3 +149,4 @@ Please note that this blueprint provides deCONZ support for the 2018 version of 
 ## Changelog
 
 - **2022-07-22**: first blueprint version :tada:
+- **2022-08-08**: Optimize characters usage for the `helper_last_controller_event` text input.


### PR DESCRIPTION
This pull request reworks the `helper_last_controller_event` entity to use less characters (see #333).

I tested the e2001/e2002 blueprint with custom actions and once confirmed working went through and updated all the other blueprints.

## Breaking change

There should not be any breaking changes as the new regex_match should cause existing entities to be updated to the new format on first use.

## Proposed change\*

- Replace current value: `{"trigger_action": "off", "last_triggered": "2022-05-05 09:58:25.740583+02:00"}` with `{"a": "off", "t": <unix time>}`
  - In this format the max size without event should be 33 characters (`{"a": "", "t": 1658511756.518805}`)
  - The longest current event I could find was 25 characters (`move_to_level_with_on_off`)
- Stores last triggered time as float instead of string to avoid multiple conversions back and forth
- Updated regex_match to look for `"a": ".*"` or `"t": \d+.\d+` in either order
  - This will cause the old format to be overridden by the new format on first run

Closes #333 

## Checklist\*

- [x] I followed sections of the [Contribution Guidelines](https://github.com/EPMatt/awesome-ha-blueprints/blob/main/CONTRIBUTING.md) relevant to changes I'm proposing.
- [x] I properly tested proposed changes on my system and confirm that they are working as expected.
- [x] I formatted files with Prettier using the command `npm run format` before submitting my Pull Request.
