### PR TITLE
add support for event entities

### DIFF
--- a/blueprints/controllers/ikea_e1744/ikea_e1744.yaml
+++ b/blueprints/controllers/ikea_e1744/ikea_e1744.yaml
@@ -211,7 +211,7 @@ condition:
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" -%}
-        {{ trigger.event.data.new_state.attributes.event_type }}
+        {{ trigger.event.data.new_state.attributes.event_type }}{{ "_" if trigger.event.data.new_state.attributes.direction }}{{trigger.event.data.new_state.attributes.direction if trigger.event.data.new_state.attributes.direction }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
@@ -219,9 +219,10 @@ condition:
         {%- endif -%}
         {%- endset -%}
         {{ trigger_action not in ["","None"] }}
+      # afaict there is no necessity for this any more
       # only for zigbee2mqtt, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
-      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.attributes.event_type != trigger.event.data.old_state.attributes.event_type }}'
+      # - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.attributes.event_type != trigger.event.data.old_state.attributes.event_type }}'
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -233,7 +234,7 @@ action:
   - variables:
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" -%}
-        {{ trigger.event.data.new_state.attributes.event_type }}
+        {{ trigger.event.data.new_state.attributes.event_type }}{{ "_" if trigger.event.data.new_state.attributes.direction }}{{trigger.event.data.new_state.attributes.direction if trigger.event.data.new_state.attributes.direction }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}

--- a/blueprints/controllers/ikea_e1744/ikea_e1744.yaml
+++ b/blueprints/controllers/ikea_e1744/ikea_e1744.yaml
@@ -35,12 +35,12 @@ blueprint:
       selector:
         device:
     controller_entity:
-      name: (Zigbee2MQTT) Controller Entity
-      description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
+      name: (Zigbee2MQTT) Controller Event Entity
+      description: The event entity of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
       default: ''
       selector:
         entity:
-          domain: sensor
+          domain: event
     helper_last_controller_event:
       name: (Required) Helper - Last Controller Event
       description: Input Text used to store the last event fired by the controller. You will need to manually create a text input entity for this, please read the blueprint Additional Notes for more info.
@@ -211,7 +211,7 @@ condition:
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" -%}
-        {{ trigger.event.data.new_state.state }}
+        {{ trigger.event.data.new_state.attributes.event_type }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
@@ -221,7 +221,7 @@ condition:
         {{ trigger_action not in ["","None"] }}
       # only for zigbee2mqtt, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
-      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.attributes.event_type != trigger.event.data.old_state.attributes.event_type }}'
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -233,7 +233,7 @@ action:
   - variables:
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" -%}
-        {{ trigger.event.data.new_state.state }}
+        {{ trigger.event.data.new_state.attributes.event_type }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}


### PR DESCRIPTION
Thank you for taking the time to work on a Pull Request. Your contribution is really appreciated! :tada:
**Please don't delete any part of the template**, since keeping the provided structure will help maintainers to review your work more rapidly.

Sections marked as \* are required and need to be filled in.

## Breaking change

This change requires you to enable `Home Assistant experimental event entities` in Zigbee2MQTT. Enabling this experimental features may break you current automations, dashboards, etc.

**Enabling event entities**
![image](https://github.com/user-attachments/assets/e244638c-046a-48c4-8018-748e43fef869)

**Event entities in HA**
![image](https://github.com/user-attachments/assets/1be2bb87-1f16-4648-824d-57c38f3cd53a)

![image](https://github.com/user-attachments/assets/ce3b3260-6885-4f37-80ca-750cd819defb)

**Trace of working automation**
![image](https://github.com/user-attachments/assets/f7afe2ee-f096-4d78-8775-de0dcb12e4da)



## Proposed change\*

This change allows to make use of event entities in HA. Enabling `Home Assistant experimental event entities` in Zigbee2MQTT will add event entities to your devices, like the ikea_e1744, which we can utilize to define the Controller Entity in this blueprint. 

 

## Checklist\*

- [x] I followed sections of the [Contribution Guidelines](https://github.com/EPMatt/awesome-ha-blueprints/blob/main/CONTRIBUTING.md) relevant to changes I'm proposing.
- [x] I properly tested proposed changes on my system and confirm that they are working as expected.
- [x] I formatted files with Prettier using the command `npm run format` before submitting my Pull Request.
