### PR TITLE
Mass Migrate to zigbee2mqtt MQTT device triggers (mqtt)

### DIFF
--- a/blueprints/controllers/ikea_e1524_e1810/ikea_e1524_e1810.yaml
+++ b/blueprints/controllers/ikea_e1524_e1810/ikea_e1524_e1810.yaml
@@ -11,15 +11,18 @@ blueprint:
     Hooks allow to easily create controller-based automations for interacting with media players, lights, covers and more.
     See the list of [Hooks available for this controller](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/controllers/ikea_e1524_e1810#available-hooks) for additional details.
 
+    ## More Info
+
+    ℹ️ Version 2025.01.23
+    📝 [Changelog](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/controllers/ikea_e1524_e1810/#changelog)
     📕 Full documentation regarding this blueprint is available [here](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/controllers/ikea_e1524_e1810).
 
-    🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
+    🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**. Please consider **[leaving a star on GitHub](https://github.com/EPMatt/awesome-ha-blueprints)**! 🌟
 
-    ℹ️ Version 2025.01.03
   source_url: https://github.com/EPMatt/awesome-ha-blueprints/blob/main/blueprints/controllers/ikea_e1524_e1810/ikea_e1524_e1810.yaml
   domain: automation
   homeassistant:
-    min_version: 2023.5.0
+    min_version: 2024.10.0
   input:
     integration:
       name: (Required) Integration
@@ -31,18 +34,28 @@ blueprint:
             - ZHA
             - Zigbee2MQTT
     controller_device:
-      name: (deCONZ, ZHA) Controller Device
-      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.
+      name: (Required) (deCONZ, ZHA, Zigbee2MQTT) Controller Device
+      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
       selector:
         device:
-    controller_entity:
-      name: (Zigbee2MQTT) Controller Entity
-      description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
-      default: ''
-      selector:
-        entity:
-          domain: sensor
+          filter:
+            # source: https://www.zigbee2mqtt.io/devices/E1524_E1810.html#ikea-e1524-e1810
+            - integration: mqtt
+              manufacturer: IKEA
+              model: TRADFRI remote control
+            # For backwards compatibility with z2m 1.x. model_id is added to end of model rather than a seperate attribute in z2m 2.x
+            - integration: mqtt
+              manufacturer: IKEA
+              model: TRADFRI remote control (E1524/E1810)
+            # source: https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+            - integration: zha
+              manufacturer: IKEA of Sweden
+              model: TRADFRI remote control
+            - integration: deconz
+              manufacturer: IKEA of Sweden
+              model: TRADFRI remote control
+          multiple: false
     helper_last_controller_event:
       name: (Required) Helper - Last Controller Event
       description: Input Text used to store the last event fired by the controller. You will need to manually create a text input entity for this, please read the blueprint Additional Notes for more info.
@@ -352,6 +365,7 @@ variables:
       button_center_short: [toggle]
       button_center_long: [press_2_0_0]
     zigbee2mqtt:
+      # source: https://www.zigbee2mqtt.io/devices/E1524_E1810.html#ikea-e1524-e1810
       button_left_short: [arrow_left_click]
       button_left_long: [arrow_left_hold]
       button_left_release: [arrow_left_release]
@@ -385,32 +399,96 @@ variables:
   # integrations which need to store the previous press event to determine which button was released
   integrations_with_prev_event_storage: [zha]
   # build data to send within a controller event
-  controller_entity: !input controller_entity
-  controller_device: !input controller_device
-  controller_id: '{% if integration_id=="zigbee2mqtt" %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
+  controller_id: !input controller_device
 mode: restart
 max_exceeded: silent
-trigger:
-  # trigger for zigbee2mqtt
-  - platform: event
-    event_type: state_changed
-    event_data:
-      entity_id: !input controller_entity
-  # trigger for other integrations
-  - platform: event
+triggers:
+  # triggers for zigbee2mqtt mqtt device action
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: arrow_left_click
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: arrow_left_hold
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: arrow_left_release
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: arrow_right_click
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: arrow_right_hold
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: arrow_right_release
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: brightness_up_click
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: brightness_up_hold
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: brightness_up_release
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: brightness_down_click
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: brightness_down_hold
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: brightness_down_release
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: toggle
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: toggle_hold
+  # triggers for other integrations
+  - trigger: event
     event_type:
       - deconz_event
       - zha_event
     event_data:
       device_id: !input controller_device
-condition:
+conditions:
   - condition: and
     conditions:
       # check that the button event is not empty
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" -%}
-        {{ trigger.event.data.new_state.state }}
+        {{ trigger.payload }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
@@ -418,10 +496,7 @@ condition:
         {%- endif -%}
         {%- endset -%}
         {{ trigger_action not in ["","None"] }}
-      # only for zigbee2mqtt, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
-      # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
-      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
-action:
+actions:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
   # if the delay expires and the automation is still running it means it's the last run and execution can continue
@@ -432,7 +507,7 @@ action:
   - variables:
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" -%}
-        {{ trigger.event.data.new_state.state }}
+        {{ trigger.payload }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
@@ -441,7 +516,7 @@ action:
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\":\".*\"|\"t\":\d+\.\d+)(,)?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
       last_controller_event: '{{ (states(helper_last_controller_event) | from_json).a if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\":\".*\"|\"t\":\d+\.\d+)(,)?){2}\}$")) else "" }}'
   # update helper
-  - service: input_text.set_value
+  - action: input_text.set_value
     data:
       entity_id: !input helper_last_controller_event
       value: '{{ {"a":trigger_action,"t":as_timestamp(now())} | to_json }}'
@@ -458,7 +533,7 @@ action:
                       - conditions: '{{ trigger_action | string in states(helper_last_controller_event) and trigger_delta | int <= helper_double_press_delay | int }}'
                         sequence:
                           # store the double press event in the last controller event helper
-                          - service: input_text.set_value
+                          - action: input_text.set_value
                             data:
                               entity_id: !input helper_last_controller_event
                               value: '{{ {"a":"double_press","t":as_timestamp(now())} | to_json }}'
@@ -541,7 +616,7 @@ action:
                       - conditions: '{{ trigger_action | string in states(helper_last_controller_event) and trigger_delta | int <= helper_double_press_delay | int }}'
                         sequence:
                           # store the double press event in the last controller event helper
-                          - service: input_text.set_value
+                          - action: input_text.set_value
                             data:
                               entity_id: !input helper_last_controller_event
                               value: '{{ {"a":"double_press","t":as_timestamp(now())} | to_json }}'
@@ -624,7 +699,7 @@ action:
                       - conditions: '{{ trigger_action | string in states(helper_last_controller_event) and trigger_delta | int <= helper_double_press_delay | int }}'
                         sequence:
                           # store the double press event in the last controller event helper
-                          - service: input_text.set_value
+                          - action: input_text.set_value
                             data:
                               entity_id: !input helper_last_controller_event
                               value: '{{ {"a":"double_press","t":as_timestamp(now())} | to_json }}'
@@ -707,7 +782,7 @@ action:
                       - conditions: '{{ trigger_action | string in states(helper_last_controller_event) and trigger_delta | int <= helper_double_press_delay | int }}'
                         sequence:
                           # store the double press event in the last controller event helper
-                          - service: input_text.set_value
+                          - action: input_text.set_value
                             data:
                               entity_id: !input helper_last_controller_event
                               value: '{{ {"a":"double_press","t":as_timestamp(now())} | to_json }}'
@@ -790,7 +865,7 @@ action:
                       - conditions: '{{ trigger_action | string in states(helper_last_controller_event) and trigger_delta | int <= helper_double_press_delay | int }}'
                         sequence:
                           # store the double press event in the last controller event helper
-                          - service: input_text.set_value
+                          - action: input_text.set_value
                             data:
                               entity_id: !input helper_last_controller_event
                               value: '{{ {"a":"double_press","t":as_timestamp(now())} | to_json }}'

--- a/blueprints/controllers/ikea_e1744/ikea_e1744.yaml
+++ b/blueprints/controllers/ikea_e1744/ikea_e1744.yaml
@@ -11,13 +11,18 @@ blueprint:
     Hooks allow to easily create controller-based automations for interacting with media players, lights, covers and more.
     See the list of [Hooks available for this controller](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/controllers/ikea_e1744#available-hooks) for additional details.
 
+    ## More Info
+
+    ℹ️ Version 2025.01.23
+    📝 [Changelog](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/controllers/ikea_e1744/#changelog)
     📕 Full documentation regarding this blueprint is available [here](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/controllers/ikea_e1744).
 
-    🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
+    🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**. Please consider **[leaving a star on GitHub](https://github.com/EPMatt/awesome-ha-blueprints)**! 🌟
 
-    ℹ️ Version 2025.01.05
   source_url: https://github.com/EPMatt/awesome-ha-blueprints/blob/main/blueprints/controllers/ikea_e1744/ikea_e1744.yaml
   domain: automation
+  homeassistant:
+    min_version: 2024.10.0
   input:
     integration:
       name: (Required) Integration
@@ -29,18 +34,28 @@ blueprint:
             - ZHA
             - Zigbee2MQTT
     controller_device:
-      name: (deCONZ, ZHA) Controller Device
-      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.
+      name: (Required) (deCONZ, ZHA, Zigbee2MQTT) Controller Device
+      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
       selector:
         device:
-    controller_entity:
-      name: (Zigbee2MQTT) Controller Entity
-      description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
-      default: ''
-      selector:
-        entity:
-          domain: sensor
+          filter:
+            # source: https://www.zigbee2mqtt.io/devices/E1744.html#ikea-e1744
+            - integration: mqtt
+              manufacturer: IKEA
+              model: SYMFONISK sound remote, gen 1
+            # For backwards compatability with z2m 1.x. model_id is added to end of model rather than a seperate attribute in z2m 2.x
+            - integration: mqtt
+              manufacturer: IKEA
+              model: SYMFONISK sound remote, gen 1 (E1744)
+            # source: https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+            - integration: zha
+              manufacturer: IKEA of Sweden
+              model: SYMFONISK Sound Controller
+            - integration: deconz
+              manufacturer: IKEA of Sweden
+              model: SYMFONISK Sound Controller
+          multiple: false
     helper_last_controller_event:
       name: (Required) Helper - Last Controller Event
       description: Input Text used to store the last event fired by the controller. You will need to manually create a text input entity for this, please read the blueprint Additional Notes for more info.
@@ -171,6 +186,7 @@ variables:
       click_double: [step_0_1_0, step_StepMode.Up_1_0_0_0]
       click_triple: [step_1_1_0, step_StepMode.Down_1_0_0_0]
     zigbee2mqtt:
+      # source: https://www.zigbee2mqtt.io/devices/E1744.html#ikea-e1744
       rotate_left: [brightness_move_down]
       rotate_stop: [brightness_stop]
       rotate_right: [brightness_move_up]
@@ -186,32 +202,56 @@ variables:
   click_double: '{{ actions_mapping[integration_id]["click_double"] }}'
   click_triple: '{{ actions_mapping[integration_id]["click_triple"] }}'
   # build data to send within a controller event
-  controller_entity: !input controller_entity
-  controller_device: !input controller_device
-  controller_id: '{% if integration_id=="zigbee2mqtt" %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
+  controller_id: !input controller_device
 mode: restart
 max_exceeded: silent
-trigger:
-  # trigger for zigbee2mqtt
-  - platform: event
-    event_type: state_changed
-    event_data:
-      entity_id: !input controller_entity
-  # trigger for other integrations
-  - platform: event
+triggers:
+  # triggers for zigbee2mqtt mqtt device action
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: brightness_move_down
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: brightness_stop
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: brightness_move_up
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: toggle
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: brightness_step_up
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: brightness_step_down
+  # triggers for other integrations
+  - trigger: event
     event_type:
       - deconz_event
       - zha_event
     event_data:
       device_id: !input controller_device
-condition:
+conditions:
   - condition: and
     conditions:
       # check that the button event is not empty
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" -%}
-        {{ trigger.event.data.new_state.state }}
+        {{ trigger.payload }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
@@ -219,10 +259,7 @@ condition:
         {%- endif -%}
         {%- endset -%}
         {{ trigger_action not in ["","None"] }}
-      # only for zigbee2mqtt, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
-      # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
-      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
-action:
+actions:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
   # if the delay expires and the automation is still running it means it's the last run and execution can continue
@@ -233,7 +270,7 @@ action:
   - variables:
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" -%}
-        {{ trigger.event.data.new_state.state }}
+        {{ trigger.payload }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
@@ -242,7 +279,7 @@ action:
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{\s*((\"a\":\s*\".*\"|\"t\":\s*\d+\.\d+)(,\s*)?){2}\s*\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
       last_controller_event: '{{ (states(helper_last_controller_event) | from_json).a if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{\s*((\"a\":\s*\".*\"|\"t\":\s*\d+\.\d+)(,\s*)?){2}\s*\}$")) else "" }}'
   # update helper
-  - service: input_text.set_value
+  - action: input_text.set_value
     data:
       entity_id: !input helper_last_controller_event
       value: '{{ {"a":trigger_action,"t":as_timestamp(now())} | to_json }}'

--- a/blueprints/controllers/ikea_e1766/ikea_e1766.yaml
+++ b/blueprints/controllers/ikea_e1766/ikea_e1766.yaml
@@ -11,13 +11,18 @@ blueprint:
     Hooks allow to easily create controller-based automations for interacting with media players, lights, covers and more.
     See the list of [Hooks available for this controller](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/controllers/ikea_e1766#available-hooks) for additional details.
 
+    ## More Info
+
+    ℹ️ Version 2025.01.23
+    📝 [Changelog](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/controllers/ikea_e1766/#changelog)
     📕 Full documentation regarding this blueprint is available [here](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/controllers/ikea_e1766).
 
-    🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
+    🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**. Please consider **[leaving a star on GitHub](https://github.com/EPMatt/awesome-ha-blueprints)**! 🌟
 
-    ℹ️ Version 2022.08.08
   source_url: https://github.com/EPMatt/awesome-ha-blueprints/blob/main/blueprints/controllers/ikea_e1766/ikea_e1766.yaml
   domain: automation
+  homeassistant:
+    min_version: 2024.10.0
   input:
     integration:
       name: (Required) Integration
@@ -29,18 +34,28 @@ blueprint:
             - ZHA
             - Zigbee2MQTT
     controller_device:
-      name: (deCONZ, ZHA) Controller Device
-      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.
+      name: (Required) (deCONZ, ZHA, Zigbee2MQTT) Controller Device
+      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
       selector:
         device:
-    controller_entity:
-      name: (Zigbee2MQTT) Controller Entity
-      description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
-      default: ''
-      selector:
-        entity:
-          domain: sensor
+          filter:
+            # source: https://www.zigbee2mqtt.io/devices/E1766.html#ikea-e1766
+            - integration: mqtt
+              manufacturer: IKEA
+              model: TRADFRI open/close remote
+            # For backwards compatability with z2m 1.x. model_id is added to end of model rather than a seperate attribute in z2m 2.x
+            - integration: mqtt
+              manufacturer: IKEA
+              model: TRADFRI open/close remote (E1766)
+            # source: https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+            - integration: zha
+              manufacturer: IKEA of Sweden
+              model: TRADFRI open/close remote
+            - integration: deconz
+              manufacturer: IKEA of Sweden
+              model: TRADFRI open/close remote
+          multiple: false
     helper_last_controller_event:
       name: (Required) Helper - Last Controller Event
       description: Input Text used to store the last event fired by the controller. You will need to manually create a text input entity for this, please read the blueprint Additional Notes for more info.
@@ -150,6 +165,7 @@ variables:
       button_down_short: [down_close]
       button_down_release: [stop]
     zigbee2mqtt:
+      # source: https://www.zigbee2mqtt.io/devices/E1766.html#ikea-e1766
       button_up_short: [open]
       button_up_release: [stop]
       button_down_short: [close]
@@ -163,32 +179,46 @@ variables:
   # integrations which need to store the previous press event to determine which button was released
   integrations_with_prev_event_storage: [zha, zigbee2mqtt]
   # build data to send within a controller event
-  controller_entity: !input controller_entity
-  controller_device: !input controller_device
-  controller_id: '{% if integration_id=="zigbee2mqtt" %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
+  controller_id: !input controller_device
 mode: restart
 max_exceeded: silent
-trigger:
-  # trigger for zigbee2mqtt
-  - platform: event
-    event_type: state_changed
-    event_data:
-      entity_id: !input controller_entity
-  # trigger for other integrations
-  - platform: event
+triggers:
+  # triggers for zigbee2mqtt mqtt device action
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: open
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: stop
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: close
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: stop
+  # triggers for other integrations
+  - trigger: event
     event_type:
       - deconz_event
       - zha_event
     event_data:
       device_id: !input controller_device
-condition:
+conditions:
   - condition: and
     conditions:
       # check that the button event is not empty
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" -%}
-        {{ trigger.event.data.new_state.state }}
+        {{ trigger.payload }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
@@ -196,10 +226,7 @@ condition:
         {%- endif -%}
         {%- endset -%}
         {{ trigger_action not in ["","None"] }}
-      # only for zigbee2mqtt, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
-      # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
-      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
-action:
+actions:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
   # if the delay expires and the automation is still running it means it's the last run and execution can continue
@@ -210,7 +237,7 @@ action:
   - variables:
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" -%}
-        {{ trigger.event.data.new_state.state }}
+        {{ trigger.payload }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
@@ -219,7 +246,7 @@ action:
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
       last_controller_event: '{{ (states(helper_last_controller_event) | from_json).a if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else "" }}'
   # update helper
-  - service: input_text.set_value
+  - action: input_text.set_value
     data:
       entity_id: !input helper_last_controller_event
       value: '{{ {"a":trigger_action,"t":as_timestamp(now())} | to_json }}'
@@ -236,7 +263,7 @@ action:
                       - conditions: '{{ trigger_action | string in states(helper_last_controller_event) and trigger_delta | int <= helper_double_press_delay | int }}'
                         sequence:
                           # store the double press event in the last controller event helper
-                          - service: input_text.set_value
+                          - action: input_text.set_value
                             data:
                               entity_id: !input helper_last_controller_event
                               value: '{{ {"a":"double_press","t":as_timestamp(now())} | to_json }}'
@@ -303,7 +330,7 @@ action:
                       - conditions: '{{ trigger_action | string in states(helper_last_controller_event) and trigger_delta | int <= helper_double_press_delay | int }}'
                         sequence:
                           # store the double press event in the last controller event helper
-                          - service: input_text.set_value
+                          - action: input_text.set_value
                             data:
                               entity_id: !input helper_last_controller_event
                               value: '{{ {"a":"double_press","t":as_timestamp(now())} | to_json }}'

--- a/blueprints/controllers/ikea_e1812/ikea_e1812.yaml
+++ b/blueprints/controllers/ikea_e1812/ikea_e1812.yaml
@@ -11,15 +11,18 @@ blueprint:
     Hooks allow to easily create controller-based automations for interacting with media players, lights, covers and more.
     See the list of [Hooks available for this controller](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/controllers/ikea_e1812#available-hooks) for additional details.
 
+    ## More Info
+
+    ℹ️ Version 2025.01.23
+    📝 [Changelog](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/controllers/ikea_e1812/#changelog)
     📕 Full documentation regarding this blueprint is available [here](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/controllers/ikea_e1812).
 
-    🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
+    🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**. Please consider **[leaving a star on GitHub](https://github.com/EPMatt/awesome-ha-blueprints)**! 🌟
 
-    ℹ️ Version 2025.01.03
   source_url: https://github.com/EPMatt/awesome-ha-blueprints/blob/main/blueprints/controllers/ikea_e1812/ikea_e1812.yaml
   domain: automation
   homeassistant:
-    min_version: 2023.5.0
+    min_version: 2024.10.0
   input:
     integration:
       name: (Required) Integration
@@ -31,18 +34,28 @@ blueprint:
             - ZHA
             - Zigbee2MQTT
     controller_device:
-      name: (deCONZ, ZHA) Controller Device
-      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.
+      name: (Required) (deCONZ, ZHA, Zigbee2MQTT) Controller Device
+      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
       selector:
         device:
-    controller_entity:
-      name: (Zigbee2MQTT) Controller Entity
-      description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
-      default: ''
-      selector:
-        entity:
-          domain: sensor
+          filter:
+            # source: https://www.zigbee2mqtt.io/devices/E1812.html#ikea-e1812
+            - integration: mqtt
+              manufacturer: IKEA
+              model: TRADFRI shortcut button
+            # For backwards compatability with z2m 1.x. model_id is added to end of model rather than a seperate attribute in z2m 2.x
+            - integration: mqtt
+              manufacturer: IKEA
+              model: TRADFRI shortcut button (E1812)
+            # source: https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+            - integration: zha
+              manufacturer: IKEA of Sweden
+              model: TRADFRI SHORTCUT Button
+            - integration: deconz
+              manufacturer: IKEA of Sweden
+              model: TRADFRI SHORTCUT Button
+          multiple: false
     helper_last_controller_event:
       name: (Required) Helper - Last Controller Event
       description: Input Text used to store the last event fired by the controller. You will need to manually create a text input entity for this, please read the blueprint Additional Notes for more info.
@@ -152,6 +165,7 @@ variables:
       button_long: [move_with_on_off_0_83]
       button_release: [stop]
     zigbee2mqtt:
+      # source: https://www.zigbee2mqtt.io/devices/E1812.html#ikea-e1812
       button_short: ['on']
       button_long: [brightness_move_up]
       button_release: [brightness_stop]
@@ -161,32 +175,41 @@ variables:
   button_long: '{{ actions_mapping[integration_id]["button_long"] }}'
   button_release: '{{ actions_mapping[integration_id]["button_release"] }}'
   # build data to send within a controller event
-  controller_entity: !input controller_entity
-  controller_device: !input controller_device
-  controller_id: '{% if integration_id=="zigbee2mqtt" %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
+  controller_id: !input controller_device
 mode: restart
 max_exceeded: silent
-trigger:
-  # trigger for zigbee2mqtt
-  - platform: event
-    event_type: state_changed
-    event_data:
-      entity_id: !input controller_entity
-  # trigger for other integrations
-  - platform: event
+triggers:
+  # triggers for zigbee2mqtt mqtt device action
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: 'on'
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: brightness_move_up
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: brightness_stop
+  # triggers for other integrations
+  - trigger: event
     event_type:
       - deconz_event
       - zha_event
     event_data:
       device_id: !input controller_device
-condition:
+conditions:
   - condition: and
     conditions:
       # check that the button event is not empty
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" -%}
-        {{ trigger.event.data.new_state.state }}
+        {{ trigger.payload }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
@@ -194,10 +217,7 @@ condition:
         {%- endif -%}
         {%- endset -%}
         {{ trigger_action not in ["","None"] }}
-      # only for zigbee2mqtt, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
-      # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
-      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
-action:
+actions:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
   # if the delay expires and the automation is still running it means it's the last run and execution can continue
@@ -208,7 +228,7 @@ action:
   - variables:
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" -%}
-        {{ trigger.event.data.new_state.state }}
+        {{ trigger.payload }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
@@ -216,7 +236,7 @@ action:
         {%- endif -%}
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\":\".*\"|\"t\":\d+\.\d+)(,)?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
   # update helper
-  - service: input_text.set_value
+  - action: input_text.set_value
     data:
       entity_id: !input helper_last_controller_event
       value: '{{ {"a":trigger_action,"t":as_timestamp(now())} | to_json }}'
@@ -233,7 +253,7 @@ action:
                       - conditions: '{{ trigger_action | string in states(helper_last_controller_event) and trigger_delta | int <= helper_double_press_delay | int }}'
                         sequence:
                           # store the double press event in the last controller event helper
-                          - service: input_text.set_value
+                          - action: input_text.set_value
                             data:
                               entity_id: !input helper_last_controller_event
                               value: '{{ {"a":"double_press","t":as_timestamp(now())} | to_json }}'

--- a/blueprints/controllers/ikea_e2001_e2002/ikea_e2001_e2002.yaml
+++ b/blueprints/controllers/ikea_e2001_e2002/ikea_e2001_e2002.yaml
@@ -11,15 +11,18 @@ blueprint:
     Hooks allow to easily create controller-based automations for interacting with media players, lights, covers and more.
     See the list of [Hooks available for this controller](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/controllers/ikea_e2001_e2002#available-hooks) for additional details.
 
+    ## More Info
+
+    ℹ️ Version 2025.01.23
+    📝 [Changelog](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/controllers/ikea_e2001_e2002/#changelog)
     📕 Full documentation regarding this blueprint is available [here](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/controllers/ikea_e2001_e2002).
 
-    🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
+    🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**. Please consider **[leaving a star on GitHub](https://github.com/EPMatt/awesome-ha-blueprints)**! 🌟
 
-    ℹ️ Version 2025.01.03
   source_url: https://github.com/EPMatt/awesome-ha-blueprints/blob/main/blueprints/controllers/ikea_e2001_e2002/ikea_e2001_e2002.yaml
   domain: automation
   homeassistant:
-    min_version: 2023.5.0
+    min_version: 2024.10.0
   input:
     integration:
       name: (Required) Integration
@@ -31,18 +34,28 @@ blueprint:
             - ZHA
             - Zigbee2MQTT
     controller_device:
-      name: (deCONZ, ZHA) Controller Device
-      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.
+      name: (Required) (deCONZ, ZHA, Zigbee2MQTT) Controller Device
+      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
       selector:
         device:
-    controller_entity:
-      name: (Zigbee2MQTT) Controller Entity
-      description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
-      default: ''
-      selector:
-        entity:
-          domain: sensor
+          filter:
+            # source: https://www.zigbee2mqtt.io/devices/E2001_E2002.html#ikea-e2001-e2002
+            - integration: mqtt
+              manufacturer: IKEA
+              model: STYRBAR remote control
+            # For backwards compatability with z2m 1.x. model_id is added to end of model rather than a seperate attribute in z2m 2.x
+            - integration: mqtt
+              manufacturer: IKEA
+              model: STYRBAR remote control (E2001/E2002)
+            # source: https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+            - integration: zha
+              manufacturer: IKEA of Sweden
+              model: Remote Control N2
+            - integration: deconz
+              manufacturer: IKEA of Sweden
+              model: Remote Control N2
+          multiple: false
     helper_last_controller_event:
       name: (Required) Helper - Last Controller Event
       description: Input Text used to store the last event fired by the controller. You will need to manually create a text input entity for this, please read the blueprint Additional Notes for more info.
@@ -325,6 +338,7 @@ variables:
       # Kept first parameter for potential backwards compatibility of previous firmware versions
       button_down_release: [stop, stop_with_on_off]
     zigbee2mqtt:
+      # source: https://www.zigbee2mqtt.io/devices/E2001_E2002.html#ikea-e2001-e2002
       button_left_short: [arrow_left_click]
       button_left_long: [arrow_left_hold]
       button_left_release: [arrow_left_release]
@@ -354,32 +368,81 @@ variables:
   # integrations which need to store the previous press event to determine which button was released
   integrations_with_prev_event_storage: [zha, zigbee2mqtt]
   # build data to send within a controller event
-  controller_entity: !input controller_entity
-  controller_device: !input controller_device
-  controller_id: '{% if integration_id=="zigbee2mqtt" %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
+  controller_id: !input controller_device
 mode: restart
 max_exceeded: silent
-trigger:
-  # trigger for zigbee2mqtt
-  - platform: event
-    event_type: state_changed
-    event_data:
-      entity_id: !input controller_entity
-  # trigger for other integrations
-  - platform: event
+triggers:
+  # triggers for zigbee2mqtt mqtt device action
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: arrow_left_click
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: arrow_left_hold
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: arrow_left_release
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: arrow_right_click
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: arrow_right_hold
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: arrow_right_release
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: 'on'
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: brightness_move_up
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: brightness_stop
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: 'off'
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: brightness_move_down
+  # triggers for other integrations
+  - trigger: event
     event_type:
       - deconz_event
       - zha_event
     event_data:
       device_id: !input controller_device
-condition:
+conditions:
   - condition: and
     conditions:
       # check that the button event is not empty
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" -%}
-        {{ trigger.event.data.new_state.state }}
+        {{ trigger.payload }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
@@ -387,10 +450,7 @@ condition:
         {%- endif -%}
         {%- endset -%}
         {{ trigger_action not in ["","None","unknown"] }}
-      # only for zigbee2mqtt, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
-      # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
-      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
-action:
+actions:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
   # if the delay expires and the automation is still running it means it's the last run and execution can continue
@@ -401,7 +461,7 @@ action:
   - variables:
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" -%}
-        {{ trigger.event.data.new_state.state }}
+        {{ trigger.payload }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
@@ -410,7 +470,7 @@ action:
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\":\".*\"|\"t\":\d+\.\d+)(,)?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
       last_controller_event: '{{ (states(helper_last_controller_event) | from_json).a if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\":\".*\"|\"t\":\d+\.\d+)(,)?){2}\}$")) else "" }}'
   # update helper
-  - service: input_text.set_value
+  - action: input_text.set_value
     data:
       entity_id: !input helper_last_controller_event
       value: '{{ {"a":trigger_action,"t":as_timestamp(now())} | to_json }}'
@@ -427,7 +487,7 @@ action:
                       - conditions: '{{ trigger_action | string in states(helper_last_controller_event) and trigger_delta | int <= helper_double_press_delay | int }}'
                         sequence:
                           # store the double press event in the last controller event helper
-                          - service: input_text.set_value
+                          - action: input_text.set_value
                             data:
                               entity_id: !input helper_last_controller_event
                               value: '{{ {"a":"double_press","t":as_timestamp(now())} | to_json }}'
@@ -511,7 +571,7 @@ action:
                       - conditions: '{{ trigger_action | string in states(helper_last_controller_event) and trigger_delta | int <= helper_double_press_delay | int }}'
                         sequence:
                           # store the double press event in the last controller event helper
-                          - service: input_text.set_value
+                          - action: input_text.set_value
                             data:
                               entity_id: !input helper_last_controller_event
                               value: '{{ {"a":"double_press","t":as_timestamp(now())} | to_json }}'
@@ -595,7 +655,7 @@ action:
                       - conditions: '{{ trigger_action | string in states(helper_last_controller_event) and trigger_delta | int <= helper_double_press_delay | int }}'
                         sequence:
                           # store the double press event in the last controller event helper
-                          - service: input_text.set_value
+                          - action: input_text.set_value
                             data:
                               entity_id: !input helper_last_controller_event
                               value: '{{ {"a":"double_press","t":as_timestamp(now())} | to_json }}'
@@ -678,7 +738,7 @@ action:
                       - conditions: '{{ trigger_action | string in states(helper_last_controller_event) and trigger_delta | int <= helper_double_press_delay | int }}'
                         sequence:
                           # store the double press event in the last controller event helper
-                          - service: input_text.set_value
+                          - action: input_text.set_value
                             data:
                               entity_id: !input helper_last_controller_event
                               value: '{{ {"a":"double_press","t":as_timestamp(now())} | to_json }}'

--- a/blueprints/controllers/ikea_ictc_g_1/ikea_ictc_g_1.yaml
+++ b/blueprints/controllers/ikea_ictc_g_1/ikea_ictc_g_1.yaml
@@ -11,13 +11,18 @@ blueprint:
     Hooks allow to easily create controller-based automations for interacting with media players, lights, covers and more.
     See the list of [Hooks available for this controller](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/controllers/ikea_ictc_g_1#available-hooks) for additional details.
 
+    ## More Info
+
+    ℹ️ Version 2025.01.23
+    📝 [Changelog](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/controllers/ikea_ictc_g_1/#changelog)
     📕 Full documentation regarding this blueprint is available [here](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/controllers/ikea_ictc_g_1).
 
-    🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
+    🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**. Please consider **[leaving a star on GitHub](https://github.com/EPMatt/awesome-ha-blueprints)**! 🌟
 
-    ℹ️ Version 2022.08.08
   source_url: https://github.com/EPMatt/awesome-ha-blueprints/blob/main/blueprints/controllers/ikea_ictc_g_1/ikea_ictc_g_1.yaml
   domain: automation
+  homeassistant:
+    min_version: 2024.10.0
   input:
     integration:
       name: (Required) Integration
@@ -29,18 +34,27 @@ blueprint:
             - ZHA
             - Zigbee2MQTT
     controller_device:
-      name: (deCONZ, ZHA) Controller Device
-      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.
+      name: (Required) (deCONZ, ZHA, Zigbee2MQTT) Controller Device
+      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
       selector:
         device:
-    controller_entity:
-      name: (Zigbee2MQTT) Controller Entity
-      description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
-      default: ''
-      selector:
-        entity:
-          domain: sensor
+          filter:
+            # source: https://www.zigbee2mqtt.io/devices/ICTC-G-1.html#ikea-ictc-g-1
+            - integration: mqtt
+              manufacturer: IKEA
+              model: TRADFRI wireless dimmer
+            # For backwards compatability with z2m 1.x. model_id is added to end of model rather than a seperate attribute in z2m 2.x
+            - integration: mqtt
+              manufacturer: IKEA
+              model: TRADFRI wireless dimmer (ICTC-G-1)
+            # source: https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+            - integration: zha
+              manufacturer: IKEA of Sweden
+              model: TRADFRI wireless dimmer
+            - integration: deconz
+              model: TRADFRI wireless dimmer
+          multiple: false
     helper_last_controller_event:
       name: (Required) Helper - Last Controller Event
       description: Input Text used to store the last event fired by the controller. You will need to manually create a text input entity for this, please read the blueprint Additional Notes for more info.
@@ -147,6 +161,7 @@ variables:
       rotate_stop: [stop]
       rotate_right: [move_with_on_off_0_70, move_with_on_off_0_195]
     zigbee2mqtt:
+      # source: https://www.zigbee2mqtt.io/devices/ICTC-G-1.html#ikea-ictc-g-1
       rotate_left: [brightness_move_down]
       rotate_stop: [brightness_stop]
       rotate_right: [brightness_move_up]
@@ -156,32 +171,41 @@ variables:
   rotate_stop: '{{ actions_mapping[integration_id]["rotate_stop"] }}'
   rotate_right: '{{ actions_mapping[integration_id]["rotate_right"] }}'
   # build data to send within a controller event
-  controller_entity: !input controller_entity
-  controller_device: !input controller_device
-  controller_id: '{% if integration_id=="zigbee2mqtt" %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
+  controller_id: !input controller_device
 mode: restart
 max_exceeded: silent
-trigger:
-  # trigger for zigbee2mqtt
-  - platform: event
-    event_type: state_changed
-    event_data:
-      entity_id: !input controller_entity
-  # trigger for other integrations
-  - platform: event
+triggers:
+  # triggers for zigbee2mqtt mqtt device action
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: brightness_move_down
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: brightness_stop
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: brightness_move_up
+  # triggers for other integrations
+  - trigger: event
     event_type:
       - deconz_event
       - zha_event
     event_data:
       device_id: !input controller_device
-condition:
+conditions:
   - condition: and
     conditions:
       # check that the button event is not empty
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" -%}
-        {{ trigger.event.data.new_state.state }}
+        {{ trigger.payload }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
@@ -189,10 +213,7 @@ condition:
         {%- endif -%}
         {%- endset -%}
         {{ trigger_action not in ["","None"] }}
-      # only for zigbee2mqtt, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
-      # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
-      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
-action:
+actions:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
   # if the delay expires and the automation is still running it means it's the last run and execution can continue
@@ -203,7 +224,7 @@ action:
   - variables:
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" -%}
-        {{ trigger.event.data.new_state.state }}
+        {{ trigger.payload }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
@@ -212,7 +233,7 @@ action:
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
       last_controller_event: '{{ (states(helper_last_controller_event) | from_json).a if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else "" }}'
   # update helper
-  - service: input_text.set_value
+  - action: input_text.set_value
     data:
       entity_id: !input helper_last_controller_event
       value: '{{ {"a":trigger_action,"t":as_timestamp(now())} | to_json }}'

--- a/blueprints/controllers/osram_ac025xx00nj/osram_ac025xx00nj.yaml
+++ b/blueprints/controllers/osram_ac025xx00nj/osram_ac025xx00nj.yaml
@@ -11,15 +11,18 @@ blueprint:
     Hooks allow to easily create controller-based automations for interacting with media players, lights, covers and more.
     See the list of [Hooks available for this controller](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/controllers/osram_ac025xx00nj#available-hooks) for additional details.
 
+    ## More Info
+
+    ℹ️ Version 2025.01.23
+    📝 [Changelog](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/controllers/osram_ac025xx00nj/#changelog)
     📕 Full documentation regarding this blueprint is available [here](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/controllers/osram_ac025xx00nj).
 
-    🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
+    🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**. Please consider **[leaving a star on GitHub](https://github.com/EPMatt/awesome-ha-blueprints)**! 🌟
 
-    ℹ️ Version 2025.01.05
   source_url: https://github.com/EPMatt/awesome-ha-blueprints/blob/main/blueprints/controllers/osram_ac025xx00nj/osram_ac025xx00nj.yaml
   domain: automation
   homeassistant:
-    min_version: 2023.5.0
+    min_version: 2024.10.0
   input:
     integration:
       name: (Required) Integration
@@ -31,18 +34,28 @@ blueprint:
             - ZHA
             - Zigbee2MQTT
     controller_device:
-      name: (deCONZ, ZHA) Controller Device
-      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.
+      name: (Required) (deCONZ, ZHA, Zigbee2MQTT) Controller Device
+      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
       selector:
         device:
-    controller_entity:
-      name: (Zigbee2MQTT) Controller Entity
-      description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
-      default: ''
-      selector:
-        entity:
-          domain: sensor
+          filter:
+            # source: https://www.zigbee2mqtt.io/devices/AC0251100NJ_AC0251600NJ_AC0251700NJ.html#osram-ac0251100nj-ac0251600nj-ac0251700nj
+            - integration: mqtt
+              manufacturer: OSRAM
+              model: Smart+ switch mini
+            # For backwards compatability with z2m 1.x. model_id is added to end of model rather than a seperate attribute in z2m 2.x
+            - integration: mqtt
+              manufacturer: OSRAM
+              model: Smart+ switch mini (AC0251100NJ/AC0251600NJ/AC0251700NJ)
+            # source: https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+            - integration: zha
+            # **TBConfirmed** manufacturer: OSRAM
+            # **TBConfirmed** model: Lightify Switch Mini
+            - integration: deconz
+            # **TBConfirmed** manufacturer: OSRAM
+            # **TBConfirmed** model: Lightify Switch Mini
+          multiple: false
     helper_last_controller_event:
       name: (Required) Helper - Last Controller Event
       description: Input Text used to store the last event fired by the controller. You will need to manually create a text input entity for this, please read the blueprint Additional Notes for more info.
@@ -288,32 +301,76 @@ variables:
   button_down_long: '{{ actions_mapping[integration_id]["button_down_long"] }}'
   button_down_release: '{{ actions_mapping[integration_id]["button_down_release"] }}'
   # build data to send within a controller event
-  controller_entity: !input controller_entity
-  controller_device: !input controller_device
-  controller_id: '{% if integration_id=="zigbee2mqtt" %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
+  controller_id: !input controller_device
 mode: restart
 max_exceeded: silent
-trigger:
-  # trigger for zigbee2mqtt
-  - platform: event
-    event_type: state_changed
-    event_data:
-      entity_id: !input controller_entity
-  # trigger for other integrations
-  - platform: event
+triggers:
+  # triggers for zigbee2mqtt mqtt device action
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: 'on'
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: brightness_move_up
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: brightness_stop
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: brightness_move_to_level
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: move_to_saturation
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: hue_stop
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: down
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: 'off'
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: brightness_move_down
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: brightness_stop
+  # triggers for other integrations
+  - trigger: event
     event_type:
       - deconz_event
       - zha_event
     event_data:
       device_id: !input controller_device
-condition:
+conditions:
   - condition: and
     conditions:
       # check that the button event is not empty
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" -%}
-        {{ trigger.event.data.new_state.state }}
+        {{ trigger.payload }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
@@ -321,10 +378,7 @@ condition:
         {%- endif -%}
         {%- endset -%}
         {{ trigger_action not in ["","None"] }}
-      # only for zigbee2mqtt, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
-      # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
-      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
-action:
+actions:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
   # if the delay expires and the automation is still running it means it's the last run and execution can continue
@@ -335,7 +389,7 @@ action:
   - variables:
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" -%}
-        {{ trigger.event.data.new_state.state }}
+        {{ trigger.payload }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
@@ -343,7 +397,7 @@ action:
         {%- endif -%}
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\":\".*\"|\"t\":\d+\.\d+)(,)?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
   # update helper
-  - service: input_text.set_value
+  - action: input_text.set_value
     data:
       entity_id: !input helper_last_controller_event
       value: '{{ {"a":trigger_action,"t":as_timestamp(now())} | to_json }}'
@@ -360,7 +414,7 @@ action:
                       - conditions: '{{ trigger_action | string in states(helper_last_controller_event) and trigger_delta | int <= helper_double_press_delay | int }}'
                         sequence:
                           # store the double press event in the last controller event helper
-                          - service: input_text.set_value
+                          - action: input_text.set_value
                             data:
                               entity_id: !input helper_last_controller_event
                               value: '{{ {"a":"double_press","t":as_timestamp(now())} | to_json }}'
@@ -440,7 +494,7 @@ action:
                       - conditions: '{{ trigger_action | string in states(helper_last_controller_event) and trigger_delta | int <= helper_double_press_delay | int }}'
                         sequence:
                           # store the double press event in the last controller event helper
-                          - service: input_text.set_value
+                          - action: input_text.set_value
                             data:
                               entity_id: !input helper_last_controller_event
                               value: '{{ {"a":"double_press","t":as_timestamp(now())} | to_json }}'
@@ -520,7 +574,7 @@ action:
                       - conditions: '{{ trigger_action | string in states(helper_last_controller_event) and trigger_delta | int <= helper_double_press_delay | int }}'
                         sequence:
                           # store the double press event in the last controller event helper
-                          - service: input_text.set_value
+                          - action: input_text.set_value
                             data:
                               entity_id: !input helper_last_controller_event
                               value: '{{ {"a":"double_press","t":as_timestamp(now())} | to_json }}'

--- a/blueprints/controllers/philips_324131092621/philips_324131092621.yaml
+++ b/blueprints/controllers/philips_324131092621/philips_324131092621.yaml
@@ -11,13 +11,18 @@ blueprint:
     Hooks allow to easily create controller-based automations for interacting with media players, lights, covers and more.
     See the list of [Hooks available for this controller](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/controllers/philips_324131092621#available-hooks) for additional details.
 
+    ## More Info
+
+    ℹ️ Version 2025.01.23
+    📝 [Changelog](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/controllers/philips_324131092621/#changelog)
     📕 Full documentation regarding this blueprint is available [here](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/controllers/philips_324131092621).
 
-    🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
+    🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**. Please consider **[leaving a star on GitHub](https://github.com/EPMatt/awesome-ha-blueprints)**! 🌟
 
-    ℹ️ Version 2022.08.08
   source_url: https://github.com/EPMatt/awesome-ha-blueprints/blob/main/blueprints/controllers/philips_324131092621/philips_324131092621.yaml
   domain: automation
+  homeassistant:
+    min_version: 2024.10.0
   input:
     integration:
       name: (Required) Integration
@@ -29,18 +34,29 @@ blueprint:
             - ZHA
             - Zigbee2MQTT
     controller_device:
-      name: (deCONZ, ZHA) Controller Device
-      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.
+      name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
+      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
       selector:
         device:
-    controller_entity:
-      name: (Zigbee2MQTT) Controller Entity
-      description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
-      default: ''
-      selector:
-        entity:
-          domain: sensor
+          filter:
+            # source: https://www.zigbee2mqtt.io/devices/324131092621.html#philips-324131092621
+            - integration: mqtt
+              manufacturer: Philips
+              model: Hue dimmer switch
+              model_id: 324131092621
+            # For backwards compatability with z2m 1.x. model_id is added to end of model rather than a seperate attribute in z2m 2.x
+            - integration: mqtt
+              manufacturer: Philips
+              model: Hue dimmer switch (324131092621)
+            # source: https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+            - integration: zha
+              manufacturer: Philips
+              # TBConfirmed** model:
+            - integration: deconz
+              manufacturer: Philips
+              # TBConfirmed** model:
+          multiple: false
     helper_last_controller_event:
       name: (Required) Helper - Last Controller Event
       description: Input Text used to store the last event fired by the controller. You will need to manually create a text input entity for this, please read the blueprint Additional Notes for more info.
@@ -321,6 +337,7 @@ variables:
       button_down_long: [down_hold]
       button_down_release: [down_long_release]
     zigbee2mqtt:
+      # source: https://www.zigbee2mqtt.io/devices/324131092621.html#philips-324131092621
       button_on_short: [on-press]
       button_on_long: [on-hold]
       button_on_release: [on-hold-release]
@@ -348,32 +365,86 @@ variables:
   button_down_long: '{{ actions_mapping[integration_id]["button_down_long"] }}'
   button_down_release: '{{ actions_mapping[integration_id]["button_down_release"] }}'
   # build data to send within a controller event
-  controller_entity: !input controller_entity
-  controller_device: !input controller_device
-  controller_id: '{% if integration_id=="zigbee2mqtt" %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
+  controller_id: !input controller_device
 mode: restart
 max_exceeded: silent
-trigger:
-  # trigger for zigbee2mqtt
-  - platform: event
-    event_type: state_changed
-    event_data:
-      entity_id: !input controller_entity
-  # trigger for other integrations
-  - platform: event
+triggers:
+  # triggers for zigbee2mqtt mqtt device action
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: on_press
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: on_hold
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: on_hold_release
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: off_press
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: off_hold
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: off_hold_release
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: up_press
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: up_hold
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: up_hold_release
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: down_press
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: down_hold
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: down_hold_release
+  # triggers for other integrations
+  - trigger: event
     event_type:
       - deconz_event
       - zha_event
     event_data:
       device_id: !input controller_device
-condition:
+conditions:
   - condition: and
     conditions:
       # check that the button event is not empty
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" -%}
-        {{ trigger.event.data.new_state.state }}
+        {{ trigger.payload }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
@@ -381,10 +452,7 @@ condition:
         {%- endif -%}
         {%- endset -%}
         {{ trigger_action not in ["","None"] }}
-      # only for zigbee2mqtt, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
-      # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
-      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
-action:
+actions:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
   # if the delay expires and the automation is still running it means it's the last run and execution can continue
@@ -395,7 +463,7 @@ action:
   - variables:
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" -%}
-        {{ trigger.event.data.new_state.state }}
+        {{ trigger.payload }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
@@ -403,7 +471,7 @@ action:
         {%- endif -%}
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
   # update helper
-  - service: input_text.set_value
+  - action: input_text.set_value
     data:
       entity_id: !input helper_last_controller_event
       value: '{{ {"a":trigger_action,"t":as_timestamp(now())} | to_json }}'
@@ -420,7 +488,7 @@ action:
                       - conditions: '{{ trigger_action | string in states(helper_last_controller_event) and trigger_delta | int <= helper_double_press_delay | int }}'
                         sequence:
                           # store the double press event in the last controller event helper
-                          - service: input_text.set_value
+                          - action: input_text.set_value
                             data:
                               entity_id: !input helper_last_controller_event
                               value: '{{ {"a":"double_press","t":as_timestamp(now())} | to_json }}'
@@ -500,7 +568,7 @@ action:
                       - conditions: '{{ trigger_action | string in states(helper_last_controller_event) and trigger_delta | int <= helper_double_press_delay | int }}'
                         sequence:
                           # store the double press event in the last controller event helper
-                          - service: input_text.set_value
+                          - action: input_text.set_value
                             data:
                               entity_id: !input helper_last_controller_event
                               value: '{{ {"a":"double_press","t":as_timestamp(now())} | to_json }}'
@@ -580,7 +648,7 @@ action:
                       - conditions: '{{ trigger_action | string in states(helper_last_controller_event) and trigger_delta | int <= helper_double_press_delay | int }}'
                         sequence:
                           # store the double press event in the last controller event helper
-                          - service: input_text.set_value
+                          - action: input_text.set_value
                             data:
                               entity_id: !input helper_last_controller_event
                               value: '{{ {"a":"double_press","t":as_timestamp(now())} | to_json }}'
@@ -660,7 +728,7 @@ action:
                       - conditions: '{{ trigger_action | string in states(helper_last_controller_event) and trigger_delta | int <= helper_double_press_delay | int }}'
                         sequence:
                           # store the double press event in the last controller event helper
-                          - service: input_text.set_value
+                          - action: input_text.set_value
                             data:
                               entity_id: !input helper_last_controller_event
                               value: '{{ {"a":"double_press","t":as_timestamp(now())} | to_json }}'

--- a/blueprints/controllers/philips_8718699693985/philips_8718699693985.yaml
+++ b/blueprints/controllers/philips_8718699693985/philips_8718699693985.yaml
@@ -11,15 +11,18 @@ blueprint:
     Hooks allow to easily create controller-based automations for interacting with media players, lights, covers and more.
     See the list of [Hooks available for this controller](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/controllers/philips_8718699693985#available-hooks) for additional details.
 
+    ## More Info
+
+    ℹ️ Version 2025.01.23
+    📝 [Changelog](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/controllers/philips_8718699693985/#changelog)
     📕 Full documentation regarding this blueprint is available [here](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/controllers/philips_8718699693985).
 
-    🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
+    🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**. Please consider **[leaving a star on GitHub](https://github.com/EPMatt/awesome-ha-blueprints)**! 🌟
 
-    ℹ️ Version 2025.01.05
   source_url: https://github.com/EPMatt/awesome-ha-blueprints/blob/main/blueprints/controllers/philips_8718699693985/philips_8718699693985.yaml
   domain: automation
   homeassistant:
-    min_version: 2023.5.0
+    min_version: 2024.10.0
   input:
     integration:
       name: (Required) Integration
@@ -31,18 +34,28 @@ blueprint:
             - ZHA
             - Zigbee2MQTT
     controller_device:
-      name: (deCONZ, ZHA) Controller Device
-      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.
+      name: (Required)(deCONZ, ZHA, Zigbee2MQTT) Controller Device
+      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
       selector:
         device:
-    controller_entity:
-      name: (Zigbee2MQTT) Controller Entity
-      description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
-      default: ''
-      selector:
-        entity:
-          domain: sensor
+          filter:
+            # source: https://www.zigbee2mqtt.io/devices/8718699693985.html#philips-8718699693985
+            - integration: mqtt
+              manufacturer: Philips
+              model: Hue smart button
+            # For backwards compatability with z2m 1.x. model_id is added to end of model rather than a seperate attribute in z2m 2.x
+            - integration: mqtt
+              manufacturer: Philips
+              model: Hue smart button (8718699693985)
+            # source: https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+            - integration: zha
+              manufacturer: Philips
+              # **TBConfirmed** model:
+            - integration: deconz
+              manufacturer: Philips
+              # **TBConfirmed** model:
+          multiple: false
     helper_last_controller_event:
       name: (Required) Helper - Last Controller Event
       description: Input Text used to store the last event fired by the controller. You will need to manually create a text input entity for this, please read the blueprint Additional Notes for more info.
@@ -162,30 +175,49 @@ variables:
   button_long: '{{ actions_mapping[integration_id]["button_long"] }}'
   button_release: '{{ actions_mapping[integration_id]["button_release"] }}'
   # build data to send within a controller event
-  controller_entity: !input controller_entity
-  controller_device: !input controller_device
-  controller_id: '{% if integration_id=="zigbee2mqtt" %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
+  controller_id: !input controller_device
 mode: restart
 max_exceeded: silent
-trigger:
-  # trigger for zigbee2mqtt
-  - platform: event
-    event_type: state_changed
-    event_data:
-      entity_id: !input controller_entity
-  # trigger for other integrations
-  - platform: event
+triggers:
+  # triggers for zigbee2mqtt mqtt device action
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: 'on'
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: 'off'
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: press
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: hold
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: release
+  # triggers for other integrations
+  - trigger: event
     event_type:
       - deconz_event
       - zha_event
     event_data:
       device_id: !input controller_device
-condition:
+conditions:
   # check that the button event is not empty
   - >-
     {%- set trigger_action -%}
     {%- if integration_id == "zigbee2mqtt" -%}
-    {{ trigger.event.data.new_state.state }}
+    {{ trigger.payload }}
     {%- elif integration_id == "deconz" -%}
     {{ trigger.event.data.event }}
     {%- elif integration_id == "zha" -%}
@@ -193,11 +225,7 @@ condition:
     {%- endif -%}
     {%- endset -%}
     {{ trigger_action not in ["","None"] }}
-  # only for zigbee2mqtt, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
-  # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
-  - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
-
-action:
+actions:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
   # if the delay expires and the automation is still running it means it's the last run and execution can continue
@@ -208,7 +236,7 @@ action:
   - variables:
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" -%}
-        {{ trigger.event.data.new_state.state }}
+        {{ trigger.payload }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
@@ -216,7 +244,7 @@ action:
         {%- endif -%}
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\":\".*\"|\"t\":\d+\.\d+)(,)?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
   # update helper
-  - service: input_text.set_value
+  - action: input_text.set_value
     data:
       entity_id: !input helper_last_controller_event
       value: '{{ {"a":trigger_action,"t":as_timestamp(now())} | to_json }}'
@@ -233,7 +261,7 @@ action:
                       - conditions: '{{ trigger_action | string in states(helper_last_controller_event) and trigger_delta | int <= helper_double_press_delay | int }}'
                         sequence:
                           # store the double press event in the last controller event helper
-                          - service: input_text.set_value
+                          - action: input_text.set_value
                             data:
                               entity_id: !input helper_last_controller_event
                               value: '{{ {"a":"double_press","t":as_timestamp(now())} | to_json }}'

--- a/blueprints/controllers/philips_929002398602/philips_929002398602.yaml
+++ b/blueprints/controllers/philips_929002398602/philips_929002398602.yaml
@@ -11,13 +11,18 @@ blueprint:
     Hooks allow to easily create controller-based automations for interacting with media players, lights, covers and more.
     See the list of [Hooks available for this controller](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/controllers/philips_929002398602#available-hooks) for additional details.
 
+    ## More Info
+
+    ℹ️ Version 2025.01.23
+    📝 [Changelog](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/controllers/philips_929002398602/#changelog)
     📕 Full documentation regarding this blueprint is available [here](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/controllers/philips_929002398602).
 
-    🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
+    🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**. Please consider **[leaving a star on GitHub](https://github.com/EPMatt/awesome-ha-blueprints)**! 🌟
 
-    ℹ️ Version 2022.08.08
   source_url: https://github.com/EPMatt/awesome-ha-blueprints/blob/main/blueprints/controllers/philips_929002398602/philips_929002398602.yaml
   domain: automation
+  homeassistant:
+    min_version: 2024.10.0
   input:
     integration:
       name: (Required) Integration
@@ -28,18 +33,28 @@ blueprint:
             - ZHA
             - Zigbee2MQTT
     controller_device:
-      name: (ZHA) Controller Device
-      description: The controller device to use for the automation. Choose a value only if the remote is integrated with ZHA.
+      name: (Required) (ZHA, Zigbee2MQTT) Controller Device
+      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
       selector:
         device:
-    controller_entity:
-      name: (Zigbee2MQTT) Controller Entity
-      description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
-      default: ''
-      selector:
-        entity:
-          domain: sensor
+          filter:
+            # source: https://www.zigbee2mqtt.io/devices/929002398602.html#philips-929002398602
+            - integration: mqtt
+              manufacturer: Philips
+              model: Hue dimmer switch
+            # For backwards compatability with z2m 1.x. model_id is added to end of model rather than a seperate attribute in z2m 2.x
+            - integration: mqtt
+              manufacturer: Philips
+              model: Hue dimmer switch (929002398602)
+            # source: https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+            - integration: zha
+              manufacturer: Philips
+              # **TBConfirmed** model:
+            - integration: deconz
+              manufacturer: Philips
+              # **TBConfirmed** model:
+          multiple: false
     helper_last_controller_event:
       name: (Required) Helper - Last Controller Event
       description: Input Text used to store the last event fired by the controller. You will need to manually create a text input entity for this, please read the blueprint Additional Notes for more info.
@@ -307,6 +322,7 @@ variables:
       button_down_long: [down_hold]
       button_down_release: [down_long_release]
     zigbee2mqtt:
+      # source: https://www.zigbee2mqtt.io/devices/929002398602.html#philips-929002398602
       button_on_short: [on_press, on_press_release]
       button_on_long: [on_hold]
       button_on_release: [on_hold_release]
@@ -334,31 +350,95 @@ variables:
   button_down_long: '{{ actions_mapping[integration_id]["button_down_long"] }}'
   button_down_release: '{{ actions_mapping[integration_id]["button_down_release"] }}'
   # build data to send within a controller event
-  controller_entity: !input controller_entity
-  controller_device: !input controller_device
-  controller_id: '{% if integration_id=="zigbee2mqtt" %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
+  controller_id: !input controller_device
 mode: restart
 max_exceeded: silent
-trigger:
-  # trigger for zigbee2mqtt
-  - platform: event
-    event_type: state_changed
-    event_data:
-      entity_id: !input controller_entity
-  # trigger for other integrations
-  - platform: event
+triggers:
+  # triggers for zigbee2mqtt mqtt device action
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: on_press
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: on_press_release
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: on_hold
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: on_hold_release
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: off_press
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: off_press_release
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: off_hold
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: off_hold_release
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: up_press
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: up_hold
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: up_hold_release
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: down_press
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: down_hold
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: down_hold_release
+  # triggers for other integrations
+  - trigger: event
     event_type:
       - zha_event
     event_data:
       device_id: !input controller_device
-condition:
+conditions:
   - condition: and
     conditions:
       # check that the button event is not empty
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" -%}
-        {{ trigger.event.data.new_state.state }}
+        {{ trigger.payload }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
@@ -366,10 +446,7 @@ condition:
         {%- endif -%}
         {%- endset -%}
         {{ trigger_action not in ["","None"] }}
-      # only for zigbee2mqtt, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
-      # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
-      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
-action:
+actions:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
   # if the delay expires and the automation is still running it means it's the last run and execution can continue
@@ -380,7 +457,7 @@ action:
   - variables:
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" -%}
-        {{ trigger.event.data.new_state.state }}
+        {{ trigger.payload }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
@@ -388,7 +465,7 @@ action:
         {%- endif -%}
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
   # update helper
-  - service: input_text.set_value
+  - action: input_text.set_value
     data:
       entity_id: !input helper_last_controller_event
       value: '{{ {"a":trigger_action,"t":as_timestamp(now())} | to_json }}'
@@ -405,7 +482,7 @@ action:
                       - conditions: '{{ trigger_action | string in states(helper_last_controller_event) and trigger_delta | int <= helper_double_press_delay | int }}'
                         sequence:
                           # store the double press event in the last controller event helper
-                          - service: input_text.set_value
+                          - action: input_text.set_value
                             data:
                               entity_id: !input helper_last_controller_event
                               value: '{{ {"a":"double_press","t":as_timestamp(now())} | to_json }}'
@@ -485,7 +562,7 @@ action:
                       - conditions: '{{ trigger_action | string in states(helper_last_controller_event) and trigger_delta | int <= helper_double_press_delay | int }}'
                         sequence:
                           # store the double press event in the last controller event helper
-                          - service: input_text.set_value
+                          - action: input_text.set_value
                             data:
                               entity_id: !input helper_last_controller_event
                               value: '{{ {"a":"double_press","t":as_timestamp(now())} | to_json }}'
@@ -565,7 +642,7 @@ action:
                       - conditions: '{{ trigger_action | string in states(helper_last_controller_event) and trigger_delta | int <= helper_double_press_delay | int }}'
                         sequence:
                           # store the double press event in the last controller event helper
-                          - service: input_text.set_value
+                          - action: input_text.set_value
                             data:
                               entity_id: !input helper_last_controller_event
                               value: '{{ {"a":"double_press","t":as_timestamp(now())} | to_json }}'
@@ -645,7 +722,7 @@ action:
                       - conditions: '{{ trigger_action | string in states(helper_last_controller_event) and trigger_delta | int <= helper_double_press_delay | int }}'
                         sequence:
                           # store the double press event in the last controller event helper
-                          - service: input_text.set_value
+                          - action: input_text.set_value
                             data:
                               entity_id: !input helper_last_controller_event
                               value: '{{ {"a":"double_press","t":as_timestamp(now())} | to_json }}'

--- a/blueprints/controllers/sonoff_snzb01/sonoff_snzb01.yaml
+++ b/blueprints/controllers/sonoff_snzb01/sonoff_snzb01.yaml
@@ -11,13 +11,18 @@ blueprint:
     Hooks allow to easily create controller-based automations for interacting with media players, lights, covers and more.
     See the list of [Hooks available for this controller](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/controllers/sonoff_snzb01#available-hooks) for additional details.
 
+    ## More Info
+
+    ℹ️ Version 2025.01.23
+    📝 [Changelog](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/controllers/sonoff_snzb01/#changelog)
     📕 Full documentation regarding this blueprint is available [here](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/controllers/sonoff_snzb01).
 
-    🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
+    🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**. Please consider **[leaving a star on GitHub](https://github.com/EPMatt/awesome-ha-blueprints)**! 🌟
 
-    ℹ️ Version 2022.08.08
   source_url: https://github.com/EPMatt/awesome-ha-blueprints/blob/main/blueprints/controllers/sonoff_snzb01/sonoff_snzb01.yaml
   domain: automation
+  homeassistant:
+    min_version: 2024.10.0
   input:
     integration:
       name: (Required) Integration
@@ -29,18 +34,28 @@ blueprint:
             - ZHA
             - Zigbee2MQTT
     controller_device:
-      name: (deCONZ, ZHA) Controller Device
-      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.
+      name: (Required) (deCONZ, ZHA, Zigbee2MQTT) Controller Device
+      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
       selector:
         device:
-    controller_entity:
-      name: (Zigbee2MQTT) Controller Entity
-      description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
-      default: ''
-      selector:
-        entity:
-          domain: sensor
+          filter:
+            # source: https://www.zigbee2mqtt.io/devices/SNZB-01.html#ewelink-snzb-01
+            - integration: mqtt
+              manufacturer: eWeLink
+              model: Wireless button
+            # For backwards compatability with z2m 1.x. model_id is added to end of model rather than a seperate attribute in z2m 2.x
+            - integration: mqtt
+              manufacturer: eWeLink
+              model: Wireless button (SNZB-01)
+            # source: https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+            - integration: zha
+              manufacturer: eWeLink
+              model: WB01
+            - integration: deconz
+              manufacturer: eWeLink
+              model: WB01
+          multiple: false
     helper_last_controller_event:
       name: (Required) Helper - Last Controller Event
       description: Input Text used to store the last event fired by the controller. You will need to manually create a text input entity for this, please read the blueprint Additional Notes for more info.
@@ -100,6 +115,7 @@ variables:
       button_long: ['off']
       button_double: ['on']
     zigbee2mqtt:
+      # source: https://www.zigbee2mqtt.io/devices/SNZB-01.html#ewelink-snzb-01
       button_short: [single]
       button_long: [long]
       button_double: [double]
@@ -109,32 +125,41 @@ variables:
   button_long: '{{ actions_mapping[integration_id]["button_long"] }}'
   button_double: '{{ actions_mapping[integration_id]["button_double"] }}'
   # build data to send within a controller event
-  controller_entity: !input controller_entity
-  controller_device: !input controller_device
-  controller_id: '{% if integration_id=="zigbee2mqtt" %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
+  controller_id: !input controller_device
 mode: restart
 max_exceeded: silent
-trigger:
-  # trigger for zigbee2mqtt
-  - platform: event
-    event_type: state_changed
-    event_data:
-      entity_id: !input controller_entity
-  # trigger for other integrations
-  - platform: event
+triggers:
+  # triggers for zigbee2mqtt mqtt device action
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: single
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: long
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: double
+  # triggers for other integrations
+  - trigger: event
     event_type:
       - deconz_event
       - zha_event
     event_data:
       device_id: !input controller_device
-condition:
+conditions:
   - condition: and
     conditions:
       # check that the button event is not empty
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" -%}
-        {{ trigger.event.data.new_state.state }}
+        {{ trigger.payload }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
@@ -142,10 +167,7 @@ condition:
         {%- endif -%}
         {%- endset -%}
         {{ trigger_action not in ["","None"] }}
-      # only for zigbee2mqtt, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
-      # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
-      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
-action:
+actions:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
   # if the delay expires and the automation is still running it means it's the last run and execution can continue
@@ -156,7 +178,7 @@ action:
   - variables:
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" -%}
-        {{ trigger.event.data.new_state.state }}
+        {{ trigger.payload }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
@@ -164,7 +186,7 @@ action:
         {%- endif -%}
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
   # update helper
-  - service: input_text.set_value
+  - action: input_text.set_value
     data:
       entity_id: !input helper_last_controller_event
       value: '{{ {"a":trigger_action,"t":as_timestamp(now())} | to_json }}'

--- a/blueprints/controllers/xiaomi_wxcjkg11lm/xiaomi_wxcjkg11lm.yaml
+++ b/blueprints/controllers/xiaomi_wxcjkg11lm/xiaomi_wxcjkg11lm.yaml
@@ -11,13 +11,18 @@ blueprint:
     Hooks allow to easily create controller-based automations for interacting with media players, lights, covers and more.
     See the list of [Hooks available for this controller](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/controllers/xiaomi_wxcjkg11lm#available-hooks) for additional details.
 
+    ## More Info
+
+    ℹ️ Version 2025.01.23
+    📝 [Changelog](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/controllers/xiaomi_wxcjkg11lm/#changelog)
     📕 Full documentation regarding this blueprint is available [here](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/controllers/xiaomi_wxcjkg11lm).
 
-    🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
+    🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**. Please consider **[leaving a star on GitHub](https://github.com/EPMatt/awesome-ha-blueprints)**! 🌟
 
-    ℹ️ Version 2022.08.08
   source_url: https://github.com/EPMatt/awesome-ha-blueprints/blob/main/blueprints/controllers/xiaomi_wxcjkg11lm/xiaomi_wxcjkg11lm.yaml
   domain: automation
+  homeassistant:
+    min_version: 2024.10.0
   input:
     integration:
       name: (Required) Integration
@@ -29,18 +34,28 @@ blueprint:
             - ZHA
             - Zigbee2MQTT
     controller_device:
-      name: (deCONZ, ZHA) Controller Device
-      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.
+      name: (Required) (deCONZ, ZHA, Zigbee2MQTT) Controller Device
+      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
       selector:
         device:
-    controller_entity:
-      name: (Zigbee2MQTT) Controller Entity
-      description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
-      default: ''
-      selector:
-        entity:
-          domain: sensor
+          filter:
+            # source: https://www.zigbee2mqtt.io/devices/WXCJKG11LM.html#aqara-wxcjkg11lm
+            - integration: mqtt
+              manufacturer: Aqara
+              model: Opple wireless switch (single band)
+            # For backwards compatability with z2m 1.x. model_id is added to end of model rather than a seperate attribute in z2m 2.x
+            - integration: mqtt
+              manufacturer: Aqara
+              model: Opple wireless switch (single band) (WXCJKG11LM)
+            # source: https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+            - integration: zha
+            # **TBConfirmed** manufacturer: Xiaomi
+            # **TBConfirmed**  model: Aqara Opple 2-gang
+            - integration: deconz
+            # **TBConfirmed** manufacturer: Xiaomi
+            # **TBConfirmed** model: Aqara Opple 2-gang
+          multiple: false
     helper_last_controller_event:
       name: (Required) Helper - Last Controller Event
       description: Input Text used to store the last event fired by the controller. You will need to manually create a text input entity for this, please read the blueprint Additional Notes for more info.
@@ -197,6 +212,7 @@ variables:
       button_2_double: [2_double]
       button_2_triple: [2_triple]
     zigbee2mqtt:
+      # source: https://www.zigbee2mqtt.io/devices/WXCJKG11LM.html#aqara-wxcjkg11lm
       button_1_short: [button_1_single]
       button_1_long: [button_1_hold]
       button_1_release: [button_1_release]
@@ -220,32 +236,76 @@ variables:
   button_2_double: '{{ actions_mapping[integration_id]["button_2_double"] }}'
   button_2_triple: '{{ actions_mapping[integration_id]["button_2_triple"] }}'
   # build data to send within a controller event
-  controller_entity: !input controller_entity
-  controller_device: !input controller_device
-  controller_id: '{% if integration_id=="zigbee2mqtt" %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
+  controller_id: !input controller_device
 mode: restart
 max_exceeded: silent
-trigger:
-  # trigger for zigbee2mqtt
-  - platform: event
-    event_type: state_changed
-    event_data:
-      entity_id: !input controller_entity
-  # trigger for other integrations
-  - platform: event
+triggers:
+  # triggers for zigbee2mqtt mqtt device action
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_1_single
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_1_hold
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_1_release
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_1_double
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_1_triple
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_2_single
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_2_hold
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_2_release
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_2_double
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_2_triple
+  # triggers for other integrations
+  - trigger: event
     event_type:
       - deconz_event
       - zha_event
     event_data:
       device_id: !input controller_device
-condition:
+conditions:
   - condition: and
     conditions:
       # check that the button event is not empty
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" -%}
-        {{ trigger.event.data.new_state.state }}
+        {{ trigger.payload }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
@@ -253,10 +313,7 @@ condition:
         {%- endif -%}
         {%- endset -%}
         {{ trigger_action not in ["","None"] }}
-      # only for zigbee2mqtt, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
-      # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
-      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
-action:
+actions:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
   # if the delay expires and the automation is still running it means it's the last run and execution can continue
@@ -267,7 +324,7 @@ action:
   - variables:
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" -%}
-        {{ trigger.event.data.new_state.state }}
+        {{ trigger.payload }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
@@ -275,7 +332,7 @@ action:
         {%- endif -%}
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
   # update helper
-  - service: input_text.set_value
+  - action: input_text.set_value
     data:
       entity_id: !input helper_last_controller_event
       value: '{{ {"a":trigger_action,"t":as_timestamp(now())} | to_json }}'

--- a/blueprints/controllers/xiaomi_wxcjkg12lm/xiaomi_wxcjkg12lm.yaml
+++ b/blueprints/controllers/xiaomi_wxcjkg12lm/xiaomi_wxcjkg12lm.yaml
@@ -11,13 +11,18 @@ blueprint:
     Hooks allow to easily create controller-based automations for interacting with media players, lights, covers and more.
     See the list of [Hooks available for this controller](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/controllers/xiaomi_wxcjkg12lm#available-hooks) for additional details.
 
+    ## More Info
+
+    ℹ️ Version 2025.01.23
+    📝 [Changelog](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/controllers/xiaomi_wxcjkg12lm/#changelog)
     📕 Full documentation regarding this blueprint is available [here](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/controllers/xiaomi_wxcjkg12lm).
 
-    🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
+    🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**. Please consider **[leaving a star on GitHub](https://github.com/EPMatt/awesome-ha-blueprints)**! 🌟
 
-    ℹ️ Version 2022.08.08
   source_url: https://github.com/EPMatt/awesome-ha-blueprints/blob/main/blueprints/controllers/xiaomi_wxcjkg12lm/xiaomi_wxcjkg12lm.yaml
   domain: automation
+  homeassistant:
+    min_version: 2024.10.0
   input:
     integration:
       name: (Required) Integration
@@ -29,18 +34,28 @@ blueprint:
             - ZHA
             - Zigbee2MQTT
     controller_device:
-      name: (deCONZ, ZHA) Controller Device
-      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.
+      name: (Required) (deCONZ, ZHA, Zigbee2MQTT) Controller Device
+      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
       selector:
         device:
-    controller_entity:
-      name: (Zigbee2MQTT) Controller Entity
-      description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
-      default: ''
-      selector:
-        entity:
-          domain: sensor
+          filter:
+            # source: https://www.zigbee2mqtt.io/devices/WXCJKG12LM.html#aqara-wxcjkg12lm
+            - integration: mqtt
+              manufacturer: Aqara
+              model: Opple wireless switch (double band)
+            # For backwards compatability with z2m 1.x. model_id is added to end of model rather than a seperate attribute in z2m 2.x
+            - integration: mqtt
+              manufacturer: Aqara
+              model: Opple wireless switch (double band) (WXCJKG12LM)
+            # source: https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+            - integration: zha
+            # **TBConfirmed** manufacturer: Xiaomi
+            # **TBConfirmed**  model: Aqara Opple 4-gang
+            - integration: deconz
+            # **TBConfirmed** manufacturer: Xiaomi
+            # **TBConfirmed** model: Aqara Opple 4-gang
+          multiple: false
     helper_last_controller_event:
       name: (Required) Helper - Last Controller Event
       description: Input Text used to store the last event fired by the controller. You will need to manually create a text input entity for this, please read the blueprint Additional Notes for more info.
@@ -317,6 +332,7 @@ variables:
       button_4_double: [4_double]
       button_4_triple: [4_triple]
     zigbee2mqtt:
+      # source: https://www.zigbee2mqtt.io/devices/WXCJKG12LM.html#aqara-wxcjkg12lm
       button_1_short: [button_1_single]
       button_1_long: [button_1_hold]
       button_1_release: [button_1_release]
@@ -360,32 +376,126 @@ variables:
   button_4_double: '{{ actions_mapping[integration_id]["button_4_double"] }}'
   button_4_triple: '{{ actions_mapping[integration_id]["button_4_triple"] }}'
   # build data to send within a controller event
-  controller_entity: !input controller_entity
-  controller_device: !input controller_device
-  controller_id: '{% if integration_id=="zigbee2mqtt" %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
+  controller_id: !input controller_device
 mode: restart
 max_exceeded: silent
-trigger:
-  # trigger for zigbee2mqtt
-  - platform: event
-    event_type: state_changed
-    event_data:
-      entity_id: !input controller_entity
-  # trigger for other integrations
+triggers:
+  # triggers for zigbee2mqtt mqtt device action
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_1_single
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_1_hold
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_1_release
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_1_double
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_1_triple
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_2_single
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_2_hold
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_2_release
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_2_double
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_2_triple
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_3_single
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_3_hold
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_3_release
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_3_double
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_3_triple
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_4_single
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_4_hold
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_4_release
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_4_double
+  - platform: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_4_triple
+  # triggers for other integrations
   - platform: event
     event_type:
       - deconz_event
       - zha_event
     event_data:
       device_id: !input controller_device
-condition:
+conditions:
   - condition: and
     conditions:
       # check that the button event is not empty
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" -%}
-        {{ trigger.event.data.new_state.state }}
+        {{ trigger.payload }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
@@ -393,10 +503,7 @@ condition:
         {%- endif -%}
         {%- endset -%}
         {{ trigger_action not in ["","None"] }}
-      # only for zigbee2mqtt, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
-      # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
-      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
-action:
+actions:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
   # if the delay expires and the automation is still running it means it's the last run and execution can continue
@@ -407,7 +514,7 @@ action:
   - variables:
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" -%}
-        {{ trigger.event.data.new_state.state }}
+        {{ trigger.payload }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
@@ -415,7 +522,7 @@ action:
         {%- endif -%}
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
   # update helper
-  - service: input_text.set_value
+  - action: input_text.set_value
     data:
       entity_id: !input helper_last_controller_event
       value: '{{ {"a":trigger_action,"t":as_timestamp(now())} | to_json }}'

--- a/blueprints/controllers/xiaomi_wxcjkg13lm/xiaomi_wxcjkg13lm.yaml
+++ b/blueprints/controllers/xiaomi_wxcjkg13lm/xiaomi_wxcjkg13lm.yaml
@@ -11,13 +11,18 @@ blueprint:
     Hooks allow to easily create controller-based automations for interacting with media players, lights, covers and more.
     See the list of [Hooks available for this controller](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/controllers/xiaomi_wxcjkg13lm#available-hooks) for additional details.
 
+    ## More Info
+
+    ℹ️ Version 2025.01.23
+    📝 [Changelog](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/controllers/xiaomi_wxcjkg13lm/#changelog)
     📕 Full documentation regarding this blueprint is available [here](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/controllers/xiaomi_wxcjkg13lm).
 
-    🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
+    🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**. Please consider **[leaving a star on GitHub](https://github.com/EPMatt/awesome-ha-blueprints)**! 🌟
 
-    ℹ️ Version 2022.08.08
   source_url: https://github.com/EPMatt/awesome-ha-blueprints/blob/main/blueprints/controllers/xiaomi_wxcjkg13lm/xiaomi_wxcjkg13lm.yaml
   domain: automation
+  homeassistant:
+    min_version: 2024.10.0
   input:
     integration:
       name: (Required) Integration
@@ -29,18 +34,28 @@ blueprint:
             - ZHA
             - Zigbee2MQTT
     controller_device:
-      name: (deCONZ, ZHA) Controller Device
-      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.
+      name: (Required) (deCONZ, ZHA, Zigbee2MQTT) Controller Device
+      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
       selector:
         device:
-    controller_entity:
-      name: (Zigbee2MQTT) Controller Entity
-      description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
-      default: ''
-      selector:
-        entity:
-          domain: sensor
+          filter:
+            # source: https://www.zigbee2mqtt.io/devices/WXCJKG13LM.html#aqara-wxcjkg13lm
+            - integration: mqtt
+              manufacturer: Aqara
+              model: Opple wireless switch (triple band)
+            # For backwards compatability with z2m 1.x. model_id is added to end of model rather than a seperate attribute in z2m 2.x
+            - integration: mqtt
+              manufacturer: Aqara
+              model: Opple wireless switch (triple band) (WXCJKG13LM)
+            # source: https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+            - integration: zha
+            # **TBConfirmed** manufacturer: Xiaomi
+            # **TBConfirmed** model: Aqara Opple 6-gang
+            - integration: deconz
+            # **TBConfirmed** manufacturer: Xiaomi
+            # **TBConfirmed** model: Aqara Opple 6-gang
+          multiple: false
     helper_last_controller_event:
       name: (Required) Helper - Last Controller Event
       description: Input Text used to store the last event fired by the controller. You will need to manually create a text input entity for this, please read the blueprint Additional Notes for more info.
@@ -437,6 +452,7 @@ variables:
       button_6_double: [6_double]
       button_6_triple: [6_triple]
     zigbee2mqtt:
+      # source: https://www.zigbee2mqtt.io/devices/WXCJKG13LM.html#aqara-wxcjkg13lm
       button_1_short: [button_1_single]
       button_1_long: [button_1_hold]
       button_1_release: [button_1_release]
@@ -500,32 +516,182 @@ variables:
   button_6_double: '{{ actions_mapping[integration_id]["button_6_double"] }}'
   button_6_triple: '{{ actions_mapping[integration_id]["button_6_triple"] }}'
   # build data to send within a controller event
-  controller_entity: !input controller_entity
-  controller_device: !input controller_device
-  controller_id: '{% if integration_id=="zigbee2mqtt" %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
+  controller_id: !input controller_device
 mode: restart
 max_exceeded: silent
-trigger:
-  # trigger for zigbee2mqtt
-  - platform: event
-    event_type: state_changed
-    event_data:
-      entity_id: !input controller_entity
-  # trigger for other integrations
-  - platform: event
+triggers:
+  # triggers for zigbee2mqtt mqtt device action
+  # button_1
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_1_single
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_1_hold
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_1_release
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_1_double
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_1_triple
+  # button_2
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_2_single
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_2_hold
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_2_release
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_2_double
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_2_triple
+  # button_3
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_3_single
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_3_hold
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_3_release
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_3_double
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_3_triple
+  # button_4
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_4_single
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_4_hold
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_4_release
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_4_double
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_4_triple
+  # button_5
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_5_single
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_5_hold
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_5_release
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_5_double
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_5_triple
+  # button_6
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_6_single
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_6_hold
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_6_release
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_6_double
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: button_6_triple
+  # triggers for other integrations
+  - trigger: event
     event_type:
       - deconz_event
       - zha_event
     event_data:
       device_id: !input controller_device
-condition:
+conditions:
   - condition: and
     conditions:
       # check that the button event is not empty
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" -%}
-        {{ trigger.event.data.new_state.state }}
+        {{ trigger.payload }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
@@ -533,10 +699,7 @@ condition:
         {%- endif -%}
         {%- endset -%}
         {{ trigger_action not in ["","None"] }}
-      # only for zigbee2mqtt, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
-      # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
-      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
-action:
+actions:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
   # if the delay expires and the automation is still running it means it's the last run and execution can continue
@@ -547,7 +710,7 @@ action:
   - variables:
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" -%}
-        {{ trigger.event.data.new_state.state }}
+        {{ trigger.payload }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
@@ -555,7 +718,7 @@ action:
         {%- endif -%}
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
   # update helper
-  - service: input_text.set_value
+  - action: input_text.set_value
     data:
       entity_id: !input helper_last_controller_event
       value: '{{ {"a":trigger_action,"t":as_timestamp(now())} | to_json }}'

--- a/blueprints/controllers/xiaomi_wxkg11lm/xiaomi_wxkg11lm.yaml
+++ b/blueprints/controllers/xiaomi_wxkg11lm/xiaomi_wxkg11lm.yaml
@@ -11,13 +11,18 @@ blueprint:
     Hooks allow to easily create controller-based automations for interacting with media players, lights, covers and more.
     See the list of [Hooks available for this controller](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/controllers/xiaomi_wxkg11lm#available-hooks) for additional details.
 
+    ## More Info
+
+    ℹ️ Version 2025.01.23
+    📝 [Changelog](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/controllers/xiaomi_wxkg11lm/#changelog)
     📕 Full documentation regarding this blueprint is available [here](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/controllers/xiaomi_wxkg11lm).
 
-    🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
+    🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**. Please consider **[leaving a star on GitHub](https://github.com/EPMatt/awesome-ha-blueprints)**! 🌟
 
-    ℹ️ Version 2022.08.08
   source_url: https://github.com/EPMatt/awesome-ha-blueprints/blob/main/blueprints/controllers/xiaomi_wxkg11lm/xiaomi_wxkg11lm.yaml
   domain: automation
+  homeassistant:
+    min_version: 2024.10.0
   input:
     integration:
       name: (Required) Integration
@@ -29,18 +34,28 @@ blueprint:
             - ZHA
             - Zigbee2MQTT
     controller_device:
-      name: (deCONZ, ZHA) Controller Device
-      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.
+      name: (deCONZ, ZHA, Zigbee2MQTT) Controller Device
+      description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
       selector:
         device:
-    controller_entity:
-      name: (Zigbee2MQTT) Controller Entity
-      description: The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.
-      default: ''
-      selector:
-        entity:
-          domain: sensor
+          filter:
+            # source: https://www.zigbee2mqtt.io/devices/WXKG01LM.html#xiaomi-wxkg01lm
+            - integration: mqtt
+              manufacturer: Xiaomi
+              model: Mi wireless switch
+            # For backwards compatability with z2m 1.x. model_id is added to end of model rather than a seperate attribute in z2m 2.x
+            - integration: mqtt
+              manufacturer: Xiaomi
+              model: Mi wireless switch (WXKG01LM)
+            # source: https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+            - integration: zha
+            # **TBConfirmed** manufacturer: Xiaomi
+            # **TBConfirmed**  model: Mi round smart wireless switch
+            - integration: deconz
+            # **TBConfirmed** manufacturer: Xiaomi
+            # **TBConfirmed** model: Mi round smart wireless switch
+          multiple: false
     helper_last_controller_event:
       name: (Required) Helper - Last Controller Event
       description: Input Text used to store the last event fired by the controller. You will need to manually create a text input entity for this, please read the blueprint Additional Notes for more info.
@@ -129,6 +144,7 @@ variables:
       button_release: [release_value]
       button_double: [double_value]
     zigbee2mqtt:
+      # source: https://www.zigbee2mqtt.io/devices/WXKG01LM.html#xiaomi-wxkg01lm
       button_short: [single]
       button_long: [hold]
       button_release: [release]
@@ -140,32 +156,46 @@ variables:
   button_release: '{{ actions_mapping[integration_id]["button_release"] }}'
   button_double: '{{ actions_mapping[integration_id]["button_double"] }}'
   # build data to send within a controller event
-  controller_entity: !input controller_entity
-  controller_device: !input controller_device
-  controller_id: '{% if integration_id=="zigbee2mqtt" %}{{controller_entity}}{% else %}{{controller_device}}{% endif %}'
+  controller_id: !input controller_device
 mode: restart
 max_exceeded: silent
-trigger:
-  # trigger for zigbee2mqtt
-  - platform: event
-    event_type: state_changed
-    event_data:
-      entity_id: !input controller_entity
-  # trigger for other integrations
-  - platform: event
+triggers:
+  # triggers for zigbee2mqtt mqtt device action
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: single
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: hold
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: release
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: double
+  # triggers for other integrations
+  - trigger: event
     event_type:
       - deconz_event
       - zha_event
     event_data:
       device_id: !input controller_device
-condition:
+conditions:
   - condition: and
     conditions:
       # check that the button event is not empty
       - >-
         {%- set trigger_action -%}
         {%- if integration_id == "zigbee2mqtt" -%}
-        {{ trigger.event.data.new_state.state }}
+        {{ trigger.payload }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
@@ -173,10 +203,7 @@ condition:
         {%- endif -%}
         {%- endset -%}
         {{ trigger_action not in ["","None"] }}
-      # only for zigbee2mqtt, check if the event is relative to a real state change, and not only some minor changes in the sensor attributes
-      # this is required since multiple state_changed events are fired for a single button press, with the result of the automation being triggered multiple times
-      - '{{ integration_id != "zigbee2mqtt" or trigger.event.data.new_state.state != trigger.event.data.old_state.state }}'
-action:
+actions:
   # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
   # therefore previous runs must wait for the debounce delay before executing any other action
   # if the delay expires and the automation is still running it means it's the last run and execution can continue
@@ -187,7 +214,7 @@ action:
   - variables:
       trigger_action: >-
         {%- if integration_id == "zigbee2mqtt" -%}
-        {{ trigger.event.data.new_state.state }}
+        {{ trigger.payload }}
         {%- elif integration_id == "deconz" -%}
         {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
@@ -195,7 +222,7 @@ action:
         {%- endif -%}
       trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\": \".*\"|\"t\": \d+\.\d+)(, )?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
   # update helper
-  - service: input_text.set_value
+  - action: input_text.set_value
     data:
       entity_id: !input helper_last_controller_event
       value: '{{ {"a":trigger_action,"t":as_timestamp(now())} | to_json }}'

--- a/blueprints/hooks/cover/cover.yaml
+++ b/blueprints/hooks/cover/cover.yaml
@@ -12,11 +12,14 @@ blueprint:
 
     A list of controllers supported by this hook is available [here](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/hooks/cover#supported-controllers).
 
+    ## More Info
+
+    ℹ️ Version 2025.01.23
+    📝 [Changelog](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/hooks/cover/#changelog)
     📕 Full documentation regarding this blueprint is available [here](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/hooks/cover).
 
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
-    ℹ️ Version 2022.07.30
   source_url: https://github.com/EPMatt/awesome-ha-blueprints/blob/main/blueprints/hooks/cover/cover.yaml
   domain: automation
   input:
@@ -26,13 +29,6 @@ blueprint:
       default: ''
       selector:
         device:
-    controller_entity:
-      name: (Required) Controller Entity
-      description: The controller entity which will control the Cover. Choose a value only if the integration used to connect the controller to Home Assistant exposes it as an Entity. This value should match the one specified in the corresponding Controller automation.
-      default: ''
-      selector:
-        entity:
-          domain: sensor
     controller_model:
       name: (Required) Controller model
       description: The model for the controller used in this automation. Choose a value from the list of supported controllers.
@@ -136,47 +132,43 @@ variables:
   stop_cover_all: '{{ controller_mapping[controller_model]["stop_cover_all"] | default(None) }}'
 mode: restart
 max_exceeded: silent
-trigger:
-  - platform: event
+triggers:
+  - trigger: event
     event_type: ahb_controller_event
     event_data:
       controller: !input controller_device
-  - platform: event
-    event_type: ahb_controller_event
-    event_data:
-      controller: !input controller_entity
-condition: []
-action:
+conditions: []
+actions:
   - variables:
       action: '{{ trigger.event.data.action }}'
   - choose:
       - conditions: '{{ action == open_cover }}'
         sequence:
-          - service: cover.open_cover
+          - action: cover.open_cover
             entity_id: !input cover
       - conditions: '{{ action == close_cover }}'
         sequence:
-          - service: cover.close_cover
+          - action: cover.close_cover
             entity_id: !input cover
       - conditions: '{{ action == stop_cover }}'
         sequence:
-          - service: cover.stop_cover
+          - action: cover.stop_cover
             entity_id: !input cover
       - conditions: '{{ action == open_cover_tilt }}'
         sequence:
-          - service: cover.open_cover_tilt
+          - action: cover.open_cover_tilt
             entity_id: !input cover
       - conditions: '{{ action == close_cover_tilt }}'
         sequence:
-          - service: cover.close_cover_tilt
+          - action: cover.close_cover_tilt
             entity_id: !input cover
       - conditions: '{{ action == stop_cover_tilt }}'
         sequence:
-          - service: cover.stop_cover_tilt
+          - action: cover.stop_cover_tilt
             entity_id: !input cover
       - conditions: '{{ action == stop_cover_all }}'
         sequence:
-          - service: cover.stop_cover
+          - action: cover.stop_cover
             entity_id: !input cover
-          - service: cover.stop_cover_tilt
+          - action: cover.stop_cover_tilt
             entity_id: !input cover

--- a/blueprints/hooks/light/light.yaml
+++ b/blueprints/hooks/light/light.yaml
@@ -12,11 +12,14 @@ blueprint:
 
     A list of controllers supported by this hook is available [here](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/hooks/light#supported-controllers).
 
+    ## More Info
+
+    ℹ️ Version 2025.01.23
+    📝 [Changelog](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/hooks/light/#changelog)
     📕 Full documentation regarding this blueprint is available [here](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/hooks/light).
 
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
-    ℹ️ Version 2022.07.30
   source_url: https://github.com/EPMatt/awesome-ha-blueprints/blob/main/blueprints/hooks/light/light.yaml
   domain: automation
   input:
@@ -26,13 +29,6 @@ blueprint:
       default: ''
       selector:
         device:
-    controller_entity:
-      name: (Required) Controller Entity
-      description: The controller entity which will control the Light. Choose a value only if the integration used to connect the controller to Home Assistant exposes it as an Entity. This value should match the one specified in the corresponding Controller automation.
-      default: ''
-      selector:
-        entity:
-          domain: sensor
     controller_model:
       name: (Required) Controller model
       description: The model for the controller used in this automation. Choose a value from the list of supported controllers.
@@ -347,17 +343,13 @@ variables:
   step_long: '{{ (max_brightness-min_brightness)/brightness_steps_long }}'
 mode: restart
 max_exceeded: silent
-trigger:
-  - platform: event
+triggers:
+  - trigger: event
     event_type: ahb_controller_event
     event_data:
       controller: !input controller_device
-  - platform: event
-    event_type: ahb_controller_event
-    event_data:
-      controller: !input controller_entity
 condition: []
-action:
+actions:
   - variables:
       action: '{{ trigger.event.data.action }}'
   - choose:
@@ -366,13 +358,13 @@ action:
           - choose:
               - conditions: '{{ force_brightness }}'
                 sequence:
-                  - service: light.toggle
+                  - action: light.toggle
                     entity_id: !input light
                     data:
                       brightness: !input on_brightness
                       transition: '{{ light_transition / 1000 }}'
             default:
-              - service: light.toggle
+              - action: light.toggle
                 entity_id: !input light
                 data:
                   transition: '{{ light_transition / 1000 }}'
@@ -381,19 +373,19 @@ action:
           - choose:
               - conditions: '{{ force_brightness }}'
                 sequence:
-                  - service: light.turn_on
+                  - action: light.turn_on
                     entity_id: !input light
                     data:
                       brightness: !input on_brightness
                       transition: '{{ light_transition / 1000 }}'
             default:
-              - service: light.turn_on
+              - action: light.turn_on
                 entity_id: !input light
                 data:
                   transition: '{{ light_transition / 1000 }}'
       - conditions: '{{ action == turn_off }}'
         sequence:
-          - service: light.turn_off
+          - action: light.turn_off
             entity_id: !input light
             data:
               transition: '{{ light_transition / 1000 }}'
@@ -403,21 +395,21 @@ action:
               # if light is off and smooth power on is disabled, turn it on at the previously saved brightness
               - conditions: '{{ states(light) == "off" and not smooth_power_on}}'
                 sequence:
-                  - service: light.turn_on
+                  - action: light.turn_on
                     data:
                       transition: '{{ light_transition / 1000 }}'
                       entity_id: !input light
               # if light is off and smooth power on is enabled, turn it on at minimum brightness
               - conditions: '{{ states(light) == "off" and smooth_power_on}}'
                 sequence:
-                  - service: light.turn_on
+                  - action: light.turn_on
                     data:
                       brightness: '{{ min_brightness }}'
                       transition: '{{ light_transition / 1000 }}'
                       entity_id: !input light
             # else the light is on, hence increase its brightness
             default:
-              - service: light.turn_on
+              - action: light.turn_on
                 data:
                   brightness: '{{ [ [state_attr(light,"brightness")+step_short, min_brightness] | max, max_brightness] | min }}'
                   transition: 0.25
@@ -427,12 +419,12 @@ action:
           - choose:
               - conditions: '{{ smooth_power_off and state_attr(light,"brightness") == min_brightness }}'
                 sequence:
-                  - service: light.turn_off
+                  - action: light.turn_off
                     data:
                       transition: '{{ light_transition / 1000 }}'
                       entity_id: !input light
             default:
-              - service: light.turn_on
+              - action: light.turn_on
                 data:
                   brightness: '{{ [ [state_attr(light,"brightness")-step_short, min_brightness] | max, max_brightness] | min }}'
                   transition: 0.25
@@ -444,7 +436,7 @@ action:
               # if light is off and smooth power on is disabled, turn it on at the previously saved brightness
               - conditions: '{{ states(light) == "off" and not smooth_power_on}}'
                 sequence:
-                  - service: light.turn_on
+                  - action: light.turn_on
                     data:
                       transition: '{{ light_transition / 1000 }}'
                       entity_id: !input light
@@ -453,7 +445,7 @@ action:
               # if light is off and smooth power on is enabled, turn it on at minimum brightness
               - conditions: '{{ states(light) == "off" and smooth_power_on}}'
                 sequence:
-                  - service: light.turn_on
+                  - action: light.turn_on
                     data:
                       brightness: '{{ min_brightness }}'
                       transition: '{{ light_transition / 1000 }}'
@@ -464,7 +456,7 @@ action:
           - repeat:
               while: '{{ true }}'
               sequence:
-                - service: light.turn_on
+                - action: light.turn_on
                   data:
                     brightness: '{{ [ [state_attr(light,"brightness")+step_long, min_brightness] | max, max_brightness] | min }}'
                     transition: 0.25
@@ -485,7 +477,7 @@ action:
                             # if the light is at minimum brightness, turn it off
                             - conditions: '{{ state_attr(light,"brightness") == min_brightness }}'
                               sequence:
-                                - service: light.turn_off
+                                - action: light.turn_off
                                   data:
                                     transition: '{{ light_transition / 1000 }}'
                                     entity_id: !input light
@@ -493,7 +485,7 @@ action:
                                     milliseconds: !input light_transition
                           # else lower the light's brightness
                           default:
-                            - service: light.turn_on
+                            - action: light.turn_on
                               data:
                                 brightness: '{{ [ [state_attr(light,"brightness")-step_long, min_brightness] | max, max_brightness] | min }}'
                                 transition: 0.25
@@ -506,7 +498,7 @@ action:
                   while: '{{ states(light) != "off" }}'
                   sequence:
                     # lower the light's brightness. since smooth power off is disabled, never let the brightness move below the user-provided minimum
-                    - service: light.turn_on
+                    - action: light.turn_on
                       data:
                         brightness: '{{ [ [state_attr(light,"brightness")-step_long, min_brightness] | max, max_brightness] | min }}'
                         transition: 0.25
@@ -518,14 +510,14 @@ action:
           choose:
             - conditions: '{{ light_color_mode_id == "color_temp" }}'
               sequence:
-                - service: light.turn_on
+                - action: light.turn_on
                   data:
                     color_temp: '{{ state_attr(light,"color_temp")|int + 50 }}'
                     transition: 0.25
                   entity_id: !input light
             - conditions: '{{ light_color_mode_id == "hs_color" }}'
               sequence:
-                - service: light.turn_on
+                - action: light.turn_on
                   data:
                     hs_color: '{{ [((state_attr(light,"hs_color")[0] or 0) + 15) % 360, 100] }}'
                     transition: 0.25
@@ -535,14 +527,14 @@ action:
           choose:
             - conditions: '{{ light_color_mode_id == "color_temp" }}'
               sequence:
-                - service: light.turn_on
+                - action: light.turn_on
                   data:
                     color_temp: '{{ [state_attr(light,"color_temp")|int - 50, 1]|max }}'
                     transition: 0.25
                   entity_id: !input light
             - conditions: '{{ light_color_mode_id == "hs_color" }}'
               sequence:
-                - service: light.turn_on
+                - action: light.turn_on
                   data:
                     hs_color: '{{ [((state_attr(light,"hs_color")[0] or 0) - 15) % 360, 100] }}'
                     transition: 0.25
@@ -555,7 +547,7 @@ action:
                 - repeat:
                     while: '{{ true }}'
                     sequence:
-                      - service: light.turn_on
+                      - action: light.turn_on
                         data:
                           color_temp: '{{ state_attr(light,"color_temp")|int + 50 }}'
                           transition: 0.25
@@ -567,7 +559,7 @@ action:
                 - repeat:
                     while: '{{ true }}'
                     sequence:
-                      - service: light.turn_on
+                      - action: light.turn_on
                         data:
                           hs_color: '{{ [((state_attr(light,"hs_color")[0] or 0) + 15) % 360, 100] }}'
                           transition: 0.25
@@ -582,7 +574,7 @@ action:
                 - repeat:
                     while: '{{ true }}'
                     sequence:
-                      - service: light.turn_on
+                      - action: light.turn_on
                         data:
                           color_temp: '{{ [state_attr(light,"color_temp")|int - 50, 1]|max }}'
                           transition: 0.25
@@ -594,7 +586,7 @@ action:
                 - repeat:
                     while: '{{ true }}'
                     sequence:
-                      - service: light.turn_on
+                      - action: light.turn_on
                         data:
                           hs_color: '{{ [((state_attr(light,"hs_color")[0] or 0) - 15) % 360, 100] }}'
                           transition: 0.25

--- a/blueprints/hooks/media_player/media_player.yaml
+++ b/blueprints/hooks/media_player/media_player.yaml
@@ -12,11 +12,14 @@ blueprint:
 
     A list of controllers supported by this hook is available [here](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/hooks/media_player#supported-controllers).
 
+    ## More Info
+
+    ℹ️ Version 2025.01.23
+    📝 [Changelog](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/hooks/media_player/#changelog)
     📕 Full documentation regarding this blueprint is available [here](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/hooks/media_player).
 
     🚀 This blueprint is part of the **[Awesome HA Blueprints](https://epmatt.github.io/awesome-ha-blueprints) project**.
 
-    ℹ️ Version 2022.07.30
   source_url: https://github.com/EPMatt/awesome-ha-blueprints/blob/main/blueprints/hooks/media_player/media_player.yaml
   domain: automation
   input:
@@ -26,13 +29,6 @@ blueprint:
       default: ''
       selector:
         device:
-    controller_entity:
-      name: (Required) Controller Entity
-      description: The controller entity which will control the Media Player. Choose a value only if the integration used to connect the controller to Home Assistant exposes it as an Entity. This value should match the one specified in the corresponding Controller automation.
-      default: ''
-      selector:
-        entity:
-          domain: sensor
     controller_model:
       name: (Required) Controller model
       description: The model for the controller used in this automation. Choose a value from the list of supported controllers.
@@ -224,39 +220,35 @@ variables:
   volume_step_value_long: '{{ 1/volume_steps_long }}'
 mode: restart
 max_exceeded: silent
-trigger:
-  - platform: event
+triggers:
+  - trigger: event
     event_type: ahb_controller_event
     event_data:
       controller: !input controller_device
-  - platform: event
-    event_type: ahb_controller_event
-    event_data:
-      controller: !input controller_entity
 condition: []
-action:
+actions:
   - variables:
       action: '{{ trigger.event.data.action }}'
   - choose:
       - conditions: '{{ action == play_pause }}'
         sequence:
-          - service: media_player.media_play_pause
+          - action: media_player.media_play_pause
             entity_id: !input media_player
       - conditions: '{{ action == stop }}'
         sequence:
-          - service: media_player.media_stop
+          - action: media_player.media_stop
             entity_id: !input media_player
       - conditions: '{{ action == next_track }}'
         sequence:
-          - service: media_player.media_next_track
+          - action: media_player.media_next_track
             entity_id: !input media_player
       - conditions: '{{ action == prev_track }}'
         sequence:
-          - service: media_player.media_previous_track
+          - action: media_player.media_previous_track
             entity_id: !input media_player
       - conditions: '{{ action == toggle }}'
         sequence:
-          - service: media_player.toggle
+          - action: media_player.toggle
             entity_id: !input media_player
       - conditions: '{{ action == volume_up }}'
         sequence:
@@ -264,13 +256,13 @@ action:
               # if the volume level can be read from the media player, increase the volume by the custom step value
               - conditions: '{{ state_attr(media_player, "volume_level") != None }}'
                 sequence:
-                  - service: media_player.volume_set
+                  - action: media_player.volume_set
                     entity_id: !input media_player
                     data:
                       volume_level: '{{ [ state_attr(media_player, "volume_level")+volume_step_value_short, 1 ] | min  }}'
             # if the volume level is not available, fallback to the media_player.volume_up service
             default:
-              - service: media_player.volume_up
+              - action: media_player.volume_up
                 entity_id: !input media_player
       - conditions: '{{ action == volume_down }}'
         sequence:
@@ -278,13 +270,13 @@ action:
               # if the volume level can be read from the media player, decrease the volume by the custom step value
               - conditions: '{{ state_attr(media_player, "volume_level") != None }}'
                 sequence:
-                  - service: media_player.volume_set
+                  - action: media_player.volume_set
                     entity_id: !input media_player
                     data:
                       volume_level: '{{ [ state_attr(media_player, "volume_level")-volume_step_value_short, 0 ] | max }}'
             # if the volume level is not available, fallback to the media_player.volume_down service
             default:
-              - service: media_player.volume_down
+              - action: media_player.volume_down
                 entity_id: !input media_player
       - conditions: '{{ action == volume_up_repeat }}'
         sequence:
@@ -295,13 +287,13 @@ action:
                     # if the volume level can be read from the media player, increase the volume by the custom step value
                     - conditions: '{{ state_attr(media_player, "volume_level") != None }}'
                       sequence:
-                        - service: media_player.volume_set
+                        - action: media_player.volume_set
                           entity_id: !input media_player
                           data:
                             volume_level: '{{ [ state_attr(media_player, "volume_level")+volume_step_value_long, 1 ] | min  }}'
                   # if the volume level is not available, fallback to the media_player.volume_up service
                   default:
-                    - service: media_player.volume_up
+                    - action: media_player.volume_up
                       entity_id: !input media_player
                 - delay:
                     milliseconds: 250
@@ -314,13 +306,13 @@ action:
                     # if the volume level can be read from the media player, decrease the volume by the custom step value
                     - conditions: '{{ state_attr(media_player, "volume_level") != None }}'
                       sequence:
-                        - service: media_player.volume_set
+                        - action: media_player.volume_set
                           entity_id: !input media_player
                           data:
                             volume_level: '{{ [ state_attr(media_player, "volume_level")-volume_step_value_long, 0 ] | max }}'
                   # if the volume level is not available, fallback to the media_player.volume_down service
                   default:
-                    - service: media_player.volume_down
+                    - action: media_player.volume_down
                       entity_id: !input media_player
                 - delay:
                     milliseconds: 250

--- a/website/docs/blueprints/controllers.mdx
+++ b/website/docs/blueprints/controllers.mdx
@@ -9,7 +9,7 @@ Controllers are part of the **Controllers-Hooks Ecosystem**. You can read more a
 
 import Image from '/src/components/ControllerImage'
 
-**Controllers** are blueprints which allow to easily integrate a wide range of controllers (wall switches, remotes, dimmers, etc.) and use them to run a set of actions when interacting with them. They consist in a practical abstraction layer for easily building controlled-based automations without worrying about the handling of RAW controller events, and the integration used to connect controllers to Home Assistant (Zigbee2MQTT, ZHA, etc.).
+**Controllers** are blueprints which allow to easily integrate a wide range of controllers (wall switches, remotes, dimmers, etc.) and use them to run a set of actions when interacting with them. They consist in a practical abstraction layer for easily building controlled-based automations without worrying about the handling of RAW controller events, and the integration used to connect controllers to Home Assistant (Zigbee2MQTT, ZHA, deCONZ, etc.).
 
 You can integrate Controllers with [Hooks](hooks) and create controller-based automations to control lights, media players and much more, without having to write a single line of code.
 
@@ -30,7 +30,7 @@ _Can't find the controller you're looking for in this list? [Submit a new bluepr
 | IKEA         | [ICTC-G-1](/docs/blueprints/controllers/ikea_ictc_g_1)              | IKEA ICTC-G-1 TRÅDFRI wireless dimmer             | deCONZ,ZHA,Zigbee2MQTT | <Image>![ikea_ictc_g_1](/img/controllers/ikea_ictc_g_1.png)</Image>                 |
 | OSRAM        | [AC025XX00NJ](/docs/blueprints/controllers/osram_ac025xx00nj)       | OSRAM AC025XX00NJ SMART+ Switch Mini              | deCONZ,ZHA,Zigbee2MQTT | <Image>![osram_ac025xx00nj](/img/controllers/osram_ac025xx00nj.png)</Image>         |
 | Philips      | [324131092621](/docs/blueprints/controllers/philips_324131092621)   | Philips 324131092621 Hue Dimmer switch            | deCONZ,ZHA,Zigbee2MQTT | <Image>![philips_324131092621](/img/controllers/philips_324131092621.png)</Image>   |
-| Philips      | [8718699693985](/docs/blueprints/controllers/philips_8718699693985) | Philips 8718699693985 Hue Smart Button            | deCONZ,ZHA             | <Image>![philips_8718699693985](/img/controllers/philips_8718699693985.png)</Image> |
+| Philips      | [8718699693985](/docs/blueprints/controllers/philips_8718699693985) | Philips 8718699693985 Hue Smart Button            | deCONZ,ZHA,Zigbee2MQTT | <Image>![philips_8718699693985](/img/controllers/philips_8718699693985.png)</Image> |
 | Philips      | [929002398602](/docs/blueprints/controllers/philips_929002398602)   | Philips 929002398602 Hue Dimmer switch v2         | ZHA,Zigbee2MQTT        | <Image>![philips_929002398602](/img/controllers/philips_929002398602.png)</Image>   |
 | SONOFF       | [SNZB-01](/docs/blueprints/controllers/sonoff_snzb01)               | SONOFF SNZB-01 Wireless Switch                    | deCONZ,ZHA,Zigbee2MQTT | <Image>![sonoff_snzb01](/img/controllers/sonoff_snzb01.png)</Image>                 |
 | Xiaomi       | [WXCJKG11LM](/docs/blueprints/controllers/xiaomi_wxcjkg11lm)        | Xiaomi WXCJKG11LM Aqara Opple 2 button remote     | deCONZ,ZHA,Zigbee2MQTT | <Image>![xiaomi_wxcjkg11lm](/img/controllers/xiaomi_wxcjkg11lm.png)</Image>         |

--- a/website/docs/blueprints/controllers/ikea_e1524_e1810.mdx
+++ b/website/docs/blueprints/controllers/ikea_e1524_e1810.mdx
@@ -51,13 +51,7 @@ This integration provides the entity which must be provided to the blueprint in 
   name='Controller Device'
   description='The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.'
   selector='device'
-  required='deCONZ, ZHA'
-/>
-<Input
-  name='Controller Entity'
-  description='The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.'
-  selector='entity'
-  required='Zigbee2MQTT'
+  required='deCONZ, ZHA, Zigbee2MQTT'
 />
 <Input
   name='Helper - Last Controller Event'
@@ -355,3 +349,12 @@ If you notice your controller is not behaving as expected please remove the batt
 - **2021-10-26**: Standardize blueprints structure and inputs naming across the whole collection. Improve blueprint documentation. No functionality change.
 - **2022-08-08**: Optimize characters usage for the `helper_last_controller_event` text input.
 - **2025-01-03**: Fixed double press events not triggered due to changes in Home Assistant 2023.5.x. ([@ZtormTheCat](https://github.com/ZtormTheCat))
+- **2025-01-23**:
+
+  :warning: **Breaking Change**:
+
+  Migrate to Zigbee2MQTT MQTT Device Triggers. ([@yarafie](https://github.com/yarafie))
+
+  The `controller_entity` input has been deprecated, and `controller_device` is now mandatory.
+  If you are a Zigbee2MQTT user and plan to update this blueprint, please make sure to remove the `controller_entity` input from your automation config and add the device ID of your controller to the `controller_device` input.
+  To obtain the device ID from your controller, configure the automation from the UI and use the device selector dropdown on the `controller_device` input to select your controller.

--- a/website/docs/blueprints/controllers/ikea_e1744.mdx
+++ b/website/docs/blueprints/controllers/ikea_e1744.mdx
@@ -53,13 +53,7 @@ This integration provides the entity which must be provided to the blueprint in 
   name='Controller Device'
   description='The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.'
   selector='device'
-  required='deCONZ, ZHA'
-/>
-<Input
-  name='Controller Entity'
-  description='The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.'
-  selector='entity'
-  required='Zigbee2MQTT'
+  required='deCONZ, ZHA, Zigbee2MQTT'
 />
 <Input
   name='Helper - Last Controller Event'
@@ -203,3 +197,12 @@ The helper is used to determine stop rotation events when the controller is inte
 - **2021-10-26**: Standardize blueprints structure and inputs naming across the whole collection. Improve blueprint documentation. No functionality change.
 - **2022-08-08**: Optimize characters usage for the `helper_last_controller_event` text input.
 - **2025-01-05**: Update ZHA event data to what ZHA provides in HA 2024.03.01 ([@ogajduse](https://github.com/ogajduse))
+- **2025-01-23**:
+
+  :warning: **Breaking Change**:
+
+  Migrate to Zigbee2MQTT MQTT Device Triggers. ([@yarafie](https://github.com/yarafie))
+
+  The `controller_entity` input has been deprecated, and `controller_device` is now mandatory.
+  If you are a Zigbee2MQTT user and plan to update this blueprint, please make sure to remove the `controller_entity` input from your automation config and add the device ID of your controller to the `controller_device` input.
+  To obtain the device ID from your controller, configure the automation from the UI and use the device selector dropdown on the `controller_device` input to select your controller.

--- a/website/docs/blueprints/controllers/ikea_e1766.mdx
+++ b/website/docs/blueprints/controllers/ikea_e1766.mdx
@@ -49,13 +49,7 @@ This integration provides the entity which must be provided to the blueprint in 
   name='Controller Device'
   description='The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.'
   selector='device'
-  required='deCONZ, ZHA'
-/>
-<Input
-  name='Controller Entity'
-  description='The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.'
-  selector='entity'
-  required='Zigbee2MQTT'
+  required='deCONZ, ZHA, Zigbee2MQTT'
 />
 <Input
   name='Helper - Last Controller Event'
@@ -184,3 +178,12 @@ Due to the controller not exposing long press events but only short and release 
 
 - **2021-10-29**: first blueprint version :tada:
 - **2022-08-08**: Optimize characters usage for the `helper_last_controller_event` text input.
+- **2025-01-23**:
+
+  :warning: **Breaking Change**:
+
+  Migrate to Zigbee2MQTT MQTT Device Triggers. ([@yarafie](https://github.com/yarafie))
+
+  The `controller_entity` input has been deprecated, and `controller_device` is now mandatory.
+  If you are a Zigbee2MQTT user and plan to update this blueprint, please make sure to remove the `controller_entity` input from your automation config and add the device ID of your controller to the `controller_device` input.
+  To obtain the device ID from your controller, configure the automation from the UI and use the device selector dropdown on the `controller_device` input to select your controller.

--- a/website/docs/blueprints/controllers/ikea_e1812.mdx
+++ b/website/docs/blueprints/controllers/ikea_e1812.mdx
@@ -51,13 +51,7 @@ This integration provides the entity which must be provided to the blueprint in 
   name='Controller Device'
   description='The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.'
   selector='device'
-  required='deCONZ, ZHA'
-/>
-<Input
-  name='Controller Entity'
-  description='The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.'
-  selector='entity'
-  required='Zigbee2MQTT'
+  required='deCONZ, ZHA, Zigbee2MQTT'
 />
 <Input
   name='Helper - Last Controller Event'
@@ -193,3 +187,12 @@ It's also important to note that the controller doesn't natively support double 
 - **2021-10-26**: Standardize blueprints structure and inputs naming across the whole collection. Improve blueprint documentation. No functionality change.
 - **2022-08-08**: Optimize characters usage for the `helper_last_controller_event` text input.
 - **2025-01-03**: Fixed double press events not triggered due to changes in Home Assistant 2023.5.x.
+- **2025-01-23**:
+
+  :warning: **Breaking Change**:
+
+  Migrate to Zigbee2MQTT MQTT Device Triggers. ([@yarafie](https://github.com/yarafie))
+
+  The `controller_entity` input has been deprecated, and `controller_device` is now mandatory.
+  If you are a Zigbee2MQTT user and plan to update this blueprint, please make sure to remove the `controller_entity` input from your automation config and add the device ID of your controller to the `controller_device` input.
+  To obtain the device ID from your controller, configure the automation from the UI and use the device selector dropdown on the `controller_device` input to select your controller.

--- a/website/docs/blueprints/controllers/ikea_e2001_e2002.mdx
+++ b/website/docs/blueprints/controllers/ikea_e2001_e2002.mdx
@@ -51,13 +51,7 @@ This integration provides the entity which must be provided to the blueprint in 
   name='Controller Device'
   description='The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.'
   selector='device'
-  required='deCONZ, ZHA'
-/>
-<Input
-  name='Controller Entity'
-  description='The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.'
-  selector='entity'
-  required='Zigbee2MQTT'
+  required='deCONZ, ZHA, Zigbee2MQTT'
 />
 <Input
   name='Helper - Last Controller Event'
@@ -294,3 +288,12 @@ If you notice your controller is not behaving as expected please reset the devic
   - (ZHA) Fixed a bug preventing long pressing actions to be triggered. ([@Ivarvdb](https://github.com/Ivarvdb))
   - (Zigbee2MQTT) handle "unknown" state. ([@beardhatcode](https://github.com/beardhatcode))
 - **2025-01-03**: Remove spaces to match new helper format in Home Assistant 2023.5.x. ([@LordSushiPhoenix](https://github.com/LordSushiPhoenix))
+- **2025-01-23**:
+
+  :warning: **Breaking Change**:
+
+  Migrate to Zigbee2MQTT MQTT Device Triggers. ([@yarafie](https://github.com/yarafie))
+
+  The `controller_entity` input has been deprecated, and `controller_device` is now mandatory.
+  If you are a Zigbee2MQTT user and plan to update this blueprint, please make sure to remove the `controller_entity` input from your automation config and add the device ID of your controller to the `controller_device` input.
+  To obtain the device ID from your controller, configure the automation from the UI and use the device selector dropdown on the `controller_device` input to select your controller.

--- a/website/docs/blueprints/controllers/ikea_ictc_g_1.mdx
+++ b/website/docs/blueprints/controllers/ikea_ictc_g_1.mdx
@@ -53,13 +53,7 @@ This integration provides the entity which must be provided to the blueprint in 
   name='Controller Device'
   description='The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.'
   selector='device'
-  required='deCONZ, ZHA'
-/>
-<Input
-  name='Controller Entity'
-  description='The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.'
-  selector='entity'
-  required='Zigbee2MQTT'
+  required='deCONZ, ZHA, Zigbee2MQTT'
 />
 <Input
   name='Helper - Last Controller Event'
@@ -172,3 +166,12 @@ This blueprint provides beta support for controllers integrated with deCONZ, sin
 - **2021-08-02**: Improve inputs documentation and organization
 - **2021-10-26**: Standardize blueprints structure and inputs naming across the whole collection. Improve blueprint documentation. No functionality change.
 - **2022-08-08**: Optimize characters usage for the `helper_last_controller_event` text input.
+- **2025-01-23**:
+
+  :warning: **Breaking Change**:
+
+  Migrate to Zigbee2MQTT MQTT Device Triggers. ([@yarafie](https://github.com/yarafie))
+
+  The `controller_entity` input has been deprecated, and `controller_device` is now mandatory.
+  If you are a Zigbee2MQTT user and plan to update this blueprint, please make sure to remove the `controller_entity` input from your automation config and add the device ID of your controller to the `controller_device` input.
+  To obtain the device ID from your controller, configure the automation from the UI and use the device selector dropdown on the `controller_device` input to select your controller.

--- a/website/docs/blueprints/controllers/osram_ac025xx00nj.mdx
+++ b/website/docs/blueprints/controllers/osram_ac025xx00nj.mdx
@@ -51,13 +51,7 @@ This integration provides the entity which must be provided to the blueprint in 
   name='Controller Device'
   description='The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.'
   selector='device'
-  required='deCONZ, ZHA'
-/>
-<Input
-  name='Controller Entity'
-  description='The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.'
-  selector='entity'
-  required='Zigbee2MQTT'
+  required='deCONZ, ZHA, Zigbee2MQTT'
 />
 <Input
   name='Helper - Last Controller Event'
@@ -243,3 +237,12 @@ This blueprint supports any variant of the Osram SMART+ Switch Mini controller (
 - **2025-01-05**:
   - Updated Actions Mapping as per Z2M [docs](https://www.zigbee2mqtt.io/devices/AC0251100NJ_AC0251600NJ_AC0251700NJ.html#actions) for the device. ([@alexdelprete](https://github.com/alexdelprete))
   - Fix regex for updated helper JSON serialization starting from Home Assistant 2023.5.0.
+- **2025-01-23**:
+
+  :warning: **Breaking Change**:
+
+  Migrate to Zigbee2MQTT MQTT Device Triggers. ([@yarafie](https://github.com/yarafie))
+
+  The `controller_entity` input has been deprecated, and `controller_device` is now mandatory.
+  If you are a Zigbee2MQTT user and plan to update this blueprint, please make sure to remove the `controller_entity` input from your automation config and add the device ID of your controller to the `controller_device` input.
+  To obtain the device ID from your controller, configure the automation from the UI and use the device selector dropdown on the `controller_device` input to select your controller.

--- a/website/docs/blueprints/controllers/philips_324131092621.mdx
+++ b/website/docs/blueprints/controllers/philips_324131092621.mdx
@@ -51,13 +51,7 @@ This integration provides the entity which must be provided to the blueprint in 
   name='Controller Device'
   description='The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.'
   selector='device'
-  required='deCONZ, ZHA'
-/>
-<Input
-  name='Controller Entity'
-  description='The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.'
-  selector='entity'
-  required='Zigbee2MQTT'
+  required='deCONZ, ZHA, Zigbee2MQTT'
 />
 <Input
   name='Helper - Last Controller Event'
@@ -291,3 +285,12 @@ It's also important to note that the controller doesn't natively support double 
 - **2021-10-26**: Standardize blueprints structure and inputs naming across the whole collection. Improve blueprint documentation. No functionality change.
 - **2021-11-19**: Fix controller events not being recognized when using ZHA.
 - **2022-08-08**: Optimize characters usage for the `helper_last_controller_event` text input.
+- **2025-01-23**:
+
+  :warning: **Breaking Change**:
+
+  Migrate to Zigbee2MQTT MQTT Device Triggers. ([@yarafie](https://github.com/yarafie))
+
+  The `controller_entity` input has been deprecated, and `controller_device` is now mandatory.
+  If you are a Zigbee2MQTT user and plan to update this blueprint, please make sure to remove the `controller_entity` input from your automation config and add the device ID of your controller to the `controller_device` input.
+  To obtain the device ID from your controller, configure the automation from the UI and use the device selector dropdown on the `controller_device` input to select your controller.

--- a/website/docs/blueprints/controllers/philips_8718699693985.mdx
+++ b/website/docs/blueprints/controllers/philips_8718699693985.mdx
@@ -51,13 +51,7 @@ This integration provides the entity which must be provided to the blueprint in 
   name='Controller Device'
   description='The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.'
   selector='device'
-  required='deCONZ, ZHA'
-/>
-<Input
-  name='Controller Entity'
-  description='The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.'
-  selector='entity'
-  required='Zigbee2MQTT'
+  required='deCONZ, ZHA, Zigbee2MQTT'
 />
 <Input
   name='Helper - Last Controller Event'
@@ -158,3 +152,12 @@ It's also important to note that the controller doesn't natively support double 
 - **2025-01-05**:
   - Added support for Zigbee2MQTT. ([@alexdelprete](https://github.com/alexdelprete))
   - Fix regex for updated helper JSON serialization starting from Home Assistant 2023.5.0.
+- **2025-01-23**:
+
+  :warning: **Breaking Change**:
+
+  Migrate to Zigbee2MQTT MQTT Device Triggers. ([@yarafie](https://github.com/yarafie))
+
+  The `controller_entity` input has been deprecated, and `controller_device` is now mandatory.
+  If you are a Zigbee2MQTT user and plan to update this blueprint, please make sure to remove the `controller_entity` input from your automation config and add the device ID of your controller to the `controller_device` input.
+  To obtain the device ID from your controller, configure the automation from the UI and use the device selector dropdown on the `controller_device` input to select your controller.

--- a/website/docs/blueprints/controllers/philips_929002398602.mdx
+++ b/website/docs/blueprints/controllers/philips_929002398602.mdx
@@ -50,13 +50,7 @@ This integration provides the entity which must be provided to the blueprint in 
   name='Controller Device'
   description='The controller device to use for the automation. Choose a value only if the remote is integrated with ZHA.'
   selector='device'
-  required='ZHA'
-/>
-<Input
-  name='Controller Entity'
-  description='The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.'
-  selector='entity'
-  required='Zigbee2MQTT'
+  required='ZHA, Zigbee2MQTT'
 />
 <Input
   name='Helper - Last Controller Event'
@@ -271,3 +265,12 @@ It's also important to note that the controller doesn't natively support double 
 - **2021-11-21**: first blueprint version :tada:
 - **2022-07-22**: Fix short press actions not being triggered by quick button clicks.
 - **2022-08-08**: Optimize characters usage for the `helper_last_controller_event` text input.
+- **2025-01-23**:
+
+  :warning: **Breaking Change**:
+
+  Migrate to Zigbee2MQTT MQTT Device Triggers. ([@yarafie](https://github.com/yarafie))
+
+  The `controller_entity` input has been deprecated, and `controller_device` is now mandatory.
+  If you are a Zigbee2MQTT user and plan to update this blueprint, please make sure to remove the `controller_entity` input from your automation config and add the device ID of your controller to the `controller_device` input.
+  To obtain the device ID from your controller, configure the automation from the UI and use the device selector dropdown on the `controller_device` input to select your controller.

--- a/website/docs/blueprints/controllers/sonoff_snzb01.mdx
+++ b/website/docs/blueprints/controllers/sonoff_snzb01.mdx
@@ -47,13 +47,7 @@ This integration provides the entity which must be provided to the blueprint in 
   name='Controller Device'
   description='The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.'
   selector='device'
-  required='deCONZ, ZHA'
-/>
-<Input
-  name='Controller Entity'
-  description='The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.'
-  selector='entity'
-  required='Zigbee2MQTT'
+  required='deCONZ, ZHA, Zigbee2MQTT'
 />
 <Input
   name='Helper - Last Controller Event'
@@ -133,3 +127,12 @@ Please note that the long press action for this controller is triggered after th
 
 - **2022-07-30**: first blueprint version :tada:
 - **2022-08-08**: Optimize characters usage for the `helper_last_controller_event` text input.
+- **2025-01-23**:
+
+  :warning: **Breaking Change**:
+
+  Migrate to Zigbee2MQTT MQTT Device Triggers. ([@yarafie](https://github.com/yarafie))
+
+  The `controller_entity` input has been deprecated, and `controller_device` is now mandatory.
+  If you are a Zigbee2MQTT user and plan to update this blueprint, please make sure to remove the `controller_entity` input from your automation config and add the device ID of your controller to the `controller_device` input.
+  To obtain the device ID from your controller, configure the automation from the UI and use the device selector dropdown on the `controller_device` input to select your controller.

--- a/website/docs/blueprints/controllers/xiaomi_wxcjkg11lm.mdx
+++ b/website/docs/blueprints/controllers/xiaomi_wxcjkg11lm.mdx
@@ -49,13 +49,7 @@ This integration provides the entity which must be provided to the blueprint in 
   name='Controller Device'
   description='The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.'
   selector='device'
-  required='deCONZ, ZHA'
-/>
-<Input
-  name='Controller Entity'
-  description='The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.'
-  selector='entity'
-  required='Zigbee2MQTT'
+  required='deCONZ, ZHA, Zigbee2MQTT'
 />
 <Input
   name='Helper - Last Controller Event'
@@ -195,3 +189,12 @@ The `helper_last_controller_event` (Helper - Last Controller Event) input serves
 
 - **2021-12-03**: first blueprint version :tada:
 - **2022-08-08**: Optimize characters usage for the `helper_last_controller_event` text input.
+- **2025-01-23**:
+
+  :warning: **Breaking Change**:
+
+  Migrate to Zigbee2MQTT MQTT Device Triggers. ([@yarafie](https://github.com/yarafie))
+
+  The `controller_entity` input has been deprecated, and `controller_device` is now mandatory.
+  If you are a Zigbee2MQTT user and plan to update this blueprint, please make sure to remove the `controller_entity` input from your automation config and add the device ID of your controller to the `controller_device` input.
+  To obtain the device ID from your controller, configure the automation from the UI and use the device selector dropdown on the `controller_device` input to select your controller.

--- a/website/docs/blueprints/controllers/xiaomi_wxcjkg12lm.mdx
+++ b/website/docs/blueprints/controllers/xiaomi_wxcjkg12lm.mdx
@@ -49,13 +49,7 @@ This integration provides the entity which must be provided to the blueprint in 
   name='Controller Device'
   description='The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.'
   selector='device'
-  required='deCONZ, ZHA'
-/>
-<Input
-  name='Controller Entity'
-  description='The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.'
-  selector='entity'
-  required='Zigbee2MQTT'
+  required='deCONZ, ZHA, Zigbee2MQTT'
 />
 <Input
   name='Helper - Last Controller Event'
@@ -291,3 +285,12 @@ The `helper_last_controller_event` (Helper - Last Controller Event) input serves
 
 - **2021-12-03**: first blueprint version :tada:
 - **2022-08-08**: Optimize characters usage for the `helper_last_controller_event` text input.
+- **2025-01-23**:
+
+  :warning: **Breaking Change**:
+
+  Migrate to Zigbee2MQTT MQTT Device Triggers. ([@yarafie](https://github.com/yarafie))
+
+  The `controller_entity` input has been deprecated, and `controller_device` is now mandatory.
+  If you are a Zigbee2MQTT user and plan to update this blueprint, please make sure to remove the `controller_entity` input from your automation config and add the device ID of your controller to the `controller_device` input.
+  To obtain the device ID from your controller, configure the automation from the UI and use the device selector dropdown on the `controller_device` input to select your controller.

--- a/website/docs/blueprints/controllers/xiaomi_wxcjkg13lm.mdx
+++ b/website/docs/blueprints/controllers/xiaomi_wxcjkg13lm.mdx
@@ -49,13 +49,7 @@ This integration provides the entity which must be provided to the blueprint in 
   name='Controller Device'
   description='The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.'
   selector='device'
-  required='deCONZ, ZHA'
-/>
-<Input
-  name='Controller Entity'
-  description='The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.'
-  selector='entity'
-  required='Zigbee2MQTT'
+  required='deCONZ, ZHA, Zigbee2MQTT'
 />
 <Input
   name='Helper - Last Controller Event'
@@ -387,3 +381,12 @@ The `helper_last_controller_event` (Helper - Last Controller Event) input serves
 
 - **2021-12-03**: first blueprint version :tada:
 - **2022-08-08**: Optimize characters usage for the `helper_last_controller_event` text input.
+- **2025-01-23**:
+
+  :warning: **Breaking Change**:
+
+  Migrate to Zigbee2MQTT MQTT Device Triggers. ([@yarafie](https://github.com/yarafie))
+
+  The `controller_entity` input has been deprecated, and `controller_device` is now mandatory.
+  If you are a Zigbee2MQTT user and plan to update this blueprint, please make sure to remove the `controller_entity` input from your automation config and add the device ID of your controller to the `controller_device` input.
+  To obtain the device ID from your controller, configure the automation from the UI and use the device selector dropdown on the `controller_device` input to select your controller.

--- a/website/docs/blueprints/controllers/xiaomi_wxkg11lm.mdx
+++ b/website/docs/blueprints/controllers/xiaomi_wxkg11lm.mdx
@@ -49,13 +49,7 @@ This integration provides the entity which must be provided to the blueprint in 
   name='Controller Device'
   description='The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA.'
   selector='device'
-  required='deCONZ, ZHA'
-/>
-<Input
-  name='Controller Entity'
-  description='The action sensor of the controller to use for the automation. Choose a value only if the remote is integrated with Zigbee2MQTT.'
-  selector='entity'
-  required='Zigbee2MQTT'
+  required='deCONZ, ZHA, Zigbee2MQTT'
 />
 <Input
   name='Helper - Last Controller Event'
@@ -150,3 +144,12 @@ Please note that this blueprint provides deCONZ support for the 2018 version of 
 
 - **2022-07-22**: first blueprint version :tada:
 - **2022-08-08**: Optimize characters usage for the `helper_last_controller_event` text input.
+- **2025-01-23**:
+
+  :warning: **Breaking Change**:
+
+  Migrate to Zigbee2MQTT MQTT Device Triggers. ([@yarafie](https://github.com/yarafie))
+
+  The `controller_entity` input has been deprecated, and `controller_device` is now mandatory.
+  If you are a Zigbee2MQTT user and plan to update this blueprint, please make sure to remove the `controller_entity` input from your automation config and add the device ID of your controller to the `controller_device` input.
+  To obtain the device ID from your controller, configure the automation from the UI and use the device selector dropdown on the `controller_device` input to select your controller.

--- a/website/docs/blueprints/hooks/cover.mdx
+++ b/website/docs/blueprints/hooks/cover.mdx
@@ -42,12 +42,6 @@ This integration provides the entity which represents a cover in Home Assistant.
   required
 />
 <Input
-  name='Controller Entity'
-  description='The controller entity which will control the Cover. Choose a value only if the integration used to connect the controller to Home Assistant exposes it as an Entity. This value should match the one specified in the corresponding Controller automation.'
-  selector='entity'
-  required
-/>
-<Input
   name='Controller model'
   description='The model for the controller used in this automation. Choose a value from the list of supported controllers.'
   selector='select'
@@ -90,3 +84,12 @@ If you want to link multiple covers to the same controller you can either use [C
 - **2021-12-03**: Add support for Xiaomi WXCJKG11LM, WXCJKG12LM, WXCJKG13LM.
 - **2022-07-22**: Add support for Xiaomi WXKG11LM.
 - **2022-07-30**: Add support for SONOFF SNZB-01.
+- **2025-01-23**:
+
+  :warning: **Breaking Change**:
+
+  Migrate to Zigbee2MQTT MQTT Device Triggers. ([@yarafie](https://github.com/yarafie))
+
+  The `controller_entity` input has been deprecated, and `controller_device` is now mandatory.
+  If you are a Zigbee2MQTT user and plan to update this blueprint, please make sure to remove the `controller_entity` input from your automation config and add the device ID of your controller to the `controller_device` input.
+  To obtain the device ID from your controller, configure the automation from the UI and use the device selector dropdown on the `controller_device` input to select your controller.

--- a/website/docs/blueprints/hooks/light.mdx
+++ b/website/docs/blueprints/hooks/light.mdx
@@ -42,12 +42,6 @@ This integration provides the entity which represents a light in Home Assistant.
   required
 />
 <Input
-  name='Controller Entity'
-  description='The controller entity which will control the Light. Choose a value only if the integration used to connect the controller to Home Assistant exposes it as an Entity. This value should match the one specified in the corresponding Controller automation.'
-  selector='entity'
-  required
-/>
-<Input
   name='Controller model'
   description='The model for the controller used in this automation. Choose a value from the list of supported controllers.'
   selector='select'
@@ -170,3 +164,12 @@ If you want to link multiple lights to the same controller you can either use [L
 - **2021-12-05**: Added secondary mapping for IKEA E2001/E2002
 - **2022-07-22**: Add support for Xiaomi WXKG11LM.
 - **2022-07-30**: Add support for SONOFF SNZB-01.
+- **2025-01-23**:
+
+  :warning: **Breaking Change**:
+
+  Migrate to Zigbee2MQTT MQTT Device Triggers. ([@yarafie](https://github.com/yarafie))
+
+  The `controller_entity` input has been deprecated, and `controller_device` is now mandatory.
+  If you are a Zigbee2MQTT user and plan to update this blueprint, please make sure to remove the `controller_entity` input from your automation config and add the device ID of your controller to the `controller_device` input.
+  To obtain the device ID from your controller, configure the automation from the UI and use the device selector dropdown on the `controller_device` input to select your controller.

--- a/website/docs/blueprints/hooks/media_player.mdx
+++ b/website/docs/blueprints/hooks/media_player.mdx
@@ -42,12 +42,6 @@ This integration provides the entity which represents a media player in Home Ass
   required
 />
 <Input
-  name='Controller Entity'
-  description='The controller entity which will control the Media Player. Choose a value only if the integration used to connect the controller to Home Assistant exposes it as an Entity. This value should match the one specified in the corresponding Controller automation.'
-  selector='entity'
-  required
-/>
-<Input
   name='Controller model'
   description='The model for the controller used in this automation. Choose a value from the list of supported controllers.'
   selector='select'
@@ -117,3 +111,12 @@ Not all media players support the customization of the number of steps for volum
 - **2021-12-03**: Add support for Xiaomi WXCJKG11LM, WXCJKG12LM, WXCJKG13LM.
 - **2022-07-22**: Add support for Xiaomi WXKG11LM.
 - **2022-07-30**: Add support for SONOFF SNZB-01.
+- **2025-01-23**:
+
+  :warning: **Breaking Change**:
+
+  Migrate to Zigbee2MQTT MQTT Device Triggers. ([@yarafie](https://github.com/yarafie))
+
+  The `controller_entity` input has been deprecated, and `controller_device` is now mandatory.
+  If you are a Zigbee2MQTT user and plan to update this blueprint, please make sure to remove the `controller_entity` input from your automation config and add the device ID of your controller to the `controller_device` input.
+  To obtain the device ID from your controller, configure the automation from the UI and use the device selector dropdown on the `controller_device` input to select your controller.


### PR DESCRIPTION
Thank you for taking the time to work on a Pull Request. Your contribution is really appreciated! :tada:
**Please don't delete any part of the template**, since keeping the provided structure will help maintainers to review your work more rapidly.

Sections marked as \* are required and need to be filled in.

Migrate to Zigbee2MQTT MQTT Device Triggers.

## Breaking change

:warning: **Breaking Change**:

Migrate to Zigbee2MQTT MQTT Device Triggers. ([@yarafie](https://github.com/yarafie))

The `controller_entity` input has been deprecated, and `controller_device` is now mandatory.
 
If you are a Zigbee2MQTT user and plan to update this blueprint, please make sure to remove the `controller_entity` input from your automation config and add the device ID of your controller to the `controller_device` input.

To obtain the device ID from your controller, configure the automation from the UI and use the device selector dropdown on the `controller_device` input to select your controller.

Additionally you need to be using no less than Home Assistant Version 2024.10.0

## Proposed change\*

With zigbee2mqtt version 2.x, legacy features are planned to be removed and are disabled by default if you have updated to zigbee2mqtt version 2.x.

Further information can be found in in the zigbee2mqtt discussion link  below:

Zigbee2MQTT 2.0.0 breaking changes

https://github.com/Koenkk/zigbee2mqtt/discussions/24198

This Blueprint has been updated to make use of MQTT device triggers and deprecate the legacy entity action sensors (sensor.*_action). If you have legacy or even the experimental entities enabled in zigbee2mqtt (i.e. set to true) in your zigbee2mqtt configuration the blueprint should still work as it does not use them.

## Checklist\*

- [Y] I followed sections of the [Contribution Guidelines](https://github.com/EPMatt/awesome-ha-blueprints/blob/main/CONTRIBUTING.md) relevant to changes I'm proposing.
- [Y] I properly tested proposed changes on my system and confirm that they are working as expected.
- [Y] I formatted files with Prettier using the command `npm run format` before submitting my Pull Request.
