### PR TITLE
Bug - Fix_multiple bugs incontroller blueprint for philips_324131092621 on Zigbee2MQTT

### DIFF
--- a/blueprints/controllers/philips_324131092621/philips_324131092621.yaml
+++ b/blueprints/controllers/philips_324131092621/philips_324131092621.yaml
@@ -321,18 +321,18 @@ variables:
       button_down_long: [down_hold]
       button_down_release: [down_long_release]
     zigbee2mqtt:
-      button_on_short: [on-press]
-      button_on_long: [on-hold]
-      button_on_release: [on-hold-release]
-      button_off_short: [off-press]
-      button_off_long: [off-hold]
-      button_off_release: [off-hold-release]
-      button_up_short: [up-press]
-      button_up_long: [up-hold]
-      button_up_release: [up-hold-release]
-      button_down_short: [down-press]
-      button_down_long: [down-hold]
-      button_down_release: [down-hold-release]
+      button_on_short: [on_press_release]
+      button_on_long: [on_hold]
+      button_on_release: [on_hold_release]
+      button_off_short: [off_press_release]
+      button_off_long: [off_hold]
+      button_off_release: [off_hold_release]
+      button_up_short: [up_press_release]
+      button_up_long: [up_hold]
+      button_up_release: [up_hold_release]
+      button_down_short: [down_press_release]
+      button_down_long: [down_hold]
+      button_down_release: [down_hold_release]
   # pre-choose actions for buttons based on configured integration
   # no need to perform this task at automation runtime
   button_on_short: '{{ actions_mapping[integration_id]["button_on_short"] }}'
@@ -489,7 +489,7 @@ action:
           - choose:
               - conditions: []
                 sequence: !input action_button_on_release
-      - conditions: '{{ trigger_action | string in button_off_short }}'
+      - conditions: "{{ trigger_action | string in button_off_short }}"
         sequence:
           - choose:
               # if double press event is enabled

--- a/blueprints/controllers/philips_324131092621/philips_324131092621.yaml
+++ b/blueprints/controllers/philips_324131092621/philips_324131092621.yaml
@@ -402,7 +402,7 @@ action:
         {{ trigger.event.data.command }}
         {%- endif -%}
       # helper_last_controller_event example: {"a":"on_press_release","t":1706926380.358825}
-      trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": *\".*\"|\"t\": *\d+\.\d+)(, *)?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
+      trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\":\s*\".*\"|\"t\":\s*\d+\.\d+)(,\s*)?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
   # update helper
   - service: input_text.set_value
     data:

--- a/blueprints/controllers/philips_324131092621/philips_324131092621.yaml
+++ b/blueprints/controllers/philips_324131092621/philips_324131092621.yaml
@@ -380,7 +380,7 @@ condition:
         {{ trigger.event.data.command }}
         {%- endif -%}
         {%- endset -%}
-        {{ trigger_action not in ["","None"] }}
+        {{ trigger_action not in ["","None", "on_press", "up_press", "down_press", "off_press"] }}
       # only for zigbee2mqtt, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
       - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'

--- a/blueprints/controllers/philips_324131092621/philips_324131092621.yaml
+++ b/blueprints/controllers/philips_324131092621/philips_324131092621.yaml
@@ -401,7 +401,8 @@ action:
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}
         {%- endif -%}
-      trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
+      # helper_last_controller_event example: {"a":"on_press_release","t":1706926380.358825}
+      trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": *\".*\"|\"t\": *\d+\.\d+)(, *)?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
   # update helper
   - service: input_text.set_value
     data:


### PR DESCRIPTION
Thank you for taking the time to work on a Pull Request. Your contribution is really appreciated! :tada:
**Please don't delete any part of the template**, since keeping the provided structure will help maintainers to review your work more rapidly.

Sections marked as \* are required and need to be filled in.

## Proposed change\*

There are several bugs in the blueprint which make it unsuable when using Zigbee2MQTT.
I debugged the blueprint on my system and prepared this MR. Before submitting, I stumbled upon a few other PRs which address some of the issues exactly like I did, but not all of them.

Thus I still decided to go forward, so you can fix all issues with one single PR.

Merging this PR will solve the following issues:

#216
#406
#425
#457
#496
#541
#558
#576

and will make the following PRs obsolete:

#406
#542
#577


## The fixes in more detail

### Event mapping for zigbee2mqtt is wrong

There are two issues with that mapping. First of all, the events are sent with underscores, whereas the blueprint expects dashes. This prevents the script from working at all.

Secondly the event to listen for on short presses should be "on_press_release" and not "on_press". Listening to "on_press" triggers the script too early and too often. This causes all sorts of weird behaviour and a lot of race conditions. Listening to "on_press_release" solves this issue.

### trigger_delta calculation is not working due to the regex not matching the helper value

The helper value looks like this:

```json
{"a":"on_press_release","t":1706926380.358825}
```

The blueprint however, expects this:

```json
{"a" :"on_press_release", "t" :1706926380.358825}
```

I've modified the regular expression to make whitespaces optional and also accept other types of whitespace (tab, newline) and multiple consecutive whitespaces. This should also make it future proof.

### Automation should not run on "on_press" events

As the event mapping is now using "on_press_release" events, the whole automation should not run for "on_press" events anymore. This also causes race conditions and weird unpredictable behaviour where double presses are not recognized for example.

I've changed the trigger condition to be false if such an event is received. 

## Checklist\*

- [ ] I followed sections of the [Contribution Guidelines](https://github.com/EPMatt/awesome-ha-blueprints/blob/main/CONTRIBUTING.md) relevant to changes I'm proposing.
- [ ] I properly tested proposed changes on my system and confirm that they are working as expected.
- [ ] I formatted files with Prettier using the command `npm run format` before submitting my Pull Request.
