### PR TITLE
Update ZHA long press buttons mapping for ikea_e1743.yaml

### DIFF
--- a/blueprints/controllers/ikea_e1743/ikea_e1743.yaml
+++ b/blueprints/controllers/ikea_e1743/ikea_e1743.yaml
@@ -201,11 +201,11 @@ variables:
       button_down_release: ['2003']
     zha:
       button_up_short: ['on']
-      button_up_long: [move_with_on_off_0_83]
-      button_up_release: [stop]
+      button_up_long: [move_with_on_off_MoveMode.Up_83]
+      button_up_release: [stop_with_on_off]
       button_down_short: ['off']
-      button_down_long: [move_1_83]
-      button_down_release: [stop]
+      button_down_long: [move_MoveMode.Down_83_bitmap8.0_bitmap8.0]
+      button_down_release: [stop_with_on_off]
     zigbee2mqtt:
       button_up_short: ['on']
       button_up_long: [brightness_move_up]


### PR DESCRIPTION
Thank you for taking the time to work on a Pull Request. Your contribution is really appreciated! :tada:
**Please don't delete any part of the template**, since keeping the provided structure will help maintainers to review your work more rapidly.

Sections marked as \* are required and need to be filled in.

## Proposed change\*

I changed mapped action names for long press and for releasing long press. I did it because these actions with current blueprint didn't work because of wrong action names. Made the change only for ZHA.
New actions maps:
- `button_up_long`: `move_with_on_off_MoveMode.Up_83`
- `button_up_release`: `stop_with_on_off`
- `button_down_long`: `move_MoveMode.Down_83_bitmap8.0_bitmap8.0`
- `button_down_release`: `stop_with_on_off`

The solution tested with 3 Ikea e1743 dimmers.

## Checklist\*

- [x] I followed sections of the [Contribution Guidelines](https://github.com/EPMatt/awesome-ha-blueprints/blob/main/CONTRIBUTING.md) relevant to changes I'm proposing.
- [x] I properly tested proposed changes on my system and confirm that they are working as expected.
- [ ] I formatted files with Prettier using the command `npm run format` before submitting my Pull Request.
