### PR TITLE
ikea_e2001_e2002, zigbee2mqtt: handle "unknown" state

### DIFF
--- a/blueprints/controllers/ikea_e2001_e2002/ikea_e2001_e2002.yaml
+++ b/blueprints/controllers/ikea_e2001_e2002/ikea_e2001_e2002.yaml
@@ -382,7 +382,7 @@ condition:
         {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
         {%- endif -%}
         {%- endset -%}
-        {{ trigger_action not in ["","None"] }}
+        {{ trigger_action not in ["","None","unknown"] }}
       # only for zigbee2mqtt, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
       - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'

--- a/website/docs/blueprints/controllers/ikea_e2001_e2002.mdx
+++ b/website/docs/blueprints/controllers/ikea_e2001_e2002.mdx
@@ -290,4 +290,6 @@ If you notice your controller is not behaving as expected please reset the devic
 
 - **2021-11-07**: first blueprint version :tada:
 - **2022-08-08**: Optimize characters usage for the `helper_last_controller_event` text input.
-- **2025-01-02**: (ZHA) Fixed a bug preventing long pressing actions to be triggered. ([@Ivarvdb](https://github.com/Ivarvdb))
+- **2025-01-02**: 
+  - (ZHA) Fixed a bug preventing long pressing actions to be triggered. ([@Ivarvdb](https://github.com/Ivarvdb))
+  - (Zigbee2MQTT) handle "unknown" state. ([@beardhatcode](https://github.com/beardhatcode))


### PR DESCRIPTION
Since the update to HA2024.10, the state of my zigbee2mqqt linked Stybar becomes "unknown" instead of "None"


UI of stybar before the update:
- changed to None 00:24:55 - 23 hours ago
- changed to arrow_right_click 00:24:55 - 23 hours ago
- changed to None 00:24:55 - 23 hours ago

now the same event looks like:
- became unknown 23:52:22 - 3 minutes ago
- changed to arrow_right_click 23:52:22 - 3 minutes ago
- became unknown 23:52:21 - 3 minutes ago

Thank you for taking the time to work on a Pull Request. Your contribution is really appreciated! :tada:
**Please don't delete any part of the template**, since keeping the provided structure will help maintainers to review your work more rapidly.

Sections marked as \* are required and need to be filled in.


## Proposed change\*

Since the update to HA2024.10 my stybar left and right clicks did not work anymore. As noted above the intermediate state changed. This edit deals with that.


## Checklist\*

- [x] I followed sections of the [Contribution Guidelines](https://github.com/EPMatt/awesome-ha-blueprints/blob/main/CONTRIBUTING.md) relevant to changes I'm proposing.
- [x] I properly tested proposed changes on my system and confirm that they are working as expected.
- [x] I formatted files with Prettier using the command `npm run format` before submitting my Pull Request.
