### PR TITLE
(IKEA E1524/E1810) Improve Blueprint adding Z2M 2.0 MQTT Device Trigger support

### DIFF
--- a/blueprints/controllers/ikea_e1524_e1810/ikea_e1524_e1810.yaml
+++ b/blueprints/controllers/ikea_e1524_e1810/ikea_e1524_e1810.yaml
@@ -5,7 +5,7 @@ blueprint:
     # Controller - IKEA E1524/E1810 TRÅDFRI Wireless 5-Button Remote
 
     Controller automation for executing any kind of action triggered by the provided IKEA E1524/E1810 TRÅDFRI Wireless 5-Button Remote. Allows to optionally loop an action on a button long press.
-    Supports deCONZ, ZHA, Zigbee2MQTT.
+    Supports deCONZ, ZHA, Zigbee2MQTT and Zigbee2MQTT in Home Assistant legacy mode.
 
     Automations created with this blueprint can be connected with one or more [Hooks](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/hooks) supported by this controller.
     Hooks allow to easily create controller-based automations for interacting with media players, lights, covers and more.

--- a/blueprints/controllers/ikea_e1524_e1810/ikea_e1524_e1810.yaml
+++ b/blueprints/controllers/ikea_e1524_e1810/ikea_e1524_e1810.yaml
@@ -30,15 +30,16 @@ blueprint:
             - deCONZ
             - ZHA
             - Zigbee2MQTT
+            - LegacyZigbee2MQTT
     controller_device:
-      name: (deCONZ, ZHA) Controller Device
-      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.
+      name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
+      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA or Zigbee2MQTT.
       default: ''
       selector:
         device:
     controller_entity:
-      name: (Zigbee2MQTT) Controller Entity
-      description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
+      name: (Legacy Zigbee2MQTT) Controller Entity
+      description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with legacy Zigbee2MQTT.
       default: ''
       selector:
         entity:
@@ -387,7 +388,7 @@ variables:
   # build data to send within a controller event
   controller_entity: !input controller_entity
   controller_device: !input controller_device
-  controller_id: '{% if integration_id=="zigbee2mqtt" %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
+  controller_id: '{% if integration_id=="legacyzigbee2mqtt" %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
 mode: restart
 max_exceeded: silent
 trigger:
@@ -410,6 +411,8 @@ condition:
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" -%}
+        {{ trigger.payload }}
+        {%- elif integration_id == "legacyzigbee2mqtt" -%}
         {{ trigger.event.data.new_state.state }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
@@ -418,9 +421,9 @@ condition:
         {%- endif -%}
         {%- endset -%}
         {{ trigger_action not in ["","None"] }}
-      # only for zigbee2mqtt, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
+      # only for legacyzigbee2mqtt, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
       # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
-      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
+      - '{{ integration_id != "legacyzigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
 action:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
@@ -432,6 +435,8 @@ action:
   - variables:
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" -%}
+        {{ trigger.payload }}
+        {%- elif integration_id == "legacyzigbee2mqtt" -%}
         {{ trigger.event.data.new_state.state }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}

--- a/blueprints/controllers/ikea_e1524_e1810/ikea_e1524_e1810.yaml
+++ b/blueprints/controllers/ikea_e1524_e1810/ikea_e1524_e1810.yaml
@@ -15,7 +15,7 @@ blueprint:
 
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
-    ℹ️ Version 2025.01.03
+    ℹ️ Version 2025.01.04
   source_url: https://github.com/EPMatt/awesome-ha-blueprints/blob/main/blueprints/controllers/ikea_e1524_e1810/ikea_e1524_e1810.yaml
   domain: automation
   homeassistant:

--- a/blueprints/controllers/ikea_e1524_e1810/ikea_e1524_e1810.yaml
+++ b/blueprints/controllers/ikea_e1524_e1810/ikea_e1524_e1810.yaml
@@ -392,11 +392,37 @@ variables:
 mode: restart
 max_exceeded: silent
 trigger:
-  # trigger for zigbee2mqtt
+  # trigger for legacyzigbee2mqtt
   - platform: event
     event_type: state_changed
     event_data:
       entity_id: !input controller_entity
+  # triggers for zigbee2mqtt mqtt device action
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: 'toggle'
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: 'brightness_down_click'
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: brightness_up_click
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: arrow_left_click
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: arrow_right_click
   # trigger for other integrations
   - platform: event
     event_type:

--- a/blueprints/controllers/ikea_e1524_e1810/ikea_e1524_e1810.yaml
+++ b/blueprints/controllers/ikea_e1524_e1810/ikea_e1524_e1810.yaml
@@ -403,7 +403,7 @@ trigger:
     device_id: !input controller_device
     type: action
     subtype: 'toggle'
- - platform: device
+  - platform: device
     domain: mqtt
     device_id: !input controller_device
     type: action
@@ -413,7 +413,7 @@ trigger:
     device_id: !input controller_device
     type: action
     subtype: arrow_left_hold
- - platform: device
+  - platform: device
     domain: mqtt
     device_id: !input controller_device
     type: action
@@ -428,7 +428,7 @@ trigger:
     device_id: !input controller_device
     type: action
     subtype: arrow_right_hold
- - platform: device
+  - platform: device
     domain: mqtt
     device_id: !input controller_device
     type: action
@@ -438,12 +438,12 @@ trigger:
     device_id: !input controller_device
     type: action
     subtype: 'brightness_down_click'
- - platform: device
+  - platform: device
     domain: mqtt
     device_id: !input controller_device
     type: action
     subtype: brightness_down_hold
- - platform: device
+  - platform: device
     domain: mqtt
     device_id: !input controller_device
     type: action
@@ -458,7 +458,7 @@ trigger:
     device_id: !input controller_device
     type: action
     subtype: brightness_up_hold
- - platform: device
+  - platform: device
     domain: mqtt
     device_id: !input controller_device
     type: action

--- a/blueprints/controllers/ikea_e1524_e1810/ikea_e1524_e1810.yaml
+++ b/blueprints/controllers/ikea_e1524_e1810/ikea_e1524_e1810.yaml
@@ -15,7 +15,7 @@ blueprint:
 
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
-    ℹ️ Version 2025.01.04
+    ℹ️ Version 2025.01.05
   source_url: https://github.com/EPMatt/awesome-ha-blueprints/blob/main/blueprints/controllers/ikea_e1524_e1810/ikea_e1524_e1810.yaml
   domain: automation
   homeassistant:
@@ -403,11 +403,51 @@ trigger:
     device_id: !input controller_device
     type: action
     subtype: 'toggle'
+ - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: arrow_left_click
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: arrow_left_hold
+ - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: arrow_left_release
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: arrow_right_click
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: arrow_right_hold
+ - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: arrow_right_release
   - platform: device
     domain: mqtt
     device_id: !input controller_device
     type: action
     subtype: 'brightness_down_click'
+ - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: brightness_down_hold
+ - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: brightness_down_release
   - platform: device
     domain: mqtt
     device_id: !input controller_device
@@ -417,12 +457,12 @@ trigger:
     domain: mqtt
     device_id: !input controller_device
     type: action
-    subtype: arrow_left_click
-  - platform: device
+    subtype: brightness_up_hold
+ - platform: device
     domain: mqtt
     device_id: !input controller_device
     type: action
-    subtype: arrow_right_click
+    subtype: brightness_up_release
   # trigger for other integrations
   - platform: event
     event_type:


### PR DESCRIPTION
Thank you for taking the time to work on a Pull Request. Your contribution is really appreciated! :tada:
**Please don't delete any part of the template**, since keeping the provided structure will help maintainers to review your work more rapidly.

Sections marked as \* are required and need to be filled in.

## Proposed change\*

Using #661 as a base, I created a PR for supporting the E1524/E1810 remote with additional buttons to make my remote compatible again with the latest Z2M update.

The main difference is that I choose to add a 'Legacy Zigbee2MQTT' option in the select, making it easier to refer to the correct chosen integration later in the blueprint.

## Checklist\*

- [x] I followed sections of the [Contribution Guidelines](https://github.com/EPMatt/awesome-ha-blueprints/blob/main/CONTRIBUTING.md) relevant to changes I'm proposing.
- [x] I properly tested proposed changes on my system and confirm that they are working as expected.
- [ ] I formatted files with Prettier using the command `npm run format` before submitting my Pull Request.