### PR TITLE
Fix the formatting for new version of ZHA

### DIFF
--- a/blueprints/controllers/ikea_e1743/ikea_e1743.yaml
+++ b/blueprints/controllers/ikea_e1743/ikea_e1743.yaml
@@ -1,180 +1,195 @@
-# Blueprint metadata
 blueprint:
-  name: Controller - IKEA E1743 TRÅDFRI On/Off Switch & Dimmer
-  description: |
-    # Controller - IKEA E1743 TRÅDFRI On/Off Switch & Dimmer
-
-    Controller automation for executing any kind of action triggered by the provided IKEA E1743 TRÅDFRI On/Off Switch & Dimmer. Allows to optionally loop an action on a button long press.
-    Supports deCONZ, ZHA, Zigbee2MQTT.
-
-    Automations created with this blueprint can be connected with one or more [Hooks](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/hooks) supported by this controller.
-    Hooks allow to easily create controller-based automations for interacting with media players, lights, covers and more.
-    See the list of [Hooks available for this controller](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/controllers/ikea_e1743#available-hooks) for additional details.
-
-    📕 Full documentation regarding this blueprint is available [here](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/controllers/ikea_e1743).
-
-    🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
-
-    ℹ️ Version 2022.08.08
+  name: elindgren - IKEA E1743 TRÅDFRI On/Off Switch & Dimmer
+  description: "# Controller - IKEA E1743 TRÅDFRI On/Off Switch & Dimmer\n\nController
+    *I've modified this controller to handle the new format of long presses for E1743 controllers*
+    Specifically, I've:
+      - Updated the regex: https://github.com/EPMatt/awesome-ha-blueprints/pull/545
+      - Changed the event names for long press up and down to what is reported by the helper.
+    automation for executing any kind of action triggered by the provided IKEA E1743
+    TRÅDFRI On/Off Switch & Dimmer. Allows to optionally loop an action on a button
+    long press.\nSupports deCONZ, ZHA, Zigbee2MQTT.\n\nAutomations created with this
+    blueprint can be connected with one or more [Hooks](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/hooks)
+    supported by this controller.\nHooks allow to easily create controller-based automations
+    for interacting with media players, lights, covers and more.\nSee the list of
+    [Hooks available for this controller](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/controllers/ikea_e1743#available-hooks)
+    for additional details.\n\n\U0001F4D5 Full documentation regarding this blueprint
+    is available [here](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/controllers/ikea_e1743).\n\n\U0001F680
+    This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints)
+    project**.\n\nℹ️ Version 2022.08.08\n"
   source_url: https://github.com/EPMatt/awesome-ha-blueprints/blob/main/blueprints/controllers/ikea_e1743/ikea_e1743.yaml
   domain: automation
   input:
     integration:
       name: (Required) Integration
-      description: Integration used for connecting the remote with Home Assistant. Select one of the available values.
+      description: Integration used for connecting the remote with Home Assistant.
+        Select one of the available values.
       selector:
         select:
           options:
-            - deCONZ
-            - ZHA
-            - Zigbee2MQTT
+          - deCONZ
+          - ZHA
+          - Zigbee2MQTT
+          sort: false
+          custom_value: false
+          multiple: false
     controller_device:
       name: (deCONZ, ZHA) Controller Device
-      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.
+      description: The controller device to use for the automation. Choose a value
+        only if the remote is integrated with deCONZ, ZHA.
       default: ''
       selector:
-        device:
+        device: {}
     controller_entity:
       name: (Zigbee2MQTT) Controller Entity
-      description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
+      description: The action sensor of the controller to use for the automation.
+        Choose a value only if the remote is integrated with Zigbee2MQTT.
       default: ''
       selector:
         entity:
-          domain: sensor
+          domain:
+          - sensor
+          multiple: false
     helper_last_controller_event:
       name: (Required) Helper - Last Controller Event
-      description: Input Text used to store the last event fired by the controller. You will need to manually create a text input entity for this, please read the blueprint Additional Notes for more info.
+      description: Input Text used to store the last event fired by the controller.
+        You will need to manually create a text input entity for this, please read
+        the blueprint Additional Notes for more info.
       default: ''
       selector:
         entity:
-          domain: input_text
-    # inputs for custom actions
+          domain:
+          - input_text
+          multiple: false
     action_button_up_short:
       name: (Optional) Up button short press
       description: Action to run on short up button press.
       default: []
       selector:
-        action:
+        action: {}
     action_button_up_long:
       name: (Optional) Up button long press
       description: Action to run on long up button press.
       default: []
       selector:
-        action:
+        action: {}
     action_button_up_release:
       name: (Optional) Up button release
       description: Action to run on up button release after long press.
       default: []
       selector:
-        action:
+        action: {}
     action_button_up_double:
       name: (Optional) Up button double press
       description: Action to run on double up button press.
       default: []
       selector:
-        action:
+        action: {}
     action_button_down_short:
       name: (Optional) Down button short press
       description: Action to run on short down button press.
       default: []
       selector:
-        action:
+        action: {}
     action_button_down_long:
       name: (Optional) Down button long press
       description: Action to run on long down button press.
       default: []
       selector:
-        action:
+        action: {}
     action_button_down_release:
       name: (Optional) Down button release
       description: Action to run on down button release after long press.
       default: []
       selector:
-        action:
+        action: {}
     action_button_down_double:
       name: (Optional) Down button double press
       description: Action to run on double down button press.
       default: []
       selector:
-        action:
-    # inputs for looping custom actions on long button press events until the corresponding release event is received
+        action: {}
     button_up_long_loop:
       name: (Optional) Up button long press - loop until release
       description: Loop the up button action until the button is released.
       default: false
       selector:
-        boolean:
+        boolean: {}
     button_up_long_max_loop_repeats:
       name: (Optional) Up button long press - Maximum loop repeats
-      description: >-
-        Maximum number of repeats for the custom action, when looping is enabled.
-        Use it as a safety limit to prevent an endless loop in case the corresponding stop event is not received.
+      description: Maximum number of repeats for the custom action, when looping is
+        enabled. Use it as a safety limit to prevent an endless loop in case the corresponding
+        stop event is not received.
       default: 500
       selector:
         number:
-          min: 1
-          max: 5000
+          min: 1.0
+          max: 5000.0
           mode: slider
-          step: 1
+          step: 1.0
     button_down_long_loop:
       name: (Optional) Down button long press - loop until release
       description: Loop the down button action until the button is released.
       default: false
       selector:
-        boolean:
+        boolean: {}
     button_down_long_max_loop_repeats:
       name: (Optional) Down button long press - Maximum loop repeats
-      description: >-
-        Maximum number of repeats for the custom action, when looping is enabled.
-        Use it as a safety limit to prevent an endless loop in case the corresponding stop event is not received.
+      description: Maximum number of repeats for the custom action, when looping is
+        enabled. Use it as a safety limit to prevent an endless loop in case the corresponding
+        stop event is not received.
       default: 500
       selector:
         number:
-          min: 1
-          max: 5000
+          min: 1.0
+          max: 5000.0
           mode: slider
-          step: 1
-    # inputs for enabling double press events
+          step: 1.0
     button_up_double_press:
       name: (Optional) Expose up button double press event
-      description: Choose whether or not to expose the virtual double press event for the up button. Turn this on if you are providing an action for the up button double press event.
+      description: Choose whether or not to expose the virtual double press event
+        for the up button. Turn this on if you are providing an action for the up
+        button double press event.
       default: false
       selector:
-        boolean:
+        boolean: {}
     button_down_double_press:
       name: (Optional) Expose down button double press event
-      description: Choose whether or not to expose the virtual double press event for the down button. Turn this on if you are providing an action for the down button double press event.
+      description: Choose whether or not to expose the virtual double press event
+        for the down button. Turn this on if you are providing an action for the down
+        button double press event.
       default: false
       selector:
-        boolean:
-    # helpers used to properly recognize the remote button events
+        boolean: {}
     helper_double_press_delay:
       name: (Optional) Helper - Double Press delay
-      description: Max delay between the first and the second button press for the double press event. Provide a value only if you are using a double press action. Increase this value if you notice that the double press action is not triggered properly.
+      description: Max delay between the first and the second button press for the
+        double press event. Provide a value only if you are using a double press action.
+        Increase this value if you notice that the double press action is not triggered
+        properly.
       default: 500
       selector:
         number:
-          min: 100
-          max: 5000
+          min: 100.0
+          max: 5000.0
           unit_of_measurement: milliseconds
           mode: box
-          step: 10
+          step: 10.0
     helper_debounce_delay:
       name: (Optional) Helper - Debounce delay
-      description:
-        Delay used for debouncing RAW controller events, by default set to 0. A value of 0 disables the debouncing feature. Increase this value if you notice custom actions or linked Hooks running multiple times when interacting with the device. When the controller needs to be debounced,
-        usually a value of 100 is enough to remove all duplicate events.
+      description: Delay used for debouncing RAW controller events, by default set
+        to 0. A value of 0 disables the debouncing feature. Increase this value if
+        you notice custom actions or linked Hooks running multiple times when interacting
+        with the device. When the controller needs to be debounced, usually a value
+        of 100 is enough to remove all duplicate events.
       default: 0
       selector:
         number:
-          min: 0
-          max: 1000
+          min: 0.0
+          max: 1000.0
           unit_of_measurement: milliseconds
           mode: box
-          step: 10
-# Automation schema
+          step: 10.0
 variables:
-  # convert input tags to variables, to be used in templates
   integration: !input integration
   button_up_long_loop: !input button_up_long_loop
   button_up_long_max_loop_repeats: !input button_up_long_max_loop_repeats
@@ -185,270 +200,231 @@ variables:
   helper_last_controller_event: !input helper_last_controller_event
   helper_double_press_delay: !input helper_double_press_delay
   helper_debounce_delay: !input helper_debounce_delay
-  # integration id used to select items in the action mapping
   integration_id: '{{ integration | lower }}'
-  # adjusted debounce delay so that the resulting double press delay is exactly as specified by the user when running the action, taking also account of debouncing
-  # make sure it never goes below the minimum double press delay
-  adjusted_double_press_delay: '{{ [helper_double_press_delay - helper_debounce_delay, 100] | max }}'
-  # mapping between actions and integrations
+  adjusted_double_press_delay: '{{ [helper_double_press_delay - helper_debounce_delay,
+    100] | max }}'
   actions_mapping:
     deconz:
-      button_up_short: ['1002']
-      button_up_long: ['1001']
-      button_up_release: ['1003']
-      button_down_short: ['2002']
-      button_down_long: ['2001']
-      button_down_release: ['2003']
+      button_up_short:
+      - '1002'
+      button_up_long:
+      - '1001'
+      button_up_release:
+      - '1003'
+      button_down_short:
+      - '2002'
+      button_down_long:
+      - '2001'
+      button_down_release:
+      - '2003'
     zha:
-      button_up_short: ['on']
-      button_up_long: [move_with_on_off_0_83]
-      button_up_release: [stop]
-      button_down_short: ['off']
-      button_down_long: [move_1_83]
-      button_down_release: [stop]
+      button_up_short:
+      - 'on'
+      button_up_long:
+      - 'move_with_on_off_MoveMode.Up_83'
+      button_up_release:
+      - 'stop_with_on_off'
+      button_down_short:
+      - 'off'
+      button_down_long:
+      - 'move_MoveMode.Down_83_0_0'
+      button_down_release:
+      - 'stop_with_on_off'
     zigbee2mqtt:
-      button_up_short: ['on']
-      button_up_long: [brightness_move_up]
-      button_up_release: [brightness_stop]
-      button_down_short: ['off']
-      button_down_long: [brightness_move_down]
-      button_down_release: [brightness_stop]
-  # pre-choose actions for buttons based on configured integration
-  # no need to perform this task at automation runtime
+      button_up_short:
+      - 'on'
+      button_up_long:
+      - brightness_move_up
+      button_up_release:
+      - brightness_stop
+      button_down_short:
+      - 'off'
+      button_down_long:
+      - brightness_move_down
+      button_down_release:
+      - brightness_stop
   button_up_short: '{{ actions_mapping[integration_id]["button_up_short"] }}'
   button_up_long: '{{ actions_mapping[integration_id]["button_up_long"] }}'
   button_up_release: '{{ actions_mapping[integration_id]["button_up_release"] }}'
   button_down_short: '{{ actions_mapping[integration_id]["button_down_short"] }}'
   button_down_long: '{{ actions_mapping[integration_id]["button_down_long"] }}'
-  button_down_release: '{{ actions_mapping[integration_id]["button_down_release"] }}'
-  # integrations which need to store the previous press event to determine which button was released
-  integrations_with_prev_event_storage: [zha, zigbee2mqtt]
-  # build data to send within a controller event
+  button_down_release: '{{ actions_mapping[integration_id]["button_down_release"]
+    }}'
+  integrations_with_prev_event_storage:
+  - zha
+  - zigbee2mqtt
   controller_entity: !input controller_entity
   controller_device: !input controller_device
-  controller_id: '{% if integration_id=="zigbee2mqtt" %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
+  controller_id: '{% if integration_id=="zigbee2mqtt" %}{{controller_entity}}{% else
+    %}{{controller_device}}{% endif %}'
 mode: restart
 max_exceeded: silent
 trigger:
-  # trigger for zigbee2mqtt
-  - platform: event
-    event_type: state_changed
-    event_data:
-      entity_id: !input controller_entity
-  # trigger for other integrations
-  - platform: event
-    event_type:
-      - deconz_event
-      - zha_event
-    event_data:
-      device_id: !input controller_device
+- platform: event
+  event_type: state_changed
+  event_data:
+    entity_id: !input controller_entity
+- platform: event
+  event_type:
+  - deconz_event
+  - zha_event
+  event_data:
+    device_id: !input controller_device
 condition:
-  - condition: and
-    conditions:
-      # check that the button event is not empty
-      - >-
-        {%- set trigger_action -%}
-        {%- if integration_id == "zigbee2mqtt" -%}
-        {{ trigger.event.data.new_state.state }}
-        {%- elif integration_id == "deconz" -%}
-        {{ trigger.event.data.event }}
-        {%- elif integration_id == "zha" -%}
-        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
-        {%- endif -%}
-        {%- endset -%}
-        {{ trigger_action not in ["","None"] }}
-      # only for zigbee2mqtt, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
-      # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
-      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+- condition: and
+  conditions:
+  - '{%- set trigger_action -%} {%- if integration_id == "zigbee2mqtt" -%} {{ trigger.event.data.new_state.state
+    }} {%- elif integration_id == "deconz" -%} {{ trigger.event.data.event }} {%-
+    elif integration_id == "zha" -%} {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length
+    > 0}}{{ trigger.event.data.args|join("_") }} {%- endif -%} {%- endset -%} {{ trigger_action
+    not in ["","None"] }}'
+  - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state
+    }}'
 action:
-  # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
-  # therefore previous runs must wait for the debounce delay before executing any other action
-  # if the delay expires and the automation is still running it means it's the last run and execution can continue
-  - delay:
-      milliseconds: !input helper_debounce_delay
-  # extract button event from the trigger
-  # provide a single string value to check against
-  - variables:
-      trigger_action: >-
-        {%- if integration_id == "zigbee2mqtt" -%}
-        {{ trigger.event.data.new_state.state }}
-        {%- elif integration_id == "deconz" -%}
-        {{ trigger.event.data.event }}
-        {%- elif integration_id == "zha" -%}
-        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
-        {%- endif -%}
-      trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
-      last_controller_event: '{{ (states(helper_last_controller_event) | from_json).a if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else "" }}'
-  # update helper
-  - service: input_text.set_value
-    data:
-      entity_id: !input helper_last_controller_event
-      value: '{{ {"a":trigger_action,"t":as_timestamp(now())} | to_json }}'
-  # choose the sequence to run based on the received button event
-  - choose:
-      - conditions: '{{ trigger_action | string in button_up_short }}'
+- delay:
+    milliseconds: !input helper_debounce_delay
+- variables:
+    trigger_action: '{%- if integration_id == "zigbee2mqtt" -%} {{ trigger.event.data.new_state.state
+      }} {%- elif integration_id == "deconz" -%} {{ trigger.event.data.event }} {%-
+      elif integration_id == "zha" -%} {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length
+      > 0}}{{ trigger.event.data.args|join("_") }} {%- endif -%}'
+    trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event)
+      | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event)
+      | regex_match("^\{((\"a\":\".*\"|\"t\":\d+\.\d+)(,)?){2}\}$")) else as_timestamp("1970-01-01
+      00:00:00"))) * 1000 }}'
+    last_controller_event: '{{ (states(helper_last_controller_event) | from_json).a
+      if helper_last_controller_event is not none and (states(helper_last_controller_event)
+      | regex_match("^\{((\"a\":\".*\"|\"t\":\d+\.\d+)(,)?){2}\}$")) else "" }}'
+- service: input_text.set_value
+  data:
+    entity_id: !input helper_last_controller_event
+    value: '{{ {"a":trigger_action,"t":as_timestamp(now())} | to_json }}'
+- choose:
+  - conditions: '{{ trigger_action | string in button_up_short }}'
+    sequence:
+    - choose:
+      - conditions: '{{ button_up_double_press }}'
         sequence:
-          - choose:
-              # if double press event is enabled
-              - conditions: '{{ button_up_double_press }}'
-                sequence:
-                  - choose:
-                      # if previous event was a short press
-                      - conditions: '{{ trigger_action | string in states(helper_last_controller_event) and trigger_delta | int <= helper_double_press_delay | int }}'
-                        sequence:
-                          # store the double press event in the last controller event helper
-                          - service: input_text.set_value
-                            data:
-                              entity_id: !input helper_last_controller_event
-                              value: '{{ {"a":"double_press","t":as_timestamp(now())} | to_json }}'
-                          # run the double press action
-                          # fire the event
-                          - event: ahb_controller_event
-                            event_data:
-                              controller: '{{ controller_id }}'
-                              action: button_up_double
-                          # run the custom action
-                          - choose:
-                              - conditions: []
-                                sequence: !input action_button_up_double
-                    # previous event was not a short press
-                    default:
-                      # wait for the double press event to occur, within the provided delay
-                      # if the second press is received, automation is restarted
-                      - delay:
-                          milliseconds: '{{ adjusted_double_press_delay }}'
-                      # if delay expires, no second press was received, therefore run the short press action
-                      # run the short press action
-                      # fire the event
-                      - event: ahb_controller_event
-                        event_data:
-                          controller: '{{ controller_id }}'
-                          action: button_up_short
-                      # run the custom action
-                      - choose:
-                          - conditions: []
-                            sequence: !input action_button_up_short
-            # if double press event is disabled run the action for the single short press
-            default:
-              # fire the event
-              - event: ahb_controller_event
-                event_data:
-                  controller: '{{ controller_id }}'
-                  action: button_up_short
-              # run the custom action
-              - choose:
-                  - conditions: []
-                    sequence: !input action_button_up_short
-      - conditions: '{{ trigger_action | string in button_up_long }}'
-        sequence:
-          # fire the event only once before looping the action
-          - event: ahb_controller_event
-            event_data:
-              controller: '{{ controller_id }}'
-              action: button_up_long
-          - choose:
-              # if looping is enabled, loop the action for a finite number of iterations
-              - conditions: '{{ button_up_long_loop }}'
-                sequence:
-                  - repeat:
-                      while: '{{ repeat.index < button_up_long_max_loop_repeats | int }}'
-                      sequence: !input action_button_up_long
-            # if looping is not enabled run the custom action only once
-            default: !input action_button_up_long
-      - conditions:
-          - '{{ trigger_action | string in button_up_release }}'
-          # for integrations which need to store the last controller event, need to check the previous button event, stored in the provided input_text
-          - '{{ not integration_id in integrations_with_prev_event_storage or last_controller_event | string in button_up_long }}'
-        sequence:
-          # fire the event
-          - event: ahb_controller_event
-            event_data:
-              controller: '{{ controller_id }}'
-              action: button_up_release
-          # run the custom action
-          - choose:
+        - choose:
+          - conditions: '{{ trigger_action | string in states(helper_last_controller_event)
+              and trigger_delta | int <= helper_double_press_delay | int }}'
+            sequence:
+            - service: input_text.set_value
+              data:
+                entity_id: !input helper_last_controller_event
+                value: '{{ {"a":"double_press","t":as_timestamp(now())} | to_json
+                  }}'
+            - event: ahb_controller_event
+              event_data:
+                controller: '{{ controller_id }}'
+                action: button_up_double
+            - choose:
               - conditions: []
-                sequence: !input action_button_up_release
-      - conditions: '{{ trigger_action | string in button_down_short }}'
-        sequence:
-          - choose:
-              # if double press event is enabled
-              - conditions: '{{ button_down_double_press }}'
-                sequence:
-                  - choose:
-                      # if previous event was a short press
-                      - conditions: '{{ trigger_action | string in states(helper_last_controller_event) and trigger_delta | int <= helper_double_press_delay | int }}'
-                        sequence:
-                          # store the double press event in the last controller event helper
-                          - service: input_text.set_value
-                            data:
-                              entity_id: !input helper_last_controller_event
-                              value: '{{ {"a":"double_press","t":as_timestamp(now())} | to_json }}'
-                          # run the double press action
-                          # fire the event
-                          - event: ahb_controller_event
-                            event_data:
-                              controller: '{{ controller_id }}'
-                              action: button_down_double
-                          # run the custom action
-                          - choose:
-                              - conditions: []
-                                sequence: !input action_button_down_double
-                    # previous event was not a short press
-                    default:
-                      # wait for the double press event to occur, within the provided delay
-                      # if the second press is received, automation is restarted
-                      - delay:
-                          milliseconds: '{{ adjusted_double_press_delay }}'
-                      # if delay expires, no second press was received, therefore run the short press action
-                      # run the short press action
-                      # fire the event
-                      - event: ahb_controller_event
-                        event_data:
-                          controller: '{{ controller_id }}'
-                          action: button_down_short
-                      # run the custom action
-                      - choose:
-                          - conditions: []
-                            sequence: !input action_button_down_short
-            # if double press event is disabled run the action for the single short press
-            default:
-              # fire the event
-              - event: ahb_controller_event
-                event_data:
-                  controller: '{{ controller_id }}'
-                  action: button_down_short
-              # run the custom action
-              - choose:
-                  - conditions: []
-                    sequence: !input action_button_down_short
-      - conditions: '{{ trigger_action | string in button_down_long }}'
-        sequence:
-          # fire the event only once before looping the action
+                sequence: !input action_button_up_double
+          default:
+          - delay:
+              milliseconds: '{{ adjusted_double_press_delay }}'
           - event: ahb_controller_event
             event_data:
               controller: '{{ controller_id }}'
-              action: button_down_long
+              action: button_up_short
           - choose:
-              # if looping is enabled, loop the action for a finite number of iterations
-              - conditions: '{{ button_down_long_loop }}'
-                sequence:
-                  - repeat:
-                      while: '{{ repeat.index < button_down_long_max_loop_repeats | int }}'
-                      sequence: !input action_button_down_long
-            # if looping is not enabled run the custom action only once
-            default: !input action_button_down_long
-      - conditions:
-          - '{{ trigger_action | string in button_down_release }}'
-          # for integrations which need to store the last controller event, need to check the previous button event, stored in the provided input_text
-          - '{{ not integration_id in integrations_with_prev_event_storage or last_controller_event | string in button_down_long }}'
+            - conditions: []
+              sequence: !input action_button_up_short
+      default:
+      - event: ahb_controller_event
+        event_data:
+          controller: '{{ controller_id }}'
+          action: button_up_short
+      - choose:
+        - conditions: []
+          sequence: !input action_button_up_short
+  - conditions: '{{ trigger_action | string in button_up_long }}'
+    sequence:
+    - event: ahb_controller_event
+      event_data:
+        controller: '{{ controller_id }}'
+        action: button_up_long
+    - choose:
+      - conditions: '{{ button_up_long_loop }}'
         sequence:
-          # fire the event
-          - event: ahb_controller_event
-            event_data:
-              controller: '{{ controller_id }}'
-              action: button_down_release
-          # run the custom action
-          - choose:
+        - repeat:
+            while: '{{ repeat.index < button_up_long_max_loop_repeats | int }}'
+            sequence: !input action_button_up_long
+      default: !input action_button_up_long
+  - conditions:
+    - '{{ trigger_action | string in button_up_release }}'
+    - '{{ not integration_id in integrations_with_prev_event_storage or last_controller_event
+      | string in button_up_long }}'
+    sequence:
+    - event: ahb_controller_event
+      event_data:
+        controller: '{{ controller_id }}'
+        action: button_up_release
+    - choose:
+      - conditions: []
+        sequence: !input action_button_up_release
+  - conditions: '{{ trigger_action | string in button_down_short }}'
+    sequence:
+    - choose:
+      - conditions: '{{ button_down_double_press }}'
+        sequence:
+        - choose:
+          - conditions: '{{ trigger_action | string in states(helper_last_controller_event)
+              and trigger_delta | int <= helper_double_press_delay | int }}'
+            sequence:
+            - service: input_text.set_value
+              data:
+                entity_id: !input helper_last_controller_event
+                value: '{{ {"a":"double_press","t":as_timestamp(now())} | to_json
+                  }}'
+            - event: ahb_controller_event
+              event_data:
+                controller: '{{ controller_id }}'
+                action: button_down_double
+            - choose:
               - conditions: []
-                sequence: !input action_button_down_release
+                sequence: !input action_button_down_double
+          default:
+          - delay:
+              milliseconds: '{{ adjusted_double_press_delay }}'
+          - event: ahb_controller_event
+            event_data:
+              controller: '{{ controller_id }}'
+              action: button_down_short
+          - choose:
+            - conditions: []
+              sequence: !input action_button_down_short
+      default:
+      - event: ahb_controller_event
+        event_data:
+          controller: '{{ controller_id }}'
+          action: button_down_short
+      - choose:
+        - conditions: []
+          sequence: !input action_button_down_short
+  - conditions: '{{ trigger_action | string in button_down_long }}'
+    sequence:
+    - event: ahb_controller_event
+      event_data:
+        controller: '{{ controller_id }}'
+        action: button_down_long
+    - choose:
+      - conditions: '{{ button_down_long_loop }}'
+        sequence:
+        - repeat:
+            while: '{{ repeat.index < button_down_long_max_loop_repeats | int }}'
+            sequence: !input action_button_down_long
+      default: !input action_button_down_long
+  - conditions:
+    - '{{ trigger_action | string in button_down_release }}'
+    - '{{ not integration_id in integrations_with_prev_event_storage or last_controller_event
+      | string in button_down_long }}'
+    sequence:
+    - event: ahb_controller_event
+      event_data:
+        controller: '{{ controller_id }}'
+        action: button_down_release
+    - choose:
+      - conditions: []
+        sequence: !input action_button_down_release


### PR DESCRIPTION
*I've modified this controller to handle the new format of long presses for E1743 controllers*
    Specifically, I've:
      - Updated the regex: https://github.com/EPMatt/awesome-ha-blueprints/pull/545
      - Changed the event names for long press up and down to what is reported by the helper.