### PR TITLE
Update ZHA event data to what ZHA provides in HA 2024.03.01

### DIFF
--- a/blueprints/controllers/ikea_e1744/ikea_e1744.yaml
+++ b/blueprints/controllers/ikea_e1744/ikea_e1744.yaml
@@ -15,7 +15,7 @@ blueprint:
 
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
-    ℹ️ Version 2022.08.08
+    ℹ️ Version 2024.03.01
   source_url: https://github.com/EPMatt/awesome-ha-blueprints/blob/main/blueprints/controllers/ikea_e1744/ikea_e1744.yaml
   domain: automation
   input:
@@ -164,12 +164,12 @@ variables:
       click_double: ['1004']
       click_triple: ['1005']
     zha:
-      rotate_left: [move_1_195]
-      rotate_stop: [stop]
-      rotate_right: [move_0_195]
+      rotate_left: [move_MoveMode.Down_195_0_0]
+      rotate_stop: [stop_0_0]
+      rotate_right: [move_MoveMode.Up_195_0_0]
       click_short: [toggle]
-      click_double: [step_0_1_0]
-      click_triple: [step_1_1_0]
+      click_double: [step_StepMode.Up_1_0_0_0]
+      click_triple: [step_StepMode.Down_1_0_0_0]
     zigbee2mqtt:
       rotate_left: [brightness_move_down]
       rotate_stop: [brightness_stop]
@@ -239,8 +239,8 @@ action:
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
         {%- endif -%}
-      trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
-      last_controller_event: '{{ (states(helper_last_controller_event) | from_json).a if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else "" }}'
+      trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{\s*((\"a\":\s*\".*\"|\"t\":\s*\d+\.\d+)(,\s*)?){2}\s*\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
+      last_controller_event: '{{ (states(helper_last_controller_event) | from_json).a if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{\s*((\"a\":\s*\".*\"|\"t\":\s*\d+\.\d+)(,\s*)?){2}\s*\}$")) else "" }}'
   # update helper
   - service: input_text.set_value
     data:

--- a/blueprints/controllers/ikea_e1744/ikea_e1744.yaml
+++ b/blueprints/controllers/ikea_e1744/ikea_e1744.yaml
@@ -15,7 +15,7 @@ blueprint:
 
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
-    ℹ️ Version 2024.03.01
+    ℹ️ Version 2025.01.05
   source_url: https://github.com/EPMatt/awesome-ha-blueprints/blob/main/blueprints/controllers/ikea_e1744/ikea_e1744.yaml
   domain: automation
   input:
@@ -164,12 +164,12 @@ variables:
       click_double: ['1004']
       click_triple: ['1005']
     zha:
-      rotate_left: [move_MoveMode.Down_195_0_0]
-      rotate_stop: [stop_0_0]
-      rotate_right: [move_MoveMode.Up_195_0_0]
+      rotate_left: [move_1_195, move_MoveMode.Down_195_0_0]
+      rotate_stop: [stop, stop_0_0]
+      rotate_right: [move_0_195, move_MoveMode.Up_195_0_0]
       click_short: [toggle]
-      click_double: [step_StepMode.Up_1_0_0_0]
-      click_triple: [step_StepMode.Down_1_0_0_0]
+      click_double: [step_0_1_0, step_StepMode.Up_1_0_0_0]
+      click_triple: [step_1_1_0, step_StepMode.Down_1_0_0_0]
     zigbee2mqtt:
       rotate_left: [brightness_move_down]
       rotate_stop: [brightness_stop]

--- a/website/docs/blueprints/controllers/ikea_e1744.mdx
+++ b/website/docs/blueprints/controllers/ikea_e1744.mdx
@@ -202,3 +202,4 @@ The helper is used to determine stop rotation events when the controller is inte
 - **2021-08-02**: Improve inputs documentation and organization
 - **2021-10-26**: Standardize blueprints structure and inputs naming across the whole collection. Improve blueprint documentation. No functionality change.
 - **2022-08-08**: Optimize characters usage for the `helper_last_controller_event` text input.
+- **2025-01-05**: Update ZHA event data to what ZHA provides in HA 2024.03.01 ([@ogajduse](https://github.com/ogajduse))


### PR DESCRIPTION
## Breaking change

Breaking changes for older HA versions, ZHA respectively that do not emit two extra zeros in the event args for each button action

## Proposed change

This PR fixes args for all available actions of the Ikea E1744 button. The new ZHA version adds two zeros at the end of the `args` list. This PR adapts the controller automation to the change. Fixes #553 

I have also made the regex lazier around whitespace since the output of the sensor `last_controller_event` is a pretty formatted JSON.

## Checklist\*

- [x] I followed sections of the [Contribution Guidelines](https://github.com/EPMatt/awesome-ha-blueprints/blob/main/CONTRIBUTING.md) relevant to changes I'm proposing.
- [x] I properly tested proposed changes on my system and confirm that they are working as expected.
- [x] I formatted files with Prettier using the command `npm run format` before submitting my Pull Request.
