### PR TITLE
fixed bug with storing previous state as number

### DIFF
--- a/blueprints/controllers/ikea_e1744/ikea_e1744.yaml
+++ b/blueprints/controllers/ikea_e1744/ikea_e1744.yaml
@@ -213,7 +213,7 @@ condition:
         {%- if integration_id == "zigbee2mqtt" -%}
         {{ trigger.event.data.new_state.state }}
         {%- elif integration_id == "deconz" -%}
-        {{ trigger.event.data.event }}
+        {{ trigger.event.data.event | string }}
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
         {%- endif -%}
@@ -235,7 +235,7 @@ action:
         {%- if integration_id == "zigbee2mqtt" -%}
         {{ trigger.event.data.new_state.state }}
         {%- elif integration_id == "deconz" -%}
-        {{ trigger.event.data.event }}
+        {{ trigger.event.data.event | string }}
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
         {%- endif -%}
@@ -245,7 +245,7 @@ action:
   - service: input_text.set_value
     data:
       entity_id: !input helper_last_controller_event
-      value: '{{ {"a":trigger_action,"t":as_timestamp(now())} | to_json }}'
+      value: '{{ {"a":(trigger_action | string),"t":as_timestamp(now())} | to_json }}'
   # choose the sequence to run based on the received button event
   - choose:
       - conditions: '{{ trigger_action | string in rotate_left }}'


### PR DESCRIPTION
Thank you for taking the time to work on a Pull Request. Your contribution is really appreciated! :tada:
**Please don't delete any part of the template**, since keeping the provided structure will help maintainers to review your work more rapidly.

Sections marked as \* are required and need to be filled in.

## Proposed change\*

The current behaviour if you are on deconz and run the latest versions of deconz and homeassistant is that the state is in numbers and not string. The regex used on line 242 and 243 regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) expect the value to be a string and not a number so it is never caught as a valid state.

so i change the state to string before evaluation and when storing it to helper

## Checklist\*

- [ ] I followed sections of the [Contribution Guidelines](https://github.com/EPMatt/awesome-ha-blueprints/blob/main/CONTRIBUTING.md) relevant to changes I'm proposing.
- [x] I properly tested proposed changes on my system and confirm that they are working as expected.
- [ ] I formatted files with Prettier using the command `npm run format` before submitting my Pull Request.
