### PR TITLE
IKEA ICTC-G-1 ZHA fixes and improvements.

### DIFF
--- a/blueprints/controllers/ikea_ictc_g_1/ikea_ictc_g_1.yaml
+++ b/blueprints/controllers/ikea_ictc_g_1/ikea_ictc_g_1.yaml
@@ -61,6 +61,12 @@ blueprint:
       default: []
       selector:
         action:
+    action_rotate_left_quick:
+      name: (Optional) Rotate left quick (ZHA)
+      description: Action to run on rotate left quick.
+      default: []
+      selector:
+        action:
     action_rotate_right:
       name: (Optional) Rotate right
       description: Action to run on rotate right.
@@ -70,6 +76,12 @@ blueprint:
     action_rotate_right_stop:
       name: (Optional) Rotate right stop
       description: Action to run when stopping to rotate right the remote.
+      default: []
+      selector:
+        action:
+    action_rotate_right_quick:
+      name: (Optional) Rotate right quick (ZHA)
+      description: Action to run on rotate right quick.
       default: []
       selector:
         action:
@@ -140,21 +152,29 @@ variables:
   actions_mapping:
     deconz:
       rotate_left: ['3002']
+      rotate_left_quick: []
       rotate_stop: []
       rotate_right: ['2002']
+      rotate_right_quick: []
     zha:
-      rotate_left: [move_1_70, move_1_195]
-      rotate_stop: [stop]
-      rotate_right: [move_with_on_off_0_70, move_with_on_off_0_195]
+      rotate_left: [move_1_70, move_1_195, move_MoveMode.Down_195]
+      rotate_left_quick: [move_to_level_with_on_off_0_1]
+      rotate_stop: [stop, stop_with_on_off]
+      rotate_right: [move_with_on_off_0_70, move_with_on_off_0_195, move_with_on_off_MoveMode.Up_195]
+      rotate_right_quick: [move_to_level_with_on_off_255_1]
     zigbee2mqtt:
       rotate_left: [brightness_move_down]
+      rotate_left_quick: []
       rotate_stop: [brightness_stop]
       rotate_right: [brightness_move_up]
+      rotate_right_quick: []
   # pre-choose actions for buttons based on configured integration
   # no need to perform this task at automation runtime
   rotate_left: '{{ actions_mapping[integration_id]["rotate_left"] }}'
+  rotate_left_quick: '{{ actions_mapping[integration_id]["rotate_left_quick"] }}'
   rotate_stop: '{{ actions_mapping[integration_id]["rotate_stop"] }}'
   rotate_right: '{{ actions_mapping[integration_id]["rotate_right"] }}'
+  rotate_right_quick: '{{ actions_mapping[integration_id]["rotate_right_quick"] }}'
   # build data to send within a controller event
   controller_entity: !input controller_entity
   controller_device: !input controller_device
@@ -248,6 +268,17 @@ action:
           - choose:
               - conditions: []
                 sequence: !input action_rotate_left_stop
+      - conditions: '{{ trigger_action | string in rotate_left_quick }}'
+        sequence:
+          # fire the event
+          - event: ahb_controller_event
+            event_data:
+              controller: '{{ controller_id }}'
+              action: rotate_left_quick
+          # run the custom action
+          - choose:
+              - conditions: []
+                sequence: !input action_rotate_left_quick
       - conditions: '{{ trigger_action | string in rotate_right }}'
         sequence:
           # fire the event only once before looping the action
@@ -278,3 +309,14 @@ action:
           - choose:
               - conditions: []
                 sequence: !input action_rotate_right_stop
+      - conditions: '{{ trigger_action | string in rotate_right_quick }}'
+        sequence:
+          # fire the event
+          - event: ahb_controller_event
+            event_data:
+              controller: '{{ controller_id }}'
+              action: rotate_right_quick
+          # run the custom action
+          - choose:
+              - conditions: []
+                sequence: !input action_rotate_right_quick

--- a/blueprints/hooks/light/light.yaml
+++ b/blueprints/hooks/light/light.yaml
@@ -234,6 +234,8 @@ variables:
     IKEA ICTC-G-1 TRÅDFRI wireless dimmer:
       brightness_down_repeat: rotate_left
       brightness_up_repeat: rotate_right
+      turn_on: rotate_left_quick
+      turn_off: rotate_right_quick
     OSRAM AC025XX00NJ SMART+ Switch Mini:
       brightness_up: button_up_short
       brightness_up_repeat: button_up_long

--- a/blueprints/hooks/media_player/media_player.yaml
+++ b/blueprints/hooks/media_player/media_player.yaml
@@ -132,6 +132,8 @@ variables:
     IKEA ICTC-G-1 TRÅDFRI wireless dimmer:
       volume_down_repeat: rotate_left
       volume_up_repeat: rotate_right
+      prev_track: rotate_left_quick
+      next_track: rotate_right_quick
     OSRAM AC025XX00NJ SMART+ Switch Mini:
       volume_up: button_up_short
       volume_up_repeat: button_up_long

--- a/website/docs/blueprints/controllers/ikea_ictc_g_1.mdx
+++ b/website/docs/blueprints/controllers/ikea_ictc_g_1.mdx
@@ -78,6 +78,11 @@ This integration provides the entity which must be provided to the blueprint in 
   selector='action'
 />
 <Input
+  name='Rotate left quick'
+  description='Action to run when rotating left the remote quickly.'
+  selector='action'
+/>
+<Input
   name='Rotate right'
   description='Action to run on rotate right.'
   selector='action'
@@ -85,6 +90,11 @@ This integration provides the entity which must be provided to the blueprint in 
 <Input
   name='Rotate right stop'
   description='Action to run when stopping to rotate right the remote.'
+  selector='action'
+/>
+<Input
+  name='Rotate right quick'
+  description='Action to run when rotating right the remote quickly.'
   selector='action'
 />
 <Input
@@ -123,6 +133,8 @@ This Hook blueprint allows to build a controller-based automation to control a l
 
 - Rotate left -> Brightness down (continuous, until stop)
 - Rotate right -> Brightness up (continuous, until stop)
+- Rotate left quick -> Turn off
+- Rotate right quick -> Turn on
 
 [Light Hook docs](/docs/blueprints/hooks/light)
 
@@ -134,6 +146,8 @@ This Hook blueprint allows to build a controller-based automation to control a m
 
 - Rotate left -> Volume down (continuous, until stop)
 - Rotate right -> Volume up (continuous, until stop)
+- Rotate left quick -> Previous track
+- Rotate right quick -> Next track
 
 [Media Player Hook docs](/docs/blueprints/hooks/media_player)
 


### PR DESCRIPTION
Thank you for taking the time to work on a Pull Request. Your contribution is really appreciated! :tada:
**Please don't delete any part of the template**, since keeping the provided structure will help maintainers to review your work more rapidly.

Sections marked as \* are required and need to be filled in.

## Proposed change\*

- Fix non working controller **ICTC-G-1** on _ZHA integration_ by adding newly observed ZHA events.

- Add actions on quick rotation of the controller as the original Ikea integration: Turn on/Turn off, Prev track/Next track (Currently ZHA only); includes changes to light and mediaplayer hooks for the controller.

Can be used as base to fix other issues found with Ikea controllers using new ZHA events:
- Rotate left: `move_MoveMode.Down_195`
- Rotate right: `move_with_on_off_MoveMode.Up_195`
- Stop: `stop_with_on_off`
- Rotate left quick: `move_to_level_with_on_off_0_1`
- Rotate right quick: `move_to_level_with_on_off_255_1`

## Checklist\*

- [x] I followed sections of the [Contribution Guidelines](https://github.com/EPMatt/awesome-ha-blueprints/blob/main/CONTRIBUTING.md) relevant to changes I'm proposing.
- [x] I properly tested proposed changes on my system and confirm that they are working as expected.
- [x] I formatted files with Prettier using the command `npm run format` before submitting my Pull Request.
