### PR TITLE
feat(docs): Auto-gen automation and hooks blueprint lists, UI improvements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,19 +34,19 @@ Awesome! Follow these steps to contribute your new blueprint to this project:
 5. **Copy the example blueprint folder**:
 
    ```sh
-   cp -r blueprints/automation/_example blueprints/automation/my-new-blueprint
+   cp -r blueprints/automation/example blueprints/automation/my-new-blueprint
    ```
 
 6. **Inside your blueprint folder** (blueprints/automation/my-new-blueprint):
 
-   - **Rename** \_example.yaml to match your blueprint name.
+   - **Rename** \example.yaml to match your blueprint name.
    - **Write your blueprint code** inside the renamed .yaml file. Ensure you follow the [Blueprint Guidelines](#blueprint-guidelines).
 
 7. **Update the blueprint docs** in the website/docs/blueprints section:
 
    - Copy the example documentation file in a new folder for the blueprint:
      ```sh
-     cp website/docs/blueprints/automation/_example.mdx website/docs/blueprints/automation/my-new-blueprint.mdx
+     cp website/docs/blueprints/automation/example.mdx website/docs/blueprints/automation/my-new-blueprint.mdx
      ```
    - Add relevant documentation for your blueprint.
    - Make sure to add an entry to the **Changelog** at the bottom of the page.

--- a/blueprints/automation/example/example.yaml
+++ b/blueprints/automation/example/example.yaml
@@ -5,7 +5,7 @@ blueprint:
     A description for the blueprint
 
     Version: yyyy.mm.dd
-  source_url: https://github.com/EPMatt/awesome-ha-blueprints/blob/main/blueprints/automation/_example/_example.yaml
+  source_url: https://github.com/EPMatt/awesome-ha-blueprints/blob/main/blueprints/automation/example/example.yaml
   domain: automation
   input:
     example_input_boolean:

--- a/website/docs/blueprints/automation.mdx
+++ b/website/docs/blueprints/automation.mdx
@@ -3,11 +3,8 @@ title: Automations
 description: Generic automation blueprints which cover different use-cases.
 ---
 
+import { BlueprintsList } from '@site/src/components/blueprints_docs'
+
 This category groups generic automation blueprints covering a wide range of different use-cases, not part of the [Controllers](controllers)-[Hooks](hooks) ecosystem.
 
-| Name                                                                                                                    | Description                                                                                                                                                                                              |
-| ----------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [Send a mobile notification when add-on update is available](/docs/blueprints/automation/addon_update_notification)     | Send a notification to the provided mobile devices whenever an update for the given Home Assistant add-on is available.                                                                                  |
-| [On-Off schedule with state persistence](/docs/blueprints/automation/on_off_schedule_state_persistence)                 | A simple on-off schedule, with the addition of state persistence across disruptive events, making sure the target device is always in the expected state.                                                |
-| [Send Web UI persistent notifications to Mobile Devices](/docs/blueprints/automation/persistent_notification_to_mobile) | Send Web UI persistent notifications with the provided ID to the specified Mobile Devices.                                                                                                               |
-| [Simple Safe Scheduler](/docs/blueprints/automation/simple_safe_scheduler)                                              | A simple scheduler which executes a certain action at a given time, checking and eventually re-executing the action if the automation did not run at the expected time (e.g. due to a disruptive event). |
+<BlueprintsList category='automation' />

--- a/website/docs/blueprints/automation/example.mdx
+++ b/website/docs/blueprints/automation/example.mdx
@@ -10,7 +10,7 @@ import {
   ImportCard,
 } from '/src/components/blueprints_docs'
 
-<ImportCard id='_example' category='automation' />
+<ImportCard id='example' category='automation' />
 
 ## Description
 
@@ -36,7 +36,7 @@ You must have this integration enabled on your system to run the automation. Thi
 
 ## Inputs
 
-<Inputs category='automation' id='_example' />
+<Inputs category='automation' id='example' />
 
 ## Additional Notes
 

--- a/website/docs/blueprints/controllers.mdx
+++ b/website/docs/blueprints/controllers.mdx
@@ -3,11 +3,12 @@ title: Controllers
 description: Integrate a wide set of controllers in Home Assistant and provide an easy to use interface to run custom actions on a controller event.
 ---
 
+import { BlueprintsList } from '@site/src/components/blueprints_docs'
+import Image from '/src/components/ControllerImage'
+
 :::tip
 Controllers are part of the **Controllers-Hooks Ecosystem**. You can read more about this topic [here](/docs/controllers-hooks-ecosystem).
 :::
-
-import Image from '/src/components/ControllerImage'
 
 **Controllers** are blueprints which allow to easily integrate a wide range of controllers (wall switches, remotes, dimmers, etc.) and use them to run a set of actions when interacting with them. They consist in a practical abstraction layer for easily building controlled-based automations without worrying about the handling of RAW controller events, and the integration used to connect controllers to Home Assistant (Zigbee2MQTT, ZHA, deCONZ, etc.).
 
@@ -19,25 +20,4 @@ Currently **17** devices are supported from **6** different vendors.
 
 _Can't find the controller you're looking for in this list? [Submit a new blueprint proposal for your controller here.](https://github.com/EPMatt/awesome-ha-blueprints/issues/new?assignees=&labels=blueprint%2Cnew%2Ccontroller&template=new-controller-support.md&title=New+Controller+-+)_
 
-| Manufacturer | Model                                                               | Description                                       | Integrations           | Picture                                                                             |
-| ------------ | ------------------------------------------------------------------- | ------------------------------------------------- | ---------------------- | ----------------------------------------------------------------------------------- |
-| Aqara        | [WXKG11LM](/docs/blueprints/controllers/xiaomi_wxkg11lm)            | Aqara WXKG11LM Wireless Mini Switch               | deCONZ,ZHA,Zigbee2MQTT | <Image>![xiaomi_wxkg11lm](/img/controllers/xiaomi_wxkg11lm.png)</Image>             |
-| IKEA         | [E1524/E1810](/docs/blueprints/controllers/ikea_e1524_e1810)        | IKEA E1524/E1810 TRÅDFRI Wireless 5-Button Remote | deCONZ,ZHA,Zigbee2MQTT | <Image>![ikea_e1524_e1810](/img/controllers/ikea_e1524_e1810.png)</Image>           |
-| IKEA         | [E1743](/docs/blueprints/controllers/ikea_e1743)                    | IKEA E1743 TRÅDFRI On/Off Switch & Dimmer         | deCONZ,ZHA,Zigbee2MQTT | <Image>![ikea_e1743](/img/controllers/ikea_e1743.png)</Image>                       |
-| IKEA         | [E1744](/docs/blueprints/controllers/ikea_e1744)                    | IKEA E1744 SYMFONISK Rotary Remote                | deCONZ,ZHA,Zigbee2MQTT | <Image>![ikea_e1744](/img/controllers/ikea_e1744.png)</Image>                       |
-| IKEA         | [E1766](/docs/blueprints/controllers/ikea_e1766)                    | IKEA E1766 TRÅDFRI Open/Close Remote              | deCONZ,ZHA,Zigbee2MQTT | <Image>![ikea_e1766](/img/controllers/ikea_e1766.png)</Image>                       |
-| IKEA         | [E1812](/docs/blueprints/controllers/ikea_e1812)                    | IKEA E1812 TRÅDFRI Shortcut button                | deCONZ,ZHA,Zigbee2MQTT | <Image>![ikea_e1812](/img/controllers/ikea_e1812.png)</Image>                       |
-| IKEA         | [E2001/E2002](/docs/blueprints/controllers/ikea_e2001_e2002)        | IKEA E2001/E2002 STYRBAR Remote control           | deCONZ,ZHA,Zigbee2MQTT | <Image>![ikea_e2001_e2002](/img/controllers/ikea_e2001_e2002.png)</Image>           |
-| IKEA         | [E2201](/docs/blueprints/controllers/ikea_e2201)                    | IKEA E2201 RODRET Dimmer                          | deCONZ,ZHA,Zigbee2MQTT | <Image>![ikea_e2201](/img/controllers/ikea_e2201.png)</Image>                       |
-| IKEA         | [ICTC-G-1](/docs/blueprints/controllers/ikea_ictc_g_1)              | IKEA ICTC-G-1 TRÅDFRI wireless dimmer             | deCONZ,ZHA,Zigbee2MQTT | <Image>![ikea_ictc_g_1](/img/controllers/ikea_ictc_g_1.png)</Image>                 |
-| OSRAM        | [AC025XX00NJ](/docs/blueprints/controllers/osram_ac025xx00nj)       | OSRAM AC025XX00NJ SMART+ Switch Mini              | deCONZ,ZHA,Zigbee2MQTT | <Image>![osram_ac025xx00nj](/img/controllers/osram_ac025xx00nj.png)</Image>         |
-| Philips      | [324131092621](/docs/blueprints/controllers/philips_324131092621)   | Philips 324131092621 Hue Dimmer switch            | deCONZ,ZHA,Zigbee2MQTT | <Image>![philips_324131092621](/img/controllers/philips_324131092621.png)</Image>   |
-| Philips      | [8718699693985](/docs/blueprints/controllers/philips_8718699693985) | Philips 8718699693985 Hue Smart Button            | deCONZ,ZHA,Zigbee2MQTT | <Image>![philips_8718699693985](/img/controllers/philips_8718699693985.png)</Image> |
-| Philips      | [929002398602](/docs/blueprints/controllers/philips_929002398602)   | Philips 929002398602 Hue Dimmer switch v2         | ZHA,Zigbee2MQTT        | <Image>![philips_929002398602](/img/controllers/philips_929002398602.png)</Image>   |
-| SONOFF       | [SNZB-01](/docs/blueprints/controllers/sonoff_snzb01)               | SONOFF SNZB-01 Wireless Switch                    | deCONZ,ZHA,Zigbee2MQTT | <Image>![sonoff_snzb01](/img/controllers/sonoff_snzb01.png)</Image>                 |
-| Xiaomi       | [WXCJKG11LM](/docs/blueprints/controllers/xiaomi_wxcjkg11lm)        | Xiaomi WXCJKG11LM Aqara Opple 2 button remote     | deCONZ,ZHA,Zigbee2MQTT | <Image>![xiaomi_wxcjkg11lm](/img/controllers/xiaomi_wxcjkg11lm.png)</Image>         |
-| Xiaomi       | [WXCJKG12LM](/docs/blueprints/controllers/xiaomi_wxcjkg12lm)        | Xiaomi WXCJKG12LM Aqara Opple 4 button remote     | deCONZ,ZHA,Zigbee2MQTT | <Image>![xiaomi_wxcjkg12lm](/img/controllers/xiaomi_wxcjkg12lm.png)</Image>         |
-| Xiaomi       | [WXCJKG13LM](/docs/blueprints/controllers/xiaomi_wxcjkg13lm)        | Xiaomi WXCJKG13LM Aqara Opple 6 button remote     | deCONZ,ZHA,Zigbee2MQTT | <Image>![xiaomi_wxcjkg13lm](/img/controllers/xiaomi_wxcjkg13lm.png)</Image>         |
-| Xiaomi       | [WXKG01LM](/docs/blueprints/controllers/xiaomi_wxkg11lm)            | Xiaomi WXKG01LM Mi Wireless Switch                | deCONZ,ZHA,Zigbee2MQTT | <Image>![xiaomi_wxkg01lm](/img/controllers/xiaomi_wxkg01lm.png)</Image>             |
-
-_Can't find the controller you're looking for in this list? [Submit a new blueprint proposal for your controller here.](https://github.com/EPMatt/awesome-ha-blueprints/issues/new?assignees=&labels=blueprint%2Cnew%2Ccontroller&template=new-controller-support.md&title=New+Controller+-+)_
+<BlueprintsList category='controllers' />

--- a/website/docs/blueprints/hooks.mdx
+++ b/website/docs/blueprints/hooks.mdx
@@ -3,6 +3,8 @@ title: Hooks
 description: Provide common functionality to any of the supported controllers. Build controller-based automations for lights, media players, covers and much more in just a few clicks.
 ---
 
+import { BlueprintsList } from '@site/src/components/blueprints_docs'
+
 :::tip
 Hooks are part of the **Controllers-Hooks Ecosystem**. You can read more about this topic [here](/docs/controllers-hooks-ecosystem).
 :::
@@ -11,8 +13,4 @@ Hooks are part of the **Controllers-Hooks Ecosystem**. You can read more about t
 
 While Controllers are responsible for integrating the hardware and exposing an abstract interface to the user, Hooks can link to this interface and listen for events fired by a controller, taking care of providing the actual control functionality for common use cases.
 
-| Name                                                | Description                                                                                                                                                            |
-| --------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [Cover](/docs/blueprints/hooks/cover)               | This Hook blueprint allows to build a controller-based automation to control a cover. Supports opening, closing and tilting the cover.                                 |
-| [Light](/docs/blueprints/hooks/light)               | This Hook blueprint allows to build a controller-based automation to control a light. Supports brightness and color control both for white temperature and rgb lights. |
-| [Media Player](/docs/blueprints/hooks/media_player) | This Hook blueprint allows to build a controller-based automation to control a media player. Supports volume setting, play/pause and track selection.                  |
+<BlueprintsList category='hooks' />

--- a/website/docs/contributing.mdx
+++ b/website/docs/contributing.mdx
@@ -39,19 +39,19 @@ Awesome! Follow these steps to contribute your new blueprint to this project:
 5. **Copy the example blueprint folder**:
 
    ```sh
-   cp -r blueprints/automation/_example blueprints/automation/my-new-blueprint
+   cp -r blueprints/automation/example blueprints/automation/my-new-blueprint
    ```
 
 6. **Inside your blueprint folder** (blueprints/automation/my-new-blueprint):
 
-   - **Rename** \_example.yaml to match your blueprint name.
+   - **Rename** \example.yaml to match your blueprint name.
    - **Write your blueprint code** inside the renamed .yaml file. Ensure you follow the [Blueprint Guidelines](#blueprint-guidelines).
 
 7. **Update the blueprint docs** in the website/docs/blueprints section:
 
    - Copy the example documentation file in a new folder for the blueprint:
      ```sh
-     cp website/docs/blueprints/automation/_example.mdx website/docs/blueprints/automation/my-new-blueprint.mdx
+     cp website/docs/blueprints/automation/example.mdx website/docs/blueprints/automation/my-new-blueprint.mdx
      ```
    - Add relevant documentation for your blueprint.
    - Make sure to add an entry to the **Changelog** at the bottom of the page.

--- a/website/src/components/blueprints_docs/BlueprintItem.tsx
+++ b/website/src/components/blueprints_docs/BlueprintItem.tsx
@@ -1,5 +1,6 @@
-import React from 'react'
+import React, { useState } from 'react'
 import Link from '@docusaurus/Link'
+import { ChevronRight } from 'react-bootstrap-icons'
 
 interface BlueprintItemProps {
   id: string
@@ -14,13 +15,50 @@ const BlueprintItem: React.FC<BlueprintItemProps> = ({
   description,
   category,
 }) => {
+  const [isHovered, setIsHovered] = useState(false)
+
+  const cardStyle: React.CSSProperties = {
+    width: '100%',
+    minHeight: '200px',
+    boxShadow: isHovered
+      ? '0 4px 8px rgba(0, 0, 0, 0.3)'
+      : '0 2px 4px rgba(0, 0, 0, 0.2)',
+    padding: '16px',
+    color: 'var(--ifm-font-color-base, #000)',
+    cursor: 'pointer',
+    transition: 'box-shadow 0.3s ease',
+  }
+
+  const footerStyle: React.CSSProperties = {
+    display: 'flex',
+    justifyContent: 'flex-end',
+    marginTop: '8px',
+    transition: 'transform 0.3s ease-out',
+    transform: isHovered ? 'translateX(6px)' : 'translateX(0)',
+  }
+
   return (
-    <tr>
-      <td>
-        <Link to={`/docs/blueprints/${category}/${id}`}>{title}</Link>
-      </td>
-      <td>{description}</td>
-    </tr>
+    <Link
+      to={`/docs/blueprints/${category}/${id}`}
+      style={{ textDecoration: 'none' }}
+    >
+      <div
+        className='card'
+        style={cardStyle}
+        onMouseEnter={() => setIsHovered(true)}
+        onMouseLeave={() => setIsHovered(false)}
+      >
+        <div className='card__header'>
+          <h3>{title}</h3>
+        </div>
+        <div className='card__body'>
+          <p>{description}</p>
+        </div>
+        <div className='card__footer' style={footerStyle}>
+          <ChevronRight size={20} />
+        </div>
+      </div>
+    </Link>
   )
 }
 

--- a/website/src/components/blueprints_docs/BlueprintItem.tsx
+++ b/website/src/components/blueprints_docs/BlueprintItem.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import Link from '@docusaurus/Link'
+
+interface BlueprintItemProps {
+  id: string
+  title: string
+  description: string
+  category: string
+}
+
+const BlueprintItem: React.FC<BlueprintItemProps> = ({
+  id,
+  title,
+  description,
+  category,
+}) => {
+  return (
+    <tr>
+      <td>
+        <Link to={`/docs/blueprints/${category}/${id}`}>{title}</Link>
+      </td>
+      <td>{description}</td>
+    </tr>
+  )
+}
+
+export default BlueprintItem

--- a/website/src/components/blueprints_docs/BlueprintsList.tsx
+++ b/website/src/components/blueprints_docs/BlueprintsList.tsx
@@ -1,0 +1,105 @@
+import React, { useEffect, useState } from 'react'
+import Link from '@docusaurus/Link'
+import { docsContext } from '../../utils'
+import BlueprintItem from './BlueprintItem'
+
+interface BlueprintsListProps {
+  category: string
+}
+
+interface Blueprint {
+  id: string
+  title: string
+  description: string
+}
+
+const BlueprintsList: React.FC<BlueprintsListProps> = ({ category }) => {
+  const [blueprints, setBlueprints] = useState<Blueprint[]>([])
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    try {
+      // Get all MDX files in the specified category
+      const keys = (docsContext as any).keys()
+      const categoryPath = `./${category}/`
+
+      // Filter to just the blueprints in this category, excluding example files
+      const blueprintKeys = keys.filter((key: string) => {
+        return (
+          key.startsWith(categoryPath) &&
+          !key.includes('/_example.mdx') &&
+          !key.endsWith(`/${category}.mdx`)
+        ) // Exclude the category index file
+      })
+
+      // Process each blueprint
+      const blueprintsData = blueprintKeys.map((key: string) => {
+        // Extract ID from the path (remove .mdx extension and category prefix)
+        const id = key.replace(categoryPath, '').replace('.mdx', '')
+
+        // Get the MDX module and extract frontmatter
+        const mdxModule = docsContext(key)
+        const { title, description } = mdxModule.frontMatter
+
+        return {
+          id,
+          title: title || id,
+          description: description || '',
+        }
+      })
+
+      // Sort blueprints alphabetically by title
+      blueprintsData.sort((a, b) => a.title.localeCompare(b.title))
+
+      setBlueprints(blueprintsData)
+      setError(null)
+    } catch (e) {
+      console.error('Error loading blueprints:', e)
+      setBlueprints([])
+      setError(
+        'Failed to load blueprints. Please check the console for more details.',
+      )
+    }
+  }, [category])
+
+  if (error) {
+    return (
+      <div className='admonition admonition-danger alert alert--danger'>
+        <div className='admonition-heading'>
+          <h5>Error loading blueprints</h5>
+        </div>
+        <div className='admonition-content'>
+          <p>{error}</p>
+        </div>
+      </div>
+    )
+  }
+
+  if (blueprints.length === 0) {
+    return <div>No blueprints found in this category.</div>
+  }
+
+  return (
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        {blueprints.map((blueprint) => (
+          <BlueprintItem
+            key={blueprint.id}
+            id={blueprint.id}
+            title={blueprint.title}
+            description={blueprint.description}
+            category={category}
+          />
+        ))}
+      </tbody>
+    </table>
+  )
+}
+
+export default BlueprintsList

--- a/website/src/components/blueprints_docs/BlueprintsList.tsx
+++ b/website/src/components/blueprints_docs/BlueprintsList.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from 'react'
-import Link from '@docusaurus/Link'
 import { docsContext } from '../../utils'
 import BlueprintItem from './BlueprintItem'
 
@@ -79,26 +78,25 @@ const BlueprintsList: React.FC<BlueprintsListProps> = ({ category }) => {
     return <div>No blueprints found in this category.</div>
   }
 
+  const listStyle: React.CSSProperties = {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '16px',
+    margin: '20px 0',
+  }
+
   return (
-    <table>
-      <thead>
-        <tr>
-          <th>Name</th>
-          <th>Description</th>
-        </tr>
-      </thead>
-      <tbody>
-        {blueprints.map((blueprint) => (
-          <BlueprintItem
-            key={blueprint.id}
-            id={blueprint.id}
-            title={blueprint.title}
-            description={blueprint.description}
-            category={category}
-          />
-        ))}
-      </tbody>
-    </table>
+    <div style={listStyle}>
+      {blueprints.map((blueprint) => (
+        <BlueprintItem
+          key={blueprint.id}
+          id={blueprint.id}
+          title={blueprint.title}
+          description={blueprint.description}
+          category={category}
+        />
+      ))}
+    </div>
   )
 }
 

--- a/website/src/components/blueprints_docs/BlueprintsList.tsx
+++ b/website/src/components/blueprints_docs/BlueprintsList.tsx
@@ -26,7 +26,7 @@ const BlueprintsList: React.FC<BlueprintsListProps> = ({ category }) => {
       const blueprintKeys = keys.filter((key: string) => {
         return (
           key.startsWith(categoryPath) &&
-          !key.includes('/_example.mdx') &&
+          !key.includes('/example.mdx') &&
           !key.endsWith(`/${category}.mdx`)
         ) // Exclude the category index file
       })

--- a/website/src/components/blueprints_docs/index.tsx
+++ b/website/src/components/blueprints_docs/index.tsx
@@ -2,5 +2,6 @@ import Input from './Input'
 import Inputs from './Inputs'
 import Requirement from './Requirement'
 import ImportCard from './BlueprintImportCard'
+import BlueprintsList from './BlueprintsList'
 
-export { Input, Inputs, Requirement, ImportCard }
+export { Input, Inputs, Requirement, ImportCard, BlueprintsList }

--- a/website/src/utils.ts
+++ b/website/src/utils.ts
@@ -1,5 +1,36 @@
+/**
+ * Context for accessing blueprint YAML files
+ */
 export const blueprintsContext = require.context(
   '@blueprints',
   true,
   /\.ya?ml$/,
 )
+
+interface DocusaurusFrontMatter {
+  title: string
+  description: string
+  [key: string]: unknown
+}
+
+/**
+ * A Docusaurus-processed MDX module
+ */
+interface DocusaurusModule {
+  /** The frontmatter data from the MDX file */
+  readonly frontMatter: DocusaurusFrontMatter
+}
+
+/**
+ * Context for accessing MDX documentation files.
+ * Returns Docusaurus-processed MDX modules that include:
+ * - frontMatter: The YAML frontmatter data (title, description, etc.)
+ * - toc: Table of contents extracted from headings
+ * - default: The React component for the content
+ * - and more
+ */
+export const docsContext = require.context(
+  '@site/docs/blueprints',
+  true,
+  /\.mdx$/,
+) as unknown as (path: string) => DocusaurusModule


### PR DESCRIPTION
Thank you for taking the time to work on a Pull Request. Your contribution is really appreciated! :tada:
**Please don't delete any part of the template**, since keeping the provided structure will help maintainers to review your work more rapidly.

Sections marked as \* are required and need to be filled in.

## Proposed change\*

This PR adds the feature of auto-generating blueprint lists based on the documentation files available in the `docs/blueprints` folder.

Currently, auto-generation of blueprint lists is supported for Hooks and Automation categories. The Controllers blueprints list requires a bit extra work in order to show additional details (manufacturer, model, supported integrations, image, etc.).

Moreover, we introduce some improvements to the blueprint list UI:

Before:

![image](https://github.com/user-attachments/assets/9dd15630-3a46-45f8-9b09-e006c2851076)


After:

![image](https://github.com/user-attachments/assets/762914d6-8fb9-4127-af33-0a780c91846b)


## Checklist\*

- [X] I followed sections of the [Contribution Guidelines](https://github.com/EPMatt/awesome-ha-blueprints/blob/main/CONTRIBUTING.md) relevant to changes I'm proposing.
- [X] I properly tested proposed changes on my system and confirm that they are working as expected.
- [X] I formatted files with Prettier using the command `npm run format` before submitting my Pull Request.
