### PR TITLE
light.yaml use min_brightness and max_brightness as conditions instead of "while true" loops

### DIFF
--- a/blueprints/hooks/light/light.yaml
+++ b/blueprints/hooks/light/light.yaml
@@ -16,7 +16,7 @@ blueprint:
 
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
-    ℹ️ Version 2022.07.30
+    ℹ️ Version 2024.01.07
   source_url: https://github.com/EPMatt/awesome-ha-blueprints/blob/main/blueprints/hooks/light/light.yaml
   domain: automation
   input:

--- a/blueprints/hooks/light/light.yaml
+++ b/blueprints/hooks/light/light.yaml
@@ -460,9 +460,9 @@ action:
                       entity_id: !input light
                   - delay:
                       milliseconds: !input light_transition
-          # else move on to the loop for increasing the light brightness
+          # else move on to the loop for increasing the light brightness until the maximum brightness is reached
           - repeat:
-              while: '{{ true }}'
+              while: '{{ state_attr(light,"brightness") < max_brightness }}'
               sequence:
                 - service: light.turn_on
                   data:
@@ -502,8 +502,8 @@ action:
                                 milliseconds: 250
             default:
               - repeat:
-                  # continue lowering brightness until the light turns off
-                  while: '{{ states(light) != "off" }}'
+                  # continue lowering brightness until the light hits the minimum brightness
+                  while: '{{ state_attr(light,"brightness") > min_brightness }}'
                   sequence:
                     # lower the light's brightness. since smooth power off is disabled, never let the brightness move below the user-provided minimum
                     - service: light.turn_on


### PR DESCRIPTION
Thank you for taking the time to work on a Pull Request. Your contribution is really appreciated! :tada:
**Please don't delete any part of the template**, since keeping the provided structure will help maintainers to review your work more rapidly.

Sections marked as \* are required and need to be filled in.

## Proposed change\*

Use available min/max brightness values as failsafe/safeguards instead of "while true" loops.

Iv'e encountered the issue while creating/testing new controllers, if a "release" event is not sent for long presses.
Then my z2m network is flooded cause of the "while true" loop.

## Checklist\*

- [x] I followed sections of the [Contribution Guidelines](https://github.com/EPMatt/awesome-ha-blueprints/blob/main/CONTRIBUTING.md) relevant to changes I'm proposing.
- [x] I properly tested proposed changes on my system and confirm that they are working as expected.
- [x] I formatted files with Prettier using the command `npm run format` before submitting my Pull Request.
