### PR TITLE
IKEA_e2001_e2002 - Remove condition to check which button was released to trigger releas…

### DIFF
--- a/blueprints/controllers/ikea_e2001_e2002/ikea_e2001_e2002.yaml
+++ b/blueprints/controllers/ikea_e2001_e2002/ikea_e2001_e2002.yaml
@@ -483,8 +483,6 @@ action:
             default: !input action_button_left_long
       - conditions:
           - '{{ trigger_action | string in button_left_release }}'
-          # for integrations which need to store the last controller event, need to check the previous button event, stored in the provided input_text
-          - '{{ not integration_id in integrations_with_prev_event_storage or last_controller_event | string in button_left_long }}'
         sequence:
           # fire the event
           - event: ahb_controller_event
@@ -566,8 +564,6 @@ action:
             default: !input action_button_right_long
       - conditions:
           - '{{ trigger_action | string in button_right_release }}'
-          # for integrations which need to store the last controller event, need to check the previous button event, stored in the provided input_text
-          - '{{ not integration_id in integrations_with_prev_event_storage or last_controller_event | string in button_right_long }}'
         sequence:
           # fire the event
           - event: ahb_controller_event
@@ -649,8 +645,6 @@ action:
             default: !input action_button_up_long
       - conditions:
           - '{{ trigger_action | string in button_up_release }}'
-          # for integrations which need to store the last controller event, need to check the previous button event, stored in the provided input_text
-          - '{{ not integration_id in integrations_with_prev_event_storage or last_controller_event | string in button_up_long }}'
         sequence:
           # fire the event
           - event: ahb_controller_event
@@ -732,8 +726,6 @@ action:
             default: !input action_button_down_long
       - conditions:
           - '{{ trigger_action | string in button_down_release }}'
-          # for integrations which need to store the last controller event, need to check the previous button event, stored in the provided input_text
-          - '{{ not integration_id in integrations_with_prev_event_storage or last_controller_event | string in button_down_long }}'
         sequence:
           # fire the event
           - event: ahb_controller_event


### PR DESCRIPTION
## Proposed change

This PR removes a condition to check for the last value in the "input_text" to detect which button was pressed. This may not be an optimal solution and updating this PR with a new, working condition could be required. I did not figure out why the condition did not act as expected. Any contributions are welcome. This eventually closes #581

## Checklist

- [ x ] I followed sections of the [Contribution Guidelines](https://github.com/EPMatt/awesome-ha-blueprints/blob/main/CONTRIBUTING.md) relevant to changes I'm proposing.
- [ x ] I properly tested proposed changes on my system and confirm that they are working as expected.
- [ x ] I formatted files with Prettier using the command `npm run format` before submitting my Pull Request.
