### PR TITLE
Zigbee2MQTT: Direct Triggers

### DIFF
--- a/blueprints/controllers/ikea_e2001_e2002/ikea_e2001_e2002.yaml
+++ b/blueprints/controllers/ikea_e2001_e2002/ikea_e2001_e2002.yaml
@@ -15,7 +15,7 @@ blueprint:
 
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
-    ℹ️ Version 2022.08.08
+    ℹ️ Version 2024.02.23
   source_url: https://github.com/EPMatt/awesome-ha-blueprints/blob/main/blueprints/controllers/ikea_e2001_e2002/ikea_e2001_e2002.yaml
   domain: automation
   input:
@@ -34,13 +34,15 @@ blueprint:
       default: ''
       selector:
         device:
-    controller_entity:
-      name: (Zigbee2MQTT) Controller Entity
-      description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
+    mqtt_device:
+      name: (Zigbee2MQTT) MQTT Device
+      description: The MQTT device to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
       default: ''
       selector:
-        entity:
-          domain: sensor
+        device:
+          manufacturer: IKEA
+          model: STYRBAR remote control (E2001/E2002)
+          multiple: false
     helper_last_controller_event:
       name: (Required) Helper - Last Controller Event
       description: Input Text used to store the last event fired by the controller. You will need to manually create a text input entity for this, please read the blueprint Additional Notes for more info.
@@ -350,17 +352,73 @@ variables:
   # integrations which need to store the previous press event to determine which button was released
   integrations_with_prev_event_storage: [zha, zigbee2mqtt]
   # build data to send within a controller event
-  controller_entity: !input controller_entity
+  mqtt_device: !input mqtt_device
   controller_device: !input controller_device
-  controller_id: '{% if integration_id=="zigbee2mqtt" %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
+  controller_id: '{% if integration_id=="zigbee2mqtt" %}{{mqtt_device}}{% else %}{{controller_device}}{% endif %}'
 mode: restart
 max_exceeded: silent
 trigger:
-  # trigger for zigbee2mqtt
-  - platform: event
-    event_type: state_changed
-    event_data:
-      entity_id: !input controller_entity
+  # triggers for zigbee2mqtt
+  - platform: device
+    domain: mqtt
+    device_id: !input mqtt_device
+    type: action
+    subtype: "arrow_left_click"
+  - platform: device
+    domain: mqtt
+    device_id: !input mqtt_device
+    type: action
+    subtype: "arrow_left_hold"
+  - platform: device
+    domain: mqtt
+    device_id: !input mqtt_device
+    type: action
+    subtype: "arrow_left_release"
+  - platform: device
+    domain: mqtt
+    device_id: !input mqtt_device
+    type: action
+    subtype: "arrow_right_click"
+  - platform: device
+    domain: mqtt
+    device_id: !input mqtt_device
+    type: action
+    subtype: "arrow_right_hold"
+  - platform: device
+    domain: mqtt
+    device_id: !input mqtt_device
+    type: action
+    subtype: "arrow_right_release"
+  - platform: device
+    domain: mqtt
+    device_id: !input mqtt_device
+    type: action
+    subtype: "on"
+  - platform: device
+    domain: mqtt
+    device_id: !input mqtt_device
+    type: action
+    subtype: "brightness_move_up"
+  - platform: device
+    domain: mqtt
+    device_id: !input mqtt_device
+    type: action
+    subtype: "brightness_stop"
+  - platform: device
+    domain: mqtt
+    device_id: !input mqtt_device
+    type: action
+    subtype: "off"
+  - platform: device
+    domain: mqtt
+    device_id: !input mqtt_device
+    type: action
+    subtype: "brightness_move_down"
+  - platform: device
+    domain: mqtt
+    device_id: !input mqtt_device
+    type: action
+    subtype: "brightness_stop"
   # trigger for other integrations
   - platform: event
     event_type:
@@ -375,7 +433,7 @@ condition:
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" -%}
-        {{ trigger.event.data.new_state.state }}
+        {{ trigger.payload }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
@@ -383,9 +441,6 @@ condition:
         {%- endif -%}
         {%- endset -%}
         {{ trigger_action not in ["","None"] }}
-      # only for zigbee2mqtt, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
-      # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
-      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -397,7 +452,7 @@ action:
   - variables:
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" -%}
-        {{ trigger.event.data.new_state.state }}
+        {{ trigger.payload }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}


### PR DESCRIPTION
**Please don't delete any part of the template**, since keeping the provided structure will help maintainers to review your work more rapidly.

Sections marked as \* are required and need to be filled in.

## Breaking change

Zigbee2MQTT device selection changes to a MQTT device, requiring users to re-select the device in existing deployed automations.

## Proposed change\*

Home Assistant 2042.2 onwards supports redirect MQTT topic subscriptions using `device_id`, `type` and `subtype` trigger properties.

This updates the existing blueprint to be able to select the Zigbee2MQTT exposed IKEA E2001/E2002 STYRBAR device and leverage direct MQTT topic integration.

## Checklist\*

- [x] I followed sections of the [Contribution Guidelines](https://github.com/EPMatt/awesome-ha-blueprints/blob/main/CONTRIBUTING.md) relevant to changes I'm proposing.
- [x] I properly tested proposed changes on my system and confirm that they are working as expected.
- [x] I formatted files with Prettier using the command `npm run format` before submitting my Pull Request.
