### PR TITLE
feat(docs): automatic controller lists with search features

### DIFF
--- a/website/docs/blueprints.mdx
+++ b/website/docs/blueprints.mdx
@@ -7,7 +7,7 @@ import BlueprintCategoryCard from '/src/components/blueprints_docs/BlueprintCate
 
 Select from the blueprint categories listed below. Please note that currently Home Assistant only supports blueprints for the `automation` domain.
 
-<div class='row'>
+<div className='row'>
   <BlueprintCategoryCard
     id='controllers'
     name='Controllers'

--- a/website/docs/blueprints/controllers.mdx
+++ b/website/docs/blueprints/controllers.mdx
@@ -3,7 +3,7 @@ title: Controllers
 description: Integrate a wide set of controllers in Home Assistant and provide an easy to use interface to run custom actions on a controller event.
 ---
 
-import { BlueprintsList } from '@site/src/components/blueprints_docs'
+import { ControllersList } from '@site/src/components/blueprints_docs'
 import Image from '/src/components/ControllerImage'
 
 :::tip
@@ -20,4 +20,4 @@ Currently **19** devices are supported from **6** different vendors.
 
 _Can't find the controller you're looking for in this list? [Submit a new blueprint proposal for your controller here.](https://github.com/EPMatt/awesome-ha-blueprints/issues/new?assignees=&labels=blueprint%2Cnew%2Ccontroller&template=new-controller-support.md&title=New+Controller+-+)_
 
-<BlueprintsList category='controllers' />
+<ControllersList />

--- a/website/docs/blueprints/controllers.mdx
+++ b/website/docs/blueprints/controllers.mdx
@@ -16,8 +16,6 @@ You can integrate Controllers with [Hooks](hooks) and create controller-based au
 
 ### Supported Controllers
 
-Currently **19** devices are supported from **6** different vendors.
-
 _Can't find the controller you're looking for in this list? [Submit a new blueprint proposal for your controller here.](https://github.com/EPMatt/awesome-ha-blueprints/issues/new?assignees=&labels=blueprint%2Cnew%2Ccontroller&template=new-controller-support.md&title=New+Controller+-+)_
 
 <ControllersList />

--- a/website/docs/blueprints/controllers/ikea_e1524_e1810.mdx
+++ b/website/docs/blueprints/controllers/ikea_e1524_e1810.mdx
@@ -1,6 +1,10 @@
 ---
 title: Controller - IKEA E1524/E1810 TRÅDFRI Wireless 5-Button Remote
 description: Controller automation for executing any kind of action triggered by the provided IKEA E1524/E1810 TRÅDFRI Wireless 5-Button Remote. Supports Zigbee2MQTT, ZHA, deCONZ.
+model: E1524/E1810
+manufacturer: IKEA
+integrations: [zigbee2mqtt, zha, deconz]
+model_name: IKEA E1524/E1810 TRÅDFRI Wireless 5-Button Remote
 ---
 
 import {

--- a/website/docs/blueprints/controllers/ikea_e1524_e1810.mdx
+++ b/website/docs/blueprints/controllers/ikea_e1524_e1810.mdx
@@ -3,7 +3,7 @@ title: Controller - IKEA E1524/E1810 TRÅDFRI Wireless 5-Button Remote
 description: Controller automation for executing any kind of action triggered by the provided IKEA E1524/E1810 TRÅDFRI Wireless 5-Button Remote. Supports Zigbee2MQTT, ZHA, deCONZ.
 model: E1524/E1810
 manufacturer: IKEA
-integrations: [zigbee2mqtt, zha, deconz]
+integrations: [Zigbee2MQTT, ZHA, deCONZ]
 model_name: IKEA E1524/E1810 TRÅDFRI Wireless 5-Button Remote
 ---
 

--- a/website/docs/blueprints/controllers/ikea_e1743.mdx
+++ b/website/docs/blueprints/controllers/ikea_e1743.mdx
@@ -1,6 +1,10 @@
 ---
 title: Controller - IKEA E1743 TRÅDFRI On/Off Switch & Dimmer
 description: Controller automation for executing any kind of action triggered by the provided IKEA E1743 TRÅDFRI On/Off Switch & Dimmer. Supports Zigbee2MQTT, ZHA, deCONZ.
+model: E1743
+manufacturer: IKEA
+integrations: [zigbee2mqtt, zha, deconz]
+model_name: IKEA E1743 TRÅDFRI On/Off Switch & Dimmer
 ---
 
 import {

--- a/website/docs/blueprints/controllers/ikea_e1743.mdx
+++ b/website/docs/blueprints/controllers/ikea_e1743.mdx
@@ -3,7 +3,7 @@ title: Controller - IKEA E1743 TRÅDFRI On/Off Switch & Dimmer
 description: Controller automation for executing any kind of action triggered by the provided IKEA E1743 TRÅDFRI On/Off Switch & Dimmer. Supports Zigbee2MQTT, ZHA, deCONZ.
 model: E1743
 manufacturer: IKEA
-integrations: [zigbee2mqtt, zha, deconz]
+integrations: [Zigbee2MQTT, ZHA, deCONZ]
 model_name: IKEA E1743 TRÅDFRI On/Off Switch & Dimmer
 ---
 

--- a/website/docs/blueprints/controllers/ikea_e1744.mdx
+++ b/website/docs/blueprints/controllers/ikea_e1744.mdx
@@ -3,7 +3,7 @@ title: Controller - IKEA E1744 SYMFONISK Rotary Remote
 description: Controller automation for executing any kind of action triggered by the provided IKEA E1744 SYMFONISK Rotary Remote. Supports Zigbee2MQTT, ZHA, deCONZ.
 model: E1744
 manufacturer: IKEA
-integrations: [zigbee2mqtt, zha, deconz]
+integrations: [Zigbee2MQTT, ZHA, deCONZ]
 model_name: IKEA E1744 SYMFONISK Rotary Remote
 ---
 

--- a/website/docs/blueprints/controllers/ikea_e1744.mdx
+++ b/website/docs/blueprints/controllers/ikea_e1744.mdx
@@ -1,6 +1,10 @@
 ---
 title: Controller - IKEA E1744 SYMFONISK Rotary Remote
 description: Controller automation for executing any kind of action triggered by the provided IKEA E1744 SYMFONISK Rotary Remote. Supports Zigbee2MQTT, ZHA, deCONZ.
+model: E1744
+manufacturer: IKEA
+integrations: [zigbee2mqtt, zha, deconz]
+model_name: IKEA E1744 SYMFONISK Rotary Remote
 ---
 
 import {

--- a/website/docs/blueprints/controllers/ikea_e1766.mdx
+++ b/website/docs/blueprints/controllers/ikea_e1766.mdx
@@ -1,6 +1,10 @@
 ---
 title: Controller - IKEA E1766 TRÅDFRI Open/Close Remote
 description: Controller automation for executing any kind of action triggered by the provided IKEA E1766 TRÅDFRI Open/Close Remote. Supports Zigbee2MQTT, ZHA, deCONZ.
+model: E1766
+manufacturer: IKEA
+integrations: [zigbee2mqtt, zha, deconz]
+model_name: IKEA E1766 TRÅDFRI Open/Close Remote
 ---
 
 import {

--- a/website/docs/blueprints/controllers/ikea_e1766.mdx
+++ b/website/docs/blueprints/controllers/ikea_e1766.mdx
@@ -3,7 +3,7 @@ title: Controller - IKEA E1766 TRÅDFRI Open/Close Remote
 description: Controller automation for executing any kind of action triggered by the provided IKEA E1766 TRÅDFRI Open/Close Remote. Supports Zigbee2MQTT, ZHA, deCONZ.
 model: E1766
 manufacturer: IKEA
-integrations: [zigbee2mqtt, zha, deconz]
+integrations: [Zigbee2MQTT, ZHA, deCONZ]
 model_name: IKEA E1766 TRÅDFRI Open/Close Remote
 ---
 

--- a/website/docs/blueprints/controllers/ikea_e1812.mdx
+++ b/website/docs/blueprints/controllers/ikea_e1812.mdx
@@ -3,7 +3,7 @@ title: Controller - IKEA E1812 TRÅDFRI Shortcut button
 description: Controller automation for executing any kind of action triggered by the provided IKEA E1812 TRÅDFRI Shortcut button. Supports Zigbee2MQTT, ZHA, deCONZ.
 model: E1812
 manufacturer: IKEA
-integrations: [zigbee2mqtt, zha, deconz]
+integrations: [Zigbee2MQTT, ZHA, deCONZ]
 model_name: IKEA E1812 TRÅDFRI Shortcut button
 ---
 

--- a/website/docs/blueprints/controllers/ikea_e1812.mdx
+++ b/website/docs/blueprints/controllers/ikea_e1812.mdx
@@ -1,6 +1,10 @@
 ---
 title: Controller - IKEA E1812 TRÅDFRI Shortcut button
 description: Controller automation for executing any kind of action triggered by the provided IKEA E1812 TRÅDFRI Shortcut button. Supports Zigbee2MQTT, ZHA, deCONZ.
+model: E1812
+manufacturer: IKEA
+integrations: [zigbee2mqtt, zha, deconz]
+model_name: IKEA E1812 TRÅDFRI Shortcut button
 ---
 
 import {

--- a/website/docs/blueprints/controllers/ikea_e2001_e2002.mdx
+++ b/website/docs/blueprints/controllers/ikea_e2001_e2002.mdx
@@ -3,7 +3,7 @@ title: Controller - IKEA E2001/E2002 STYRBAR Remote control
 description: Controller automation for executing any kind of action triggered by the provided IKEA E2001/E2002 STYRBAR Remote control. Supports Zigbee2MQTT, ZHA, deCONZ.
 model: E2001/E2002
 manufacturer: IKEA
-integrations: [zigbee2mqtt, zha, deconz]
+integrations: [Zigbee2MQTT, ZHA, deCONZ]
 model_name: IKEA E2001/E2002 STYRBAR Remote control
 ---
 

--- a/website/docs/blueprints/controllers/ikea_e2001_e2002.mdx
+++ b/website/docs/blueprints/controllers/ikea_e2001_e2002.mdx
@@ -1,6 +1,10 @@
 ---
 title: Controller - IKEA E2001/E2002 STYRBAR Remote control
 description: Controller automation for executing any kind of action triggered by the provided IKEA E2001/E2002 STYRBAR Remote control. Supports Zigbee2MQTT, ZHA, deCONZ.
+model: E2001/E2002
+manufacturer: IKEA
+integrations: [zigbee2mqtt, zha, deconz]
+model_name: IKEA E2001/E2002 STYRBAR Remote control
 ---
 
 import {

--- a/website/docs/blueprints/controllers/ikea_e2201.mdx
+++ b/website/docs/blueprints/controllers/ikea_e2201.mdx
@@ -3,7 +3,7 @@ title: Controller - IKEA E2201 RODRET Dimmer
 description: Controller automation for executing any kind of action triggered by the provided IKEA E2201 RODRET Dimmer. Supports Zigbee2MQTT, ZHA, deCONZ.
 model: E2201
 manufacturer: IKEA
-integrations: [zigbee2mqtt, zha, deconz]
+integrations: [Zigbee2MQTT, ZHA, deCONZ]
 model_name: IKEA E2201 RODRET Dimmer
 ---
 

--- a/website/docs/blueprints/controllers/ikea_e2201.mdx
+++ b/website/docs/blueprints/controllers/ikea_e2201.mdx
@@ -1,6 +1,10 @@
 ---
 title: Controller - IKEA E2201 RODRET Dimmer
 description: Controller automation for executing any kind of action triggered by the provided IKEA E2201 RODRET Dimmer. Supports Zigbee2MQTT, ZHA, deCONZ.
+model: E2201
+manufacturer: IKEA
+integrations: [zigbee2mqtt, zha, deconz]
+model_name: IKEA E2201 RODRET Dimmer
 ---
 
 import {

--- a/website/docs/blueprints/controllers/ikea_e2213.mdx
+++ b/website/docs/blueprints/controllers/ikea_e2213.mdx
@@ -3,7 +3,7 @@ title: Controller - IKEA E2213 SOMRIG shortcut button
 description: Controller automation for executing any kind of action triggered by the provided IKEA E2213 SOMRIG shortcut button. Supports Zigbee2MQTT, ZHA, deCONZ.
 model: E2213
 manufacturer: IKEA
-integrations: [zigbee2mqtt, zha, deconz]
+integrations: [Zigbee2MQTT, ZHA, deCONZ]
 model_name: IKEA E2213 SOMRIG shortcut button
 ---
 

--- a/website/docs/blueprints/controllers/ikea_e2213.mdx
+++ b/website/docs/blueprints/controllers/ikea_e2213.mdx
@@ -1,6 +1,10 @@
 ---
 title: Controller - IKEA E2213 SOMRIG shortcut button
 description: Controller automation for executing any kind of action triggered by the provided IKEA E2213 SOMRIG shortcut button. Supports Zigbee2MQTT, ZHA, deCONZ.
+model: E2213
+manufacturer: IKEA
+integrations: [zigbee2mqtt, zha, deconz]
+model_name: IKEA E2213 SOMRIG shortcut button
 ---
 
 import {

--- a/website/docs/blueprints/controllers/ikea_ictc_g_1.mdx
+++ b/website/docs/blueprints/controllers/ikea_ictc_g_1.mdx
@@ -1,6 +1,10 @@
 ---
 title: Controller - IKEA ICTC-G-1 TRÅDFRI wireless dimmer
 description: Controller automation for executing any kind of action triggered by the provided IKEA ICTC-G-1 TRÅDFRI wireless dimmer. Supports Zigbee2MQTT, ZHA, deCONZ.
+model: ICTC-G-1
+manufacturer: IKEA
+integrations: [zigbee2mqtt, zha, deconz]
+model_name: IKEA ICTC-G-1 TRÅDFRI wireless dimmer
 ---
 
 import {

--- a/website/docs/blueprints/controllers/ikea_ictc_g_1.mdx
+++ b/website/docs/blueprints/controllers/ikea_ictc_g_1.mdx
@@ -3,7 +3,7 @@ title: Controller - IKEA ICTC-G-1 TRÅDFRI wireless dimmer
 description: Controller automation for executing any kind of action triggered by the provided IKEA ICTC-G-1 TRÅDFRI wireless dimmer. Supports Zigbee2MQTT, ZHA, deCONZ.
 model: ICTC-G-1
 manufacturer: IKEA
-integrations: [zigbee2mqtt, zha, deconz]
+integrations: [Zigbee2MQTT, ZHA, deCONZ]
 model_name: IKEA ICTC-G-1 TRÅDFRI wireless dimmer
 ---
 

--- a/website/docs/blueprints/controllers/osram_ac025xx00nj.mdx
+++ b/website/docs/blueprints/controllers/osram_ac025xx00nj.mdx
@@ -1,6 +1,10 @@
 ---
 title: Controller - OSRAM AC025XX00NJ SMART+ Switch Mini
 description: Controller automation for executing any kind of action triggered by the provided OSRAM AC025XX00NJ SMART+ Switch Mini. Supports Zigbee2MQTT, ZHA, deCONZ.
+model: AC025XX00NJ
+manufacturer: OSRAM
+integrations: [zigbee2mqtt, zha, deconz]
+model_name: OSRAM AC025XX00NJ SMART+ Switch Mini
 ---
 
 import {

--- a/website/docs/blueprints/controllers/osram_ac025xx00nj.mdx
+++ b/website/docs/blueprints/controllers/osram_ac025xx00nj.mdx
@@ -3,7 +3,7 @@ title: Controller - OSRAM AC025XX00NJ SMART+ Switch Mini
 description: Controller automation for executing any kind of action triggered by the provided OSRAM AC025XX00NJ SMART+ Switch Mini. Supports Zigbee2MQTT, ZHA, deCONZ.
 model: AC025XX00NJ
 manufacturer: OSRAM
-integrations: [zigbee2mqtt, zha, deconz]
+integrations: [Zigbee2MQTT, ZHA, deCONZ]
 model_name: OSRAM AC025XX00NJ SMART+ Switch Mini
 ---
 

--- a/website/docs/blueprints/controllers/philips_324131092621.mdx
+++ b/website/docs/blueprints/controllers/philips_324131092621.mdx
@@ -3,7 +3,7 @@ title: Controller - Philips 324131092621 Hue Dimmer switch
 description: Controller automation for executing any kind of action triggered by the provided Philips 324131092621 Hue Dimmer switch. Supports Zigbee2MQTT, ZHA, deCONZ.
 model: 324131092621
 manufacturer: Philips
-integrations: [zigbee2mqtt, zha, deconz]
+integrations: [Zigbee2MQTT, ZHA, deCONZ]
 model_name: Philips 324131092621 Hue Dimmer switch
 ---
 

--- a/website/docs/blueprints/controllers/philips_324131092621.mdx
+++ b/website/docs/blueprints/controllers/philips_324131092621.mdx
@@ -1,6 +1,10 @@
 ---
 title: Controller - Philips 324131092621 Hue Dimmer switch
 description: Controller automation for executing any kind of action triggered by the provided Philips 324131092621 Hue Dimmer switch. Supports Zigbee2MQTT, ZHA, deCONZ.
+model: 324131092621
+manufacturer: Philips
+integrations: [zigbee2mqtt, zha, deconz]
+model_name: Philips 324131092621 Hue Dimmer switch
 ---
 
 import {

--- a/website/docs/blueprints/controllers/philips_8718699693985.mdx
+++ b/website/docs/blueprints/controllers/philips_8718699693985.mdx
@@ -1,6 +1,10 @@
 ---
 title: Controller - Philips 8718699693985 Hue Smart Button
 description: Controller automation for executing any kind of action triggered by the provided Philips 8718699693985 Hue Smart Button. Supports Zigbee2MQTT, ZHA, deCONZ.
+model: 8718699693985
+manufacturer: Philips
+integrations: [zigbee2mqtt, zha, deconz]
+model_name: Philips 8718699693985 Hue Smart Button
 ---
 
 import {

--- a/website/docs/blueprints/controllers/philips_8718699693985.mdx
+++ b/website/docs/blueprints/controllers/philips_8718699693985.mdx
@@ -3,7 +3,7 @@ title: Controller - Philips 8718699693985 Hue Smart Button
 description: Controller automation for executing any kind of action triggered by the provided Philips 8718699693985 Hue Smart Button. Supports Zigbee2MQTT, ZHA, deCONZ.
 model: 8718699693985
 manufacturer: Philips
-integrations: [zigbee2mqtt, zha, deconz]
+integrations: [Zigbee2MQTT, ZHA, deCONZ]
 model_name: Philips 8718699693985 Hue Smart Button
 ---
 

--- a/website/docs/blueprints/controllers/philips_929002398602.mdx
+++ b/website/docs/blueprints/controllers/philips_929002398602.mdx
@@ -1,6 +1,10 @@
 ---
 title: Controller - Philips 929002398602 Hue Dimmer switch v2
 description: Controller automation for executing any kind of action triggered by the provided Philips 929002398602 Hue Dimmer switch v2. Supports Zigbee2MQTT, ZHA.
+model: 929002398602
+manufacturer: Philips
+integrations: [zigbee2mqtt, zha]
+model_name: Philips 929002398602 Hue Dimmer switch v2
 ---
 
 import {

--- a/website/docs/blueprints/controllers/philips_929002398602.mdx
+++ b/website/docs/blueprints/controllers/philips_929002398602.mdx
@@ -3,7 +3,7 @@ title: Controller - Philips 929002398602 Hue Dimmer switch v2
 description: Controller automation for executing any kind of action triggered by the provided Philips 929002398602 Hue Dimmer switch v2. Supports Zigbee2MQTT, ZHA.
 model: 929002398602
 manufacturer: Philips
-integrations: [zigbee2mqtt, zha]
+integrations: [Zigbee2MQTT, ZHA]
 model_name: Philips 929002398602 Hue Dimmer switch v2
 ---
 

--- a/website/docs/blueprints/controllers/sonoff_snzb01.mdx
+++ b/website/docs/blueprints/controllers/sonoff_snzb01.mdx
@@ -3,7 +3,7 @@ title: Controller - SONOFF SNZB-01 Wireless Switch
 description: Controller automation for executing any kind of action triggered by the provided SONOFF SNZB-01 Wireless Switch. Supports Zigbee2MQTT, ZHA, deCONZ.
 model: SNZB-01
 manufacturer: SONOFF
-integrations: [zigbee2mqtt, zha, deconz]
+integrations: [Zigbee2MQTT, ZHA, deCONZ]
 model_name: SONOFF SNZB-01 Wireless Switch
 ---
 

--- a/website/docs/blueprints/controllers/sonoff_snzb01.mdx
+++ b/website/docs/blueprints/controllers/sonoff_snzb01.mdx
@@ -1,6 +1,10 @@
 ---
 title: Controller - SONOFF SNZB-01 Wireless Switch
 description: Controller automation for executing any kind of action triggered by the provided SONOFF SNZB-01 Wireless Switch. Supports Zigbee2MQTT, ZHA, deCONZ.
+model: SNZB-01
+manufacturer: SONOFF
+integrations: [zigbee2mqtt, zha, deconz]
+model_name: SONOFF SNZB-01 Wireless Switch
 ---
 
 import {
@@ -102,7 +106,4 @@ Please note that the long press action for this controller is triggered after th
   Migrate to Zigbee2MQTT MQTT Device Triggers. ([@yarafie](https://github.com/yarafie))
 
   The `controller_entity` input has been deprecated, and `controller_device` is now mandatory.
-  If you are a Zigbee2MQTT user and plan to update this blueprint, please make sure to remove the `controller_entity` input from your automation config and add the device ID of your controller to the `controller_device` input.
-  To obtain the device ID from your controller, configure the automation from the UI and use the device selector dropdown on the `controller_device` input to select your controller.
-
-- **2025-03-20**: Standardized input naming format for controller devices and virtual button actions. No functionality changes.
+  If you are a Zigbee2MQTT user and plan to update this blueprint, please make sure to remove the `controller_entity`

--- a/website/docs/blueprints/controllers/xiaomi_wxcjkg11lm.mdx
+++ b/website/docs/blueprints/controllers/xiaomi_wxcjkg11lm.mdx
@@ -1,6 +1,10 @@
 ---
 title: Controller - Xiaomi WXCJKG11LM Aqara Opple 2 button remote
 description: Controller automation for executing any kind of action triggered by the provided Xiaomi WXCJKG11LM Aqara Opple 2 button remote. Supports Zigbee2MQTT, ZHA, deCONZ.
+model: WXCJKG11LM
+manufacturer: Xiaomi
+integrations: [zigbee2mqtt, zha, deconz]
+model_name: Xiaomi WXCJKG11LM Aqara Opple 2 button remote
 ---
 
 import {

--- a/website/docs/blueprints/controllers/xiaomi_wxcjkg11lm.mdx
+++ b/website/docs/blueprints/controllers/xiaomi_wxcjkg11lm.mdx
@@ -3,7 +3,7 @@ title: Controller - Xiaomi WXCJKG11LM Aqara Opple 2 button remote
 description: Controller automation for executing any kind of action triggered by the provided Xiaomi WXCJKG11LM Aqara Opple 2 button remote. Supports Zigbee2MQTT, ZHA, deCONZ.
 model: WXCJKG11LM
 manufacturer: Xiaomi
-integrations: [zigbee2mqtt, zha, deconz]
+integrations: [Zigbee2MQTT, ZHA, deCONZ]
 model_name: Xiaomi WXCJKG11LM Aqara Opple 2 button remote
 ---
 

--- a/website/docs/blueprints/controllers/xiaomi_wxcjkg12lm.mdx
+++ b/website/docs/blueprints/controllers/xiaomi_wxcjkg12lm.mdx
@@ -3,7 +3,7 @@ title: Controller - Xiaomi WXCJKG12LM Aqara Opple 4 button remote
 description: Controller automation for executing any kind of action triggered by the provided Xiaomi WXCJKG12LM Aqara Opple 4 button remote. Supports Zigbee2MQTT, ZHA, deCONZ.
 model: WXCJKG12LM
 manufacturer: Xiaomi
-integrations: [zigbee2mqtt, zha, deconz]
+integrations: [Zigbee2MQTT, ZHA, deCONZ]
 model_name: Xiaomi WXCJKG12LM Aqara Opple 4 button remote
 ---
 

--- a/website/docs/blueprints/controllers/xiaomi_wxcjkg12lm.mdx
+++ b/website/docs/blueprints/controllers/xiaomi_wxcjkg12lm.mdx
@@ -1,6 +1,10 @@
 ---
 title: Controller - Xiaomi WXCJKG12LM Aqara Opple 4 button remote
 description: Controller automation for executing any kind of action triggered by the provided Xiaomi WXCJKG12LM Aqara Opple 4 button remote. Supports Zigbee2MQTT, ZHA, deCONZ.
+model: WXCJKG12LM
+manufacturer: Xiaomi
+integrations: [zigbee2mqtt, zha, deconz]
+model_name: Xiaomi WXCJKG12LM Aqara Opple 4 button remote
 ---
 
 import {

--- a/website/docs/blueprints/controllers/xiaomi_wxcjkg13lm.mdx
+++ b/website/docs/blueprints/controllers/xiaomi_wxcjkg13lm.mdx
@@ -3,7 +3,7 @@ title: Controller - Xiaomi WXCJKG13LM Aqara Opple 6 button remote
 description: Controller automation for executing any kind of action triggered by the provided Xiaomi WXCJKG13LM Aqara Opple 6 button remote. Supports Zigbee2MQTT, ZHA, deCONZ.
 model: WXCJKG13LM
 manufacturer: Xiaomi
-integrations: [zigbee2mqtt, zha, deconz]
+integrations: [Zigbee2MQTT, ZHA, deCONZ]
 model_name: Xiaomi WXCJKG13LM Aqara Opple 6 button remote
 ---
 

--- a/website/docs/blueprints/controllers/xiaomi_wxcjkg13lm.mdx
+++ b/website/docs/blueprints/controllers/xiaomi_wxcjkg13lm.mdx
@@ -1,6 +1,10 @@
 ---
 title: Controller - Xiaomi WXCJKG13LM Aqara Opple 6 button remote
 description: Controller automation for executing any kind of action triggered by the provided Xiaomi WXCJKG13LM Aqara Opple 6 button remote. Supports Zigbee2MQTT, ZHA, deCONZ.
+model: WXCJKG13LM
+manufacturer: Xiaomi
+integrations: [zigbee2mqtt, zha, deconz]
+model_name: Xiaomi WXCJKG13LM Aqara Opple 6 button remote
 ---
 
 import {

--- a/website/docs/blueprints/controllers/xiaomi_wxkg11lm.mdx
+++ b/website/docs/blueprints/controllers/xiaomi_wxkg11lm.mdx
@@ -5,7 +5,7 @@ model: [WXKG11LM, WXKG01LM]
 model_name:
   [Aqara WXKG11LM Wireless Mini Switch, Xiaomi WXKG01LM Mi Wireless Switch]
 manufacturer: [Aqara, Xiaomi]
-integrations: [zigbee2mqtt, zha, deconz]
+integrations: [Zigbee2MQTT, ZHA, deCONZ]
 ---
 
 import {

--- a/website/docs/blueprints/controllers/xiaomi_wxkg11lm.mdx
+++ b/website/docs/blueprints/controllers/xiaomi_wxkg11lm.mdx
@@ -1,6 +1,11 @@
 ---
 title: Controller - Aqara WXKG11LM Wireless Mini Switch / Xiaomi WXKG01LM Mi Wireless Switch
 description: Controller automation for executing any kind of action triggered by the provided Aqara WXKG11LM Wireless Mini Switch / Xiaomi WXKG01LM Mi Wireless Switch. Supports Zigbee2MQTT, ZHA, deCONZ.
+model: [WXKG11LM, WXKG01LM]
+model_name:
+  [Aqara WXKG11LM Wireless Mini Switch, Xiaomi WXKG01LM Mi Wireless Switch]
+manufacturer: [Aqara, Xiaomi]
+integrations: [zigbee2mqtt, zha, deconz]
 ---
 
 import {

--- a/website/src/components/blueprints_docs/ControllerItem.tsx
+++ b/website/src/components/blueprints_docs/ControllerItem.tsx
@@ -1,0 +1,98 @@
+import React, { useState } from 'react'
+import Link from '@docusaurus/Link'
+import { ChevronRight } from 'react-bootstrap-icons'
+
+interface ControllerItemProps {
+  id: string
+  model: string
+  manufacturer: string
+  integrations: string[]
+  image: string
+  model_name: string
+}
+
+const ControllerItem: React.FC<ControllerItemProps> = ({
+  id,
+  model,
+  manufacturer,
+  integrations,
+  image,
+  model_name,
+}) => {
+  const [isHovered, setIsHovered] = useState(false)
+
+  const cardStyle: React.CSSProperties = {
+    width: '100%',
+    minHeight: '120px',
+    boxShadow: isHovered
+      ? '0 4px 8px rgba(0, 0, 0, 0.3)'
+      : '0 2px 4px rgba(0, 0, 0, 0.2)',
+    padding: '16px',
+    color: 'var(--ifm-font-color-base, #000)',
+    cursor: 'pointer',
+    display: 'flex',
+    alignItems: 'flex-start',
+    position: 'relative',
+    gap: '16px',
+    transition: 'box-shadow 0.3s ease',
+  }
+
+  const imageStyle: React.CSSProperties = {
+    width: '150px',
+    height: 'auto',
+    borderRadius: '8px',
+    flexShrink: 0,
+  }
+
+  const textContainerStyle: React.CSSProperties = {
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'flex-start',
+    flex: 1,
+    overflow: 'wrap',
+    paddingRight: '24px',
+  }
+
+  const footerStyle: React.CSSProperties = {
+    position: 'absolute',
+    right: '16px',
+    top: '50%',
+    transform: `translateY(-50%) ${isHovered ? 'translateX(6px)' : 'translateX(0)'}`,
+    transition: 'transform 0.3s ease-out',
+  }
+
+  return (
+    <Link
+      to={`/docs/blueprints/controllers/${id}`}
+      style={{ textDecoration: 'none' }}
+    >
+      <div
+        className='card'
+        style={cardStyle}
+        onMouseEnter={() => setIsHovered(true)}
+        onMouseLeave={() => setIsHovered(false)}
+      >
+        <div style={textContainerStyle}>
+          <h3 style={{ margin: '0' }}>{model_name}</h3>
+        </div>
+        <img src={image} alt={model_name} style={imageStyle} />
+        <div style={textContainerStyle}>
+          <p style={{ margin: '0' }}>
+            <strong>Model:</strong> {model}
+          </p>
+          <p style={{ margin: '0' }}>
+            <strong>Manufacturer:</strong> {manufacturer}
+          </p>
+          <p style={{ margin: '0' }}>
+            <strong>Integrations:</strong> {integrations.join(', ')}
+          </p>
+        </div>
+        <div className='card__footer' style={footerStyle}>
+          <ChevronRight size={20} />
+        </div>
+      </div>
+    </Link>
+  )
+}
+
+export default ControllerItem

--- a/website/src/components/blueprints_docs/ControllerItem.tsx
+++ b/website/src/components/blueprints_docs/ControllerItem.tsx
@@ -5,7 +5,7 @@ import { ChevronRight } from 'react-bootstrap-icons'
 interface ControllerItemProps {
   id: string
   model: string
-  manufacturer: string
+  manufacturer: string | string[]
   integrations: string[]
   image: string
   model_name: string
@@ -20,6 +20,10 @@ const ControllerItem: React.FC<ControllerItemProps> = ({
   model_name,
 }) => {
   const [isHovered, setIsHovered] = useState(false)
+
+  const formattedManufacturer = Array.isArray(manufacturer)
+    ? manufacturer.join(', ')
+    : manufacturer
 
   const cardStyle: React.CSSProperties = {
     width: '100%',
@@ -81,7 +85,7 @@ const ControllerItem: React.FC<ControllerItemProps> = ({
             <strong>Model:</strong> {model}
           </p>
           <p style={{ margin: '0' }}>
-            <strong>Manufacturer:</strong> {manufacturer}
+            <strong>Manufacturer:</strong> {formattedManufacturer}
           </p>
           <p style={{ margin: '0' }}>
             <strong>Integrations:</strong> {integrations.join(', ')}

--- a/website/src/components/blueprints_docs/ControllersList.tsx
+++ b/website/src/components/blueprints_docs/ControllersList.tsx
@@ -1,0 +1,116 @@
+import React, { useEffect, useState } from 'react'
+import { docsContext } from '../../utils'
+import ControllerItem from './ControllerItem'
+
+interface Controller {
+  id: string
+  model: string
+  manufacturer: string
+  integrations: string[]
+  model_name: string
+}
+
+const ControllersList: React.FC = () => {
+  const [controllers, setControllers] = useState<Controller[]>([])
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    try {
+      const keys = (docsContext as any).keys()
+      const categoryPath = `./controllers/`
+
+      const controllerKeys = keys.filter((key: string) => {
+        return (
+          key.startsWith(categoryPath) &&
+          !key.includes('/example.mdx') &&
+          !key.endsWith(`/controllers.mdx`)
+        )
+      })
+
+      const controllersData = controllerKeys.map((key: string) => {
+        const id = key.replace(categoryPath, '').replace('.mdx', '')
+        const mdxModule = docsContext(key)
+        const {
+          title,
+          description,
+          model,
+          manufacturer,
+          integrations,
+          model_name,
+        } = mdxModule.frontMatter
+
+        return {
+          id,
+          title: title || id,
+          description: description || '',
+          model: Array.isArray(model) ? model.join(', ') : model || '',
+          manufacturer: Array.isArray(manufacturer)
+            ? manufacturer.join(', ')
+            : manufacturer || '',
+          integrations: integrations || [],
+          model_name: Array.isArray(model_name)
+            ? model_name.join(', ')
+            : model_name || '',
+        }
+      })
+
+      controllersData.sort((a, b) => a.title.localeCompare(b.title))
+
+      setControllers(controllersData)
+      setError(null)
+    } catch (e) {
+      console.error('Error loading controllers:', e)
+      setControllers([])
+      setError(
+        'Failed to load controllers. Please check the console for more details.',
+      )
+    }
+  }, [])
+
+  if (error) {
+    return (
+      <div className='admonition admonition-danger alert alert--danger'>
+        <div className='admonition-heading'>
+          <h5>Error loading controllers</h5>
+        </div>
+        <div className='admonition-content'>
+          <p>{error}</p>
+        </div>
+      </div>
+    )
+  }
+
+  if (controllers.length === 0) {
+    return <div>No controllers found in this category.</div>
+  }
+
+  const listStyle: React.CSSProperties = {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '16px',
+    margin: '20px 0',
+  }
+
+  return (
+    <div style={listStyle}>
+      {controllers.map((controller) => {
+        // Construct the image path using the id
+        const imagePath = `/awesome-ha-blueprints/img/controllers/${controller.id}.png`
+
+        return (
+          <ControllerItem
+            key={controller.id}
+            id={controller.id}
+            model={controller.model}
+            model_name={controller.model_name}
+            manufacturer={controller.manufacturer}
+            integrations={controller.integrations}
+            image={imagePath} // Pass the image path to ControllerItem
+          />
+        )
+      })}
+    </div>
+  )
+}
+
+export default ControllersList

--- a/website/src/components/blueprints_docs/index.tsx
+++ b/website/src/components/blueprints_docs/index.tsx
@@ -3,5 +3,13 @@ import Inputs from './Inputs'
 import Requirement from './Requirement'
 import ImportCard from './BlueprintImportCard'
 import BlueprintsList from './BlueprintsList'
+import ControllersList from './ControllersList'
 
-export { Input, Inputs, Requirement, ImportCard, BlueprintsList }
+export {
+  Input,
+  Inputs,
+  Requirement,
+  ImportCard,
+  BlueprintsList,
+  ControllersList,
+}


### PR DESCRIPTION
Thank you for taking the time to work on a Pull Request. Your contribution is really appreciated! :tada:
**Please don't delete any part of the template**, since keeping the provided structure will help maintainers to review your work more rapidly.

Sections marked as \* are required and need to be filled in.

## Proposed change\*

This PR adds support for automatically generating the list of controllers in our docs website. Plus, it includes several improvements to the UX in browsing the list of supported controllers, including:
- Search by Model Name
- Dropdown selection of Manufacturer
- Easier at-a-glance information about the controller (Model, Manufacturer, Image, Supported Integrations)

![image](https://github.com/user-attachments/assets/af8dfd23-f538-4cfa-aced-50631f2c08f5)


## Checklist\*

- [X] I followed sections of the [Contribution Guidelines](https://github.com/EPMatt/awesome-ha-blueprints/blob/main/CONTRIBUTING.md) relevant to changes I'm proposing.
- [X] I properly tested proposed changes on my system and confirm that they are working as expected.
- [X] I formatted files with Prettier using the command `npm run format` before submitting my Pull Request.
