### PR TITLE
Update ikea_e1812.yaml

### DIFF
--- a/blueprints/controllers/ikea_e1812/ikea_e1812.yaml
+++ b/blueprints/controllers/ikea_e1812/ikea_e1812.yaml
@@ -3,18 +3,13 @@ blueprint:
   name: Controller - IKEA E1812 TRÅDFRI Shortcut button
   description: |
     # Controller - IKEA E1812 TRÅDFRI Shortcut button
-
     Controller automation for executing any kind of action triggered by the provided IKEA E1812 TRÅDFRI Shortcut button. Allows to optionally loop an action on a button long press.
     Supports deCONZ, ZHA, Zigbee2MQTT.
-
     Automations created with this blueprint can be connected with one or more [Hooks](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/hooks) supported by this controller.
     Hooks allow to easily create controller-based automations for interacting with media players, lights, covers and more.
     See the list of [Hooks available for this controller](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/controllers/ikea_e1812#available-hooks) for additional details.
-
     📕 Full documentation regarding this blueprint is available [here](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/controllers/ikea_e1812).
-
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
-
     ℹ️ Version 2022.08.08
   source_url: https://github.com/EPMatt/awesome-ha-blueprints/blob/main/blueprints/controllers/ikea_e1812/ikea_e1812.yaml
   domain: automation
@@ -92,25 +87,6 @@ blueprint:
           max: 5000
           mode: slider
           step: 1
-    # inputs for enabling double press events
-    button_double_press:
-      name: (Optional) Expose button double press event
-      description: Choose whether or not to expose the virtual double press event for the button. Turn this on if you are providing an action for the button double press event.
-      default: false
-      selector:
-        boolean:
-    # helpers used to properly recognize the remote button events
-    helper_double_press_delay:
-      name: (Optional) Helper - Double Press delay
-      description: Max delay between the first and the second button press for the double press event. Provide a value only if you are using a double press action. Increase this value if you notice that the double press action is not triggered properly.
-      default: 500
-      selector:
-        number:
-          min: 100
-          max: 5000
-          unit_of_measurement: milliseconds
-          mode: box
-          step: 10
     helper_debounce_delay:
       name: (Optional) Helper - Debounce delay
       description:
@@ -130,15 +106,13 @@ variables:
   integration: !input integration
   button_long_loop: !input button_long_loop
   button_long_max_loop_repeats: !input button_long_max_loop_repeats
-  button_double_press: !input button_double_press
   helper_last_controller_event: !input helper_last_controller_event
-  helper_double_press_delay: !input helper_double_press_delay
   helper_debounce_delay: !input helper_debounce_delay
   # integration id used to select items in the action mapping
   integration_id: '{{ integration | lower }}'
   # adjusted debounce delay so that the resulting double press delay is exactly as specified by the user when running the action, taking also account of debouncing
   # make sure it never goes below the minimum double press delay
-  adjusted_double_press_delay: '{{ [helper_double_press_delay - helper_debounce_delay, 100] | max }}'
+#  adjusted_double_press_delay: '{{ [helper_double_press_delay - helper_debounce_delay, 100] | max }}'
   # mapping between actions and integrations
   actions_mapping:
     deconz:
@@ -151,11 +125,13 @@ variables:
       button_release: [stop]
     zigbee2mqtt:
       button_short: ['on']
+      button_double: ['off']
       button_long: [brightness_move_up]
       button_release: [brightness_stop]
   # pre-choose actions for buttons based on configured integration
   # no need to perform this task at automation runtime
   button_short: '{{ actions_mapping[integration_id]["button_short"] }}'
+  button_double: '{{ actions_mapping[integration_id]["button_double"] }}'
   button_long: '{{ actions_mapping[integration_id]["button_long"] }}'
   button_release: '{{ actions_mapping[integration_id]["button_release"] }}'
   # build data to send within a controller event
@@ -221,58 +197,25 @@ action:
   # choose the sequence to run based on the received button event
   - choose:
       - conditions: '{{ trigger_action | string in button_short }}'
-        sequence:
+        sequence: 
+          - event: ahb_controller_event
+            event_data: 
+              controller: '{{ controller_id }}'
+              action: button_short
+          # run the custom action
           - choose:
-              # if double press event is enabled
-              - conditions: '{{ button_double_press }}'
-                sequence:
-                  - choose:
-                      # if previous event was a short press
-                      - conditions: '{{ trigger_action | string in states(helper_last_controller_event) and trigger_delta | int <= helper_double_press_delay | int }}'
-                        sequence:
-                          # store the double press event in the last controller event helper
-                          - service: input_text.set_value
-                            data:
-                              entity_id: !input helper_last_controller_event
-                              value: '{{ {"a":"double_press","t":as_timestamp(now())} | to_json }}'
-                          # run the double press action
-                          # fire the event
-                          - event: ahb_controller_event
-                            event_data:
-                              controller: '{{ controller_id }}'
-                              action: button_double
-                          # run the custom action
-                          - choose:
-                              - conditions: []
-                                sequence: !input action_button_double
-                    # previous event was not a short press
-                    default:
-                      # wait for the double press event to occur, within the provided delay
-                      # if the second press is received, automation is restarted
-                      - delay:
-                          milliseconds: '{{ adjusted_double_press_delay }}'
-                      # if delay expires, no second press was received, therefore run the short press action
-                      # run the short press action
-                      # fire the event
-                      - event: ahb_controller_event
-                        event_data:
-                          controller: '{{ controller_id }}'
-                          action: button_short
-                      # run the custom action
-                      - choose:
-                          - conditions: []
-                            sequence: !input action_button_short
-            # if double press event is disabled run the action for the single short press
-            default:
-              # fire the event
-              - event: ahb_controller_event
-                event_data:
-                  controller: '{{ controller_id }}'
-                  action: button_short
-              # run the custom action
-              - choose:
-                  - conditions: []
-                    sequence: !input action_button_short
+              - conditions: []
+                sequence: !input action_button_short
+      - conditions: '{{ trigger_action | string in button_double }}'
+        sequence:
+          - event: ahb_controller_event
+            event_data:
+              controller: '{{ controller_id }}'
+              action: button_double
+           # run the custom action
+          - choose:
+              - conditions: []
+                sequence: !input action_button_double
       - conditions: '{{ trigger_action | string in button_long }}'
         sequence:
           # fire the event only once before looping the action


### PR DESCRIPTION
Add double_press action

Thank you for taking the time to work on a Pull Request. Your contribution is really appreciated! :tada:
**Please don't delete any part of the template**, since keeping the provided structure will help maintainers to review your work more rapidly.

Sections marked as \* are required and need to be filled in.

## Proposed change\*

zigbee2mqtt version (docker) > 1.28.2 commit: 360a777
home-assistant version (docker) > 2022.11.2
Coordinator type > EZSP v8
Coordinator revision > 6.10.3.0 build 297
ikea_e1812 > Firmware build date (20210727)
                     Firmware version (2.3.080)


*I tested this with zigbee2mqtt and confirm that it is working. I didn't test this with ZHA or deCONZ

After updating the ikea tradfri shortcut button (e1812) to 2.3.080 (20210727) version, the double press action stopped working. Only single and long press was working. Double press seems to be added to the update version as "off" action. With this, I change a little the blueprint so the double_press, single and long_press work.

## Checklist\*

- [x] I followed sections of the [Contribution Guidelines](https://github.com/EPMatt/awesome-ha-blueprints/blob/main/CONTRIBUTING.md) relevant to changes I'm proposing.
- [x] I properly tested proposed changes on my system and confirm that they are working as expected.
- [x] I formatted files with Prettier using the command `npm run format` before submitting my Pull Request.
