### PR TITLE
feat(docs): remove direct link, use tracking links in MyHomeAssistant buttons

### DIFF
--- a/website/src/components/blueprints_docs/BlueprintImportCard.tsx
+++ b/website/src/components/blueprints_docs/BlueprintImportCard.tsx
@@ -1,6 +1,4 @@
-import { useState } from 'react'
-import { ClipboardPlus } from 'react-bootstrap-icons'
-
+import Link from '@docusaurus/Link'
 const styles = {
   myHomeAssistantImage: {
     width: '100%',
@@ -14,14 +12,9 @@ interface BlueprintImportCardProps {
 }
 
 function BlueprintImportCard({ category, id }: BlueprintImportCardProps) {
-  const [copy, setCopy] = useState(false)
   // New custom URL format that will redirect to the GitHub URL
-  const blueprintUrl = `https://epmatt.github.io/awesome-ha-blueprints/blueprints/${category}/${id}?version=latest`
+  const blueprintUrl = `/blueprints/${category}/${id}?version=latest`
 
-  const copyToClipboard = async () => {
-    await navigator.clipboard.writeText(blueprintUrl)
-    setCopy(true)
-  }
   return (
     <div className='card item shadow--md'>
       <div className='card__header margin-bottom--md'>
@@ -29,38 +22,18 @@ function BlueprintImportCard({ category, id }: BlueprintImportCardProps) {
       </div>
       <div className='card__body'>
         <div className='row row--no-gutters'>
-          <div className='col col--6'>
+          <div className='col col--12'>
             <h5>My Home Assistant</h5>
             <p>
-              <a
-                href={`https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=${escape(
-                  blueprintUrl,
-                )}`}
-                target='_blank'
-                rel='noreferrer'
-              >
+              <Link to={blueprintUrl} target='_blank' rel='noreferrer'>
                 <img
                   src='https://my.home-assistant.io/badges/blueprint_import.svg'
                   alt='Open your Home Assistant instance and show the blueprint import dialog with a specific blueprint pre-filled.'
                   style={styles.myHomeAssistantImage}
                 />
-              </a>
+              </Link>
               <br />
-              <small>(Home Assistant 2024.10.0 or higher)</small>
             </p>
-          </div>
-          <div className='col col--6'>
-            <h5>Direct Link</h5>
-            <button
-              type='button'
-              className={`button button--${copy ? 'success' : 'primary'}`}
-              onClick={copyToClipboard}
-            >
-              <span>
-                <ClipboardPlus size={16} />
-                <span> {copy ? 'Link Copied!' : 'Copy Link'}</span>
-              </span>
-            </button>
           </div>
         </div>
       </div>

--- a/website/src/plugins/blueprint-downloader-plugin/download-blueprint.tsx
+++ b/website/src/plugins/blueprint-downloader-plugin/download-blueprint.tsx
@@ -1,34 +1,19 @@
 import React, { useEffect } from 'react'
 // @ts-expect-error no types for this
-import { useLocation } from '@docusaurus/router'
-// @ts-expect-error no types for this
 import Head from '@docusaurus/Head'
 
 export default function DownloadBlueprint(props: {
   route: { category: string; id: string }
 }) {
-  const location = useLocation()
   const category = props.route.category
   const id = props.route.id
 
-  useEffect(() => {
-    // Get query parameters
-    const searchParams = new URLSearchParams(location.search)
-    const version = searchParams.get('version') || 'latest'
-    // Sanitize version - only allow 0-9, dot and a-z
-    // eslint-disable-next-line
-    const sanitizedVersion = version.replace(/[^0-9a-z.]/gi, '')
+  const githubUrl = `https://raw.githubusercontent.com/EPMatt/awesome-ha-blueprints/main/blueprints/${category}/${id}/${id}.yaml`
+  const myHomeAssistantURL = `https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=${encodeURIComponent(githubUrl)}`
 
-    if (category && id) {
-      // Redirect to GitHub repository
-      const githubUrl = `https://raw.githubusercontent.com/EPMatt/awesome-ha-blueprints/main/blueprints/${category}/${id}/${id}.yaml`
-      window.location.href = githubUrl
-    } else {
-      console.error(
-        'Invalid blueprint id parameter format. Expected format: category/id',
-      )
-    }
-  }, [location])
+  useEffect(() => {
+    window.location.href = myHomeAssistantURL
+  }, [])
 
   return (
     <>
@@ -40,13 +25,15 @@ export default function DownloadBlueprint(props: {
       <div
         style={{
           display: 'flex',
+          flexDirection: 'column',
           justifyContent: 'center',
           alignItems: 'center',
           height: '50vh',
           fontSize: '20px',
         }}
       >
-        <p>Downloading blueprint...</p>
+        <h1>Thanks for downloading!</h1>
+        <p>Redirecting to your Home Assistant instance...</p>
       </div>
     </>
   )


### PR DESCRIPTION
Thank you for taking the time to work on a Pull Request. Your contribution is really appreciated! :tada:
**Please don't delete any part of the template**, since keeping the provided structure will help maintainers to review your work more rapidly.

Sections marked as \* are required and need to be filled in.

## Proposed change\*

This PR adds support for using tracking links in the docs page for My Home Assistant import. This allows us to identify the most popular blueprints, and get useful insights on how users are interacting with the project.

Plus, we remove the option of copying the direct link from the Blueprint Import Card, as shown below:

![image](https://github.com/user-attachments/assets/a62caa41-d4f2-47f7-b477-3d2abe0f8e0a)

This will encourage users to:
- share links to the Website Documentation page and not directly to the GitHub blueprint. This ensures users get the full experience of the project - Docs + Blueprints.
- use MyHomeAssistant to import the blueprint - which has been supported by HA Core for a few years.

A redesign of the Import Blueprint Card will be implemented in a separate PR.

## Checklist\*

- [X] I followed sections of the [Contribution Guidelines](https://github.com/EPMatt/awesome-ha-blueprints/blob/main/CONTRIBUTING.md) relevant to changes I'm proposing.
- [X] I properly tested proposed changes on my system and confirm that they are working as expected.
- [X] I formatted files with Prettier using the command `npm run format` before submitting my Pull Request.
