### PR TITLE
Fix virtual double press event for deconz

### DIFF
--- a/blueprints/controllers/ikea_e1524_e1810/ikea_e1524_e1810.yaml
+++ b/blueprints/controllers/ikea_e1524_e1810/ikea_e1524_e1810.yaml
@@ -442,7 +442,7 @@ action:
   - service: input_text.set_value
     data:
       entity_id: !input helper_last_controller_event
-      value: '{{ {"a":trigger_action,"t":as_timestamp(now())} | to_json }}'
+      value: '{{ {"a":trigger_action|string,"t":as_timestamp(now())} | to_json }}'
   # choose the sequence to run based on the received button event
   - choose:
       - conditions: '{{ trigger_action | string in button_left_short }}'

--- a/blueprints/controllers/ikea_e1743/ikea_e1743.yaml
+++ b/blueprints/controllers/ikea_e1743/ikea_e1743.yaml
@@ -283,7 +283,7 @@ action:
   - service: input_text.set_value
     data:
       entity_id: !input helper_last_controller_event
-      value: '{{ {"a":trigger_action,"t":as_timestamp(now())} | to_json }}'
+      value: '{{ {"a":trigger_action|string,"t":as_timestamp(now())} | to_json }}'
   # choose the sequence to run based on the received button event
   - choose:
       - conditions: '{{ trigger_action | string in button_up_short }}'

--- a/blueprints/controllers/ikea_e1744/ikea_e1744.yaml
+++ b/blueprints/controllers/ikea_e1744/ikea_e1744.yaml
@@ -245,7 +245,7 @@ action:
   - service: input_text.set_value
     data:
       entity_id: !input helper_last_controller_event
-      value: '{{ {"a":trigger_action,"t":as_timestamp(now())} | to_json }}'
+      value: '{{ {"a":trigger_action|string,"t":as_timestamp(now())} | to_json }}'
   # choose the sequence to run based on the received button event
   - choose:
       - conditions: '{{ trigger_action | string in rotate_left }}'

--- a/blueprints/controllers/ikea_e1766/ikea_e1766.yaml
+++ b/blueprints/controllers/ikea_e1766/ikea_e1766.yaml
@@ -222,7 +222,7 @@ action:
   - service: input_text.set_value
     data:
       entity_id: !input helper_last_controller_event
-      value: '{{ {"a":trigger_action,"t":as_timestamp(now())} | to_json }}'
+      value: '{{ {"a":trigger_action|string,"t":as_timestamp(now())} | to_json }}'
   # choose the sequence to run based on the received button event
   - choose:
       - conditions: '{{ trigger_action | string in button_up_short }}'

--- a/blueprints/controllers/ikea_e1812/ikea_e1812.yaml
+++ b/blueprints/controllers/ikea_e1812/ikea_e1812.yaml
@@ -217,7 +217,7 @@ action:
   - service: input_text.set_value
     data:
       entity_id: !input helper_last_controller_event
-      value: '{{ {"a":trigger_action,"t":as_timestamp(now())} | to_json }}'
+      value: '{{ {"a":trigger_action|string,"t":as_timestamp(now())} | to_json }}'
   # choose the sequence to run based on the received button event
   - choose:
       - conditions: '{{ trigger_action | string in button_short }}'

--- a/blueprints/controllers/ikea_e2001_e2002/ikea_e2001_e2002.yaml
+++ b/blueprints/controllers/ikea_e2001_e2002/ikea_e2001_e2002.yaml
@@ -409,7 +409,7 @@ action:
   - service: input_text.set_value
     data:
       entity_id: !input helper_last_controller_event
-      value: '{{ {"a":trigger_action,"t":as_timestamp(now())} | to_json }}'
+      value: '{{ {"a":trigger_action|string,"t":as_timestamp(now())} | to_json }}'
   # choose the sequence to run based on the received button event
   - choose:
       - conditions: '{{ trigger_action | string in button_left_short }}'

--- a/blueprints/controllers/ikea_ictc_g_1/ikea_ictc_g_1.yaml
+++ b/blueprints/controllers/ikea_ictc_g_1/ikea_ictc_g_1.yaml
@@ -215,7 +215,7 @@ action:
   - service: input_text.set_value
     data:
       entity_id: !input helper_last_controller_event
-      value: '{{ {"a":trigger_action,"t":as_timestamp(now())} | to_json }}'
+      value: '{{ {"a":trigger_action|string,"t":as_timestamp(now())} | to_json }}'
   # choose the sequence to run based on the received button event
   - choose:
       - conditions: '{{ trigger_action | string in rotate_left }}'

--- a/blueprints/controllers/osram_ac025xx00nj/osram_ac025xx00nj.yaml
+++ b/blueprints/controllers/osram_ac025xx00nj/osram_ac025xx00nj.yaml
@@ -343,7 +343,7 @@ action:
   - service: input_text.set_value
     data:
       entity_id: !input helper_last_controller_event
-      value: '{{ {"a":trigger_action,"t":as_timestamp(now())} | to_json }}'
+      value: '{{ {"a":trigger_action|string,"t":as_timestamp(now())} | to_json }}'
   # choose the sequence to run based on the received button event
   - choose:
       - conditions: '{{ trigger_action | string in button_up_short }}'

--- a/blueprints/controllers/philips_324131092621/philips_324131092621.yaml
+++ b/blueprints/controllers/philips_324131092621/philips_324131092621.yaml
@@ -406,7 +406,7 @@ action:
   - service: input_text.set_value
     data:
       entity_id: !input helper_last_controller_event
-      value: '{{ {"a":trigger_action,"t":as_timestamp(now())} | to_json }}'
+      value: '{{ {"a":trigger_action|string,"t":as_timestamp(now())} | to_json }}'
   # choose the sequence to run based on the received button event
   - choose:
       - conditions: '{{ trigger_action | string in button_on_short }}'

--- a/blueprints/controllers/philips_8718699693985/philips_8718699693985.yaml
+++ b/blueprints/controllers/philips_8718699693985/philips_8718699693985.yaml
@@ -194,7 +194,7 @@ action:
   - service: input_text.set_value
     data:
       entity_id: !input helper_last_controller_event
-      value: '{{ {"a":trigger_action,"t":as_timestamp(now())} | to_json }}'
+      value: '{{ {"a":trigger_action|string,"t":as_timestamp(now())} | to_json }}'
   # choose the sequence to run based on the received button event
   - choose:
       - conditions: '{{ trigger_action | string in button_short }}'

--- a/blueprints/controllers/philips_929002398602/philips_929002398602.yaml
+++ b/blueprints/controllers/philips_929002398602/philips_929002398602.yaml
@@ -391,7 +391,7 @@ action:
   - service: input_text.set_value
     data:
       entity_id: !input helper_last_controller_event
-      value: '{{ {"a":trigger_action,"t":as_timestamp(now())} | to_json }}'
+      value: '{{ {"a":trigger_action|string,"t":as_timestamp(now())} | to_json }}'
   # choose the sequence to run based on the received button event
   - choose:
       - conditions: '{{ trigger_action | string in button_on_short }}'

--- a/blueprints/controllers/sonoff_snzb01/sonoff_snzb01.yaml
+++ b/blueprints/controllers/sonoff_snzb01/sonoff_snzb01.yaml
@@ -167,7 +167,7 @@ action:
   - service: input_text.set_value
     data:
       entity_id: !input helper_last_controller_event
-      value: '{{ {"a":trigger_action,"t":as_timestamp(now())} | to_json }}'
+      value: '{{ {"a":trigger_action|string,"t":as_timestamp(now())} | to_json }}'
   # choose the sequence to run based on the received button event
   - choose:
       - conditions: '{{ trigger_action | string in button_short }}'

--- a/blueprints/controllers/xiaomi_wxcjkg11lm/xiaomi_wxcjkg11lm.yaml
+++ b/blueprints/controllers/xiaomi_wxcjkg11lm/xiaomi_wxcjkg11lm.yaml
@@ -278,7 +278,7 @@ action:
   - service: input_text.set_value
     data:
       entity_id: !input helper_last_controller_event
-      value: '{{ {"a":trigger_action,"t":as_timestamp(now())} | to_json }}'
+      value: '{{ {"a":trigger_action|string,"t":as_timestamp(now())} | to_json }}'
   # choose the sequence to run based on the received button event
   - choose:
       - conditions: '{{ trigger_action | string in button_1_short }}'

--- a/blueprints/controllers/xiaomi_wxcjkg12lm/xiaomi_wxcjkg12lm.yaml
+++ b/blueprints/controllers/xiaomi_wxcjkg12lm/xiaomi_wxcjkg12lm.yaml
@@ -418,7 +418,7 @@ action:
   - service: input_text.set_value
     data:
       entity_id: !input helper_last_controller_event
-      value: '{{ {"a":trigger_action,"t":as_timestamp(now())} | to_json }}'
+      value: '{{ {"a":trigger_action|string,"t":as_timestamp(now())} | to_json }}'
   # choose the sequence to run based on the received button event
   - choose:
       - conditions: '{{ trigger_action | string in button_1_short }}'

--- a/blueprints/controllers/xiaomi_wxcjkg13lm/xiaomi_wxcjkg13lm.yaml
+++ b/blueprints/controllers/xiaomi_wxcjkg13lm/xiaomi_wxcjkg13lm.yaml
@@ -558,7 +558,7 @@ action:
   - service: input_text.set_value
     data:
       entity_id: !input helper_last_controller_event
-      value: '{{ {"a":trigger_action,"t":as_timestamp(now())} | to_json }}'
+      value: '{{ {"a":trigger_action|string,"t":as_timestamp(now())} | to_json }}'
   # choose the sequence to run based on the received button event
   - choose:
       - conditions: '{{ trigger_action | string in button_1_short }}'

--- a/blueprints/controllers/xiaomi_wxkg11lm/xiaomi_wxkg11lm.yaml
+++ b/blueprints/controllers/xiaomi_wxkg11lm/xiaomi_wxkg11lm.yaml
@@ -198,7 +198,7 @@ action:
   - service: input_text.set_value
     data:
       entity_id: !input helper_last_controller_event
-      value: '{{ {"a":trigger_action,"t":as_timestamp(now())} | to_json }}'
+      value: '{{ {"a":trigger_action|string,"t":as_timestamp(now())} | to_json }}'
   # choose the sequence to run based on the received button event
   - choose:
       - conditions: '{{ trigger_action | string in button_short }}'


### PR DESCRIPTION
## Breaking change

The helper_last_controller_event "a" attribute is now forced to be written as a string, may break some integrations if a number or other type is expected.

## Proposed change\*

This change modifies all helper_last_controller_event updates to force the trigger_action to be written (and appropriately quoted) as a string.

There are a collection of regexes that test the contents of this json before parsing it and expect this value to be quoted.  The existing implementation means that Virtual Double Press events were never generated in my use cases (deconz + ikea).

A better change might be to update the regexes to allow all types of variables or rework completely how that validation is applied,  given that it is evidently fragile, but I settled on this approach as it seemed less impactful.

## Checklist\*

- [ ] I followed sections of the [Contribution Guidelines](https://github.com/EPMatt/awesome-ha-blueprints/blob/main/CONTRIBUTING.md) relevant to changes I'm proposing.
- [ ] I properly tested proposed changes on my system and confirm that they are working as expected.
- [ ] I formatted files with Prettier using the command `npm run format` before submitting my Pull Request.
