### PR TITLE
add partial zigbee2mqtt support to philips 8718699693985

### DIFF
--- a/blueprints/controllers/philips_8718699693985/philips_8718699693985.yaml
+++ b/blueprints/controllers/philips_8718699693985/philips_8718699693985.yaml
@@ -5,7 +5,7 @@ blueprint:
     # Controller - Philips 8718699693985 Hue Smart Button
 
     Controller automation for executing any kind of action triggered by the provided Philips 8718699693985 Hue Smart Button. Allows to optionally loop an action on a button long press.
-    Supports deCONZ, ZHA.
+    Supports deCONZ, ZHA. Supports button short and long press and release for zigbee2mqtt.
 
     Automations created with this blueprint can be connected with one or more [Hooks](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/hooks) supported by this controller.
     Hooks allow to easily create controller-based automations for interacting with media players, lights, covers and more.
@@ -27,12 +27,20 @@ blueprint:
           options:
             - deCONZ
             - ZHA
+            - zigbee2mqtt
     controller_device:
       name: (deCONZ, ZHA) Controller Device
       description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.
       default: ''
       selector:
         device:
+    controller_entity:
+      name: (Zigbee2MQTT) Controller Entity
+      description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
+      default: ''
+      selector:
+        entity:
+          domain: sensor
     helper_last_controller_event:
       name: (Required) Helper - Last Controller Event
       description: Input Text used to store the last event fired by the controller. You will need to manually create a text input entity for this, please read the blueprint Additional Notes for more info.
@@ -141,6 +149,10 @@ variables:
       button_short: [on_short_release]
       button_long: [on_hold]
       button_release: [on_long_release]
+    zigbee2mqtt:
+      button_short: ["on", "off"]
+      button_long: [hold, brightness_step_down]
+      button_release: ["release"]
   # pre-choose actions for buttons based on configured integration
   # no need to perform this task at automation runtime
   button_short: '{{ actions_mapping[integration_id]["button_short"] }}'
@@ -152,6 +164,11 @@ variables:
 mode: restart
 max_exceeded: silent
 trigger:
+  # trigger for zigbee2mqtt
+  - platform: event
+    event_type: state_changed
+    event_data:
+      entity_id: !input controller_entity
   # trigger for other integrations
   - platform: event
     event_type:
@@ -160,18 +177,23 @@ trigger:
     event_data:
       device_id: !input controller_device
 condition:
-  # check that the button event is not empty
-  - >-
-    {%- set trigger_action -%}
-    {%- if integration_id == "zigbee2mqtt" -%}
-    {{ trigger.event.data.new_state.state }}
-    {%- elif integration_id == "deconz" -%}
-    {{ trigger.event.data.event }}
-    {%- elif integration_id == "zha" -%}
-    {{ trigger.event.data.command }}
-    {%- endif -%}
-    {%- endset -%}
-    {{ trigger_action not in ["","None"] }}
+  - condition: and
+    conditions:
+      # check that the button event is not empty
+      - >-
+        {%- set trigger_action -%}
+        {%- if integration_id == "zigbee2mqtt" -%}
+        {{ trigger.event.data.new_state.state }}
+        {%- elif integration_id == "deconz" -%}
+        {{ trigger.event.data.event }}
+        {%- elif integration_id == "zha" -%}
+        {{ trigger.event.data.command }}
+        {%- endif -%}
+        {%- endset -%}
+        {{ trigger_action not in ["","None"] }}
+      # only for zigbee2mqtt, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
+      # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
+      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action


### PR DESCRIPTION
## Proposed change

I wanted to use the Hue Smart Button via zigbee2mqtt. Unfortunately, I only managed to create partial support for this. You can now use the actions `button_short` and `button_long`. However `button_short` also triggers when the button is pressed twice. Problem is that the button uses the same events for different scenarios. I guess for better support one would need to save more than the last event. If you could give me hints in the right direction I will try to improve the blueprint futher.

Example: 
- Events for button short press: `"press"`, `""`, `"release"`, `""`, `"off"`, `""`
- Events for button double press: `"press"`, `""`, `"release"`, `""`, `"press"` , `""`, `"release"`, `""`, `"off"`, `""`
  - A second double press will change `"off"` to `"on"` for both events 

Partially `closes #262`. 

## Checklist

- [x] I followed sections of the [Contribution Guidelines](https://github.com/EPMatt/awesome-ha-blueprints/blob/main/CONTRIBUTING.md) relevant to changes I'm proposing.
- [x] I properly tested proposed changes on my system and confirm that they are working as expected.
- [x] I formatted files with Prettier using the command `npm run format` before submitting my Pull Request.

## Information to further improve blueprint

I've recorded the different actions with MQTT Explorer. Here are the triggered actions. They **always** have an empty action in between which looks like this:
```
    {
        "action": "",
        "battery": 100,
        "last_seen": "2022-08-25T20:59:37+02:00",
        "linkquality": 21,
        "update": {
            "state": "available"
        },
        "update_available": null
    },
```
I will remove them from the output for readability.

<details><summary>Button short press</summary>  

```
  {
    "action": "press",
    "battery": 100,
    "last_seen": "2022-08-25T21:11:16+02:00",
    "linkquality": 0,
    "update": { "state": "available" },
    "update_available": null
  },
  {
    "action": "release",
    "battery": 100,
    "last_seen": "2022-08-25T21:11:16+02:00",
    "linkquality": 0,
    "update": { "state": "available" },
    "update_available": null
  },
  {
    "action": "on",
    "battery": 100,
    "last_seen": "2022-08-25T21:11:16+02:00",
    "linkquality": 47,
    "update": { "state": "available" },
    "update_available": null
  }
```

> The last action can also be `off` as explained above.

</details>

<details><summary>Button long press</summary>  

```
    {
        "action": "press",
        "battery": 100,
        "last_seen": "2022-08-25T20:59:37+02:00",
        "linkquality": 21,
        "update": {
            "state": "available"
        },
        "update_available": null
    },
    {
        "action": "brightness_step_down",
        "action_step_size": 30,
        "action_transition_time": 0.09,
        "battery": 100,
        "last_seen": "2022-08-25T20:59:38+02:00",
        "linkquality": 29,
        "update": {
            "state": "available"
        },
        "update_available": null
    },
    {
        "action": "hold",
        "battery": 100,
        "last_seen": "2022-08-25T20:59:38+02:00",
        "linkquality": 29,
        "update": {
            "state": "available"
        },
        "update_available": null
    },
    {
        "loop": "brightness_step_down and hold until release"
    },
    {
        "action": "release",
        "battery": 100,
        "last_seen": "2022-08-25T20:59:41+02:00",
        "linkquality": 32,
        "update": {
            "state": "available"
        },
        "update_available": null
    },
    {
        "action": null,
        "battery": 100,
        "last_seen": "2022-08-25T21:05:58+02:00",
        "linkquality": 51,
        "update": {
            "state": "available"
        },
        "update_available": null
    }
```

</details>

<details><summary>Button double press</summary>  

```
  {
    "action": "press",
    "battery": 100,
    "last_seen": "2022-08-25T21:15:40+02:00",
    "linkquality": 43,
    "update": { "state": "available" },
    "update_available": null
  },
  {
    "action": "release",
    "battery": 100,
    "last_seen": "2022-08-25T21:15:40+02:00",
    "linkquality": 43,
    "update": { "state": "available" },
    "update_available": null
  },
  {
    "action": "press",
    "battery": 100,
    "last_seen": "2022-08-25T21:15:41+02:00",
    "linkquality": 43,
    "update": { "state": "available" },
    "update_available": null
  },
  {
    "action": "release",
    "battery": 100,
    "last_seen": "2022-08-25T21:15:41+02:00",
    "linkquality": 43,
    "update": { "state": "available" },
    "update_available": null
  },
  {
    "action": "off",
    "battery": 100,
    "last_seen": "2022-08-25T21:15:41+02:00",
    "linkquality": 7,
    "update": { "state": "available" },
    "update_available": null
  }
```

</details>