### PR TITLE
Updated ikea_e1812 to add new double press to triggers and refactored blueprint

### DIFF
--- a/blueprints/controllers/ikea_e1812/ikea_e1812.yaml
+++ b/blueprints/controllers/ikea_e1812/ikea_e1812.yaml
@@ -4,8 +4,10 @@ blueprint:
   description: |
     # Controller - IKEA E1812 TRÅDFRI Shortcut button
 
-    Controller automation for executing any kind of action triggered by the provided IKEA E1812 TRÅDFRI Shortcut button. Allows to optionally loop an action on a button long press.
-    Supports deCONZ, ZHA, Zigbee2MQTT.
+    Controller automation for executing any kind of action triggered by the provided IKEA E1812 TRÅDFRI Shortcut button.
+    Allows to optionally loop an action on a button long press.
+    The blueprint handles double button press events natively as it is supported by the controller device itself.
+    Supports Zigbee2MQTT, ZHA, deCONZ.
 
     Automations created with this blueprint can be connected with one or more [Hooks](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/hooks) supported by this controller.
     Hooks allow to easily create controller-based automations for interacting with media players, lights, covers and more.
@@ -13,7 +15,7 @@ blueprint:
 
     ## More Info
 
-    ℹ️ Version 2025.04.06
+    ℹ️ Version 2025.04.07
     📝 [Changelog](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/controllers/ikea_e1812/#changelog)
     📕 Full documentation regarding this blueprint is available [here](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/controllers/ikea_e1812).
 
@@ -23,18 +25,10 @@ blueprint:
   domain: automation
   homeassistant:
     min_version: 2024.10.0
+  # Device Selector
   input:
-    integration:
-      name: (Required) Integration
-      description: Integration used for connecting the remote with Home Assistant. Select one of the available values.
-      selector:
-        select:
-          options:
-            - deCONZ
-            - ZHA
-            - Zigbee2MQTT
     controller_device:
-      name: (deCONZ, ZHA, Zigbee2MQTT Required) Controller Device
+      name: (Required) (Zigbee2MQTT, ZHA, deCONZ) Controller Device
       description: The controller device to use for the automation. Choose a value only if the remote is integrated with deCONZ, ZHA, Zigbee2MQTT.
       default: ''
       selector:
@@ -48,21 +42,15 @@ blueprint:
             - integration: mqtt
               manufacturer: IKEA
               model: TRADFRI shortcut button (E1812)
-            # source: https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+            # source: https://github.com/zigpy/zha-device-handlers/blob/dev/zhaquirks/ikea/shortcutbtn.py
             - integration: zha
               manufacturer: IKEA of Sweden
               model: TRADFRI SHORTCUT Button
+            # source: https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
             - integration: deconz
               manufacturer: IKEA of Sweden
               model: TRADFRI SHORTCUT Button
           multiple: false
-    helper_last_controller_event:
-      name: (Required) Helper - Last Controller Event
-      description: Input Text used to store the last event fired by the controller. You will need to manually create a text input entity for this, please read the blueprint Additional Notes for more info.
-      default: ''
-      selector:
-        entity:
-          domain: input_text
     # inputs for custom actions
     action_button_short:
       name: (Optional) Button short press
@@ -83,235 +71,296 @@ blueprint:
       selector:
         action:
     action_button_double:
-      name: (Optional) (Virtual) Button double press
+      name: (Optional) Button double press
       description: Action to run on double button press.
       default: []
       selector:
         action:
     # inputs for looping custom actions on long button press events until the corresponding release event is received
-    button_long_loop:
-      name: (Optional) Button long press - loop until release
-      description: Loop the button action until the button is released.
-      default: false
-      selector:
-        boolean:
-    button_long_max_loop_repeats:
-      name: (Optional) Button long press - Maximum loop repeats
-      description: >-
-        Maximum number of repeats for the custom action, when looping is enabled.
-        Use it as a safety limit to prevent an endless loop in case the corresponding stop event is not received.
-      default: 500
-      selector:
-        number:
-          min: 1
-          max: 5000
-          mode: slider
-          step: 1
-    # inputs for enabling double press events
-    button_double_press:
-      name: (Optional) Expose button double press event
-      description: Choose whether or not to expose the virtual double press event for the button. Turn this on if you are providing an action for the button double press event.
-      default: false
-      selector:
-        boolean:
-    # helpers used to properly recognize the remote button events
-    helper_double_press_delay:
-      name: (Optional) Helper - Double Press delay
-      description: Max delay between the first and the second button press for the double press event. Provide a value only if you are using a double press action. Increase this value if you notice that the double press action is not triggered properly.
-      default: 500
-      selector:
-        number:
-          min: 100
-          max: 5000
-          unit_of_measurement: milliseconds
-          mode: box
-          step: 10
-    helper_debounce_delay:
-      name: (Optional) Helper - Debounce delay
-      description:
-        Delay used for debouncing RAW controller events, by default set to 0. A value of 0 disables the debouncing feature. Increase this value if you notice custom actions or linked Hooks running multiple times when interacting with the device. When the controller needs to be debounced,
-        usually a value of 100 is enough to remove all duplicate events.
-      default: 0
-      selector:
-        number:
-          min: 0
-          max: 1000
-          unit_of_measurement: milliseconds
-          mode: box
-          step: 10
+    long_press_options_section:
+      name: Long Press options
+      icon: mdi:remote
+      collapsed: true
+      input:
+        button_long_loop:
+          name: (Optional) Button long press - loop until release
+          description: Loop the button action until the button is released.
+          default: false
+          selector:
+            boolean:
+        button_long_max_loop_repeats:
+          name: (Optional) Button long press - Maximum loop repeats
+          description: >-
+            Maximum number of repeats for the custom action, when looping is enabled.
+            Use it as a safety limit to prevent an endless loop in case the corresponding stop event is not received.
+          default: 20
+          selector:
+            number:
+              min: 1.0
+              max: 1000.0
+              mode: slider
+              step: 1.0
+        helper_long_press_delay:
+          name: (Optional) Helper - Long Press delay
+          description: Max delay between the pushing and releasing of a button long press event. Increase this value if you notice that the long press action is not triggered properly.
+          default: 250
+          selector:
+            number:
+              min: 100.0
+              max: 5000.0
+              unit_of_measurement: milliseconds
+              mode: box
+              step: 10.0
+#
 # Automation schema
 variables:
+  # Controller ID
+  controller_id: !input controller_device
+  # integration id used to select items in the action mapping
+  # integration type is set from trigger.id
+  integration_id: '{{ trigger.id.split("-")[0] }}'
   # convert input tags to variables, to be used in templates
-  integration: !input integration
   button_long_loop: !input button_long_loop
   button_long_max_loop_repeats: !input button_long_max_loop_repeats
-  button_double_press: !input button_double_press
-  helper_last_controller_event: !input helper_last_controller_event
-  helper_double_press_delay: !input helper_double_press_delay
-  helper_debounce_delay: !input helper_debounce_delay
-  # integration id used to select items in the action mapping
-  integration_id: '{{ integration | lower }}'
-  # adjusted debounce delay so that the resulting double press delay is exactly as specified by the user when running the action, taking also account of debouncing
-  # make sure it never goes below the minimum double press delay
-  adjusted_double_press_delay: '{{ [helper_double_press_delay - helper_debounce_delay, 100] | max }}'
+  helper_long_press_delay: !input helper_long_press_delay
   # mapping between actions and integrations
   actions_mapping:
-    deconz:
-      button_short: ['1002']
-      button_long: ['1001']
-      button_release: ['1003']
-    zha:
-      button_short: ['on']
-      button_long: [move_with_on_off_0_83]
-      button_release: [stop]
-    zigbee2mqtt:
+    z2m:
       # source: https://www.zigbee2mqtt.io/devices/E1812.html#ikea-e1812
       button_short: ['on']
       button_long: [brightness_move_up]
       button_release: [brightness_stop]
+      button_double: ['off']
+    zha:
+      # source: https://github.com/zigpy/zha-device-handlers/blob/dev/zhaquirks/ikea/shortcutbtn.py
+      button_short: ['on']
+      button_long: [move_with_on_off_0_83]
+      button_release: [stop]
+      button_double: ['off']
+    dcz:
+      # source: https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+      button_short: ['1002']
+      button_long: ['1001']
+      button_release: ['1003']
+      button_double: ['1004']
   # pre-choose actions for buttons based on configured integration
   # no need to perform this task at automation runtime
   button_short: '{{ actions_mapping[integration_id]["button_short"] }}'
   button_long: '{{ actions_mapping[integration_id]["button_long"] }}'
   button_release: '{{ actions_mapping[integration_id]["button_release"] }}'
-  # build data to send within a controller event
-  controller_id: !input controller_device
-mode: restart
+  button_double: '{{ actions_mapping[integration_id]["button_double"] }}'
+#
+# Mode Block
+mode: single
 max_exceeded: silent
+#
+# Triggers Block
 triggers:
-  # triggers for zigbee2mqtt mqtt device action
+  # triggers for zigbee2mqtt
   - trigger: device
+    id: z2m-button-short
     domain: mqtt
     device_id: !input controller_device
     type: action
     subtype: 'on'
   - trigger: device
+    id: z2m-button-long
     domain: mqtt
     device_id: !input controller_device
     type: action
     subtype: brightness_move_up
   - trigger: device
+    id: z2m-button-release
     domain: mqtt
     device_id: !input controller_device
     type: action
     subtype: brightness_stop
-  # triggers for other integrations
+  - trigger: device
+    id: z2m-button-double
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: 'off'
+  # triggers for ZHA
   - trigger: event
-    event_type:
-      - deconz_event
-      - zha_event
+    id: zha-button-short
+    event_type: zha_event
     event_data:
       device_id: !input controller_device
+      command: 'on'
+      endpoint_id: 1
+      cluster_id: 6
+  - trigger: event
+    id: zha-button-long
+    event_type: zha_event
+    event_data:
+      device_id: !input controller_device
+      command: move
+      endpoint_id: 1
+      cluster_id: 8
+  - trigger: event
+    id: zha-button-release
+    event_type: zha_event
+    event_data:
+      device_id: !input controller_device
+      command: stop
+      endpoint_id: 1
+      cluster_id: 8
+  - trigger: event
+    id: zha-button-double
+    event_type: zha_event
+    event_data:
+      device_id: !input controller_device
+      command: 'off'
+      endpoint_id: 1
+      cluster_id: 6
+  # triggers for deCONZ
+  - trigger: event
+    id: dcz-button-short
+    event_type: deconz_event
+    event_data:
+      device_id: !input controller_device
+      event: '1002'
+  - trigger: event
+    id: dcz-button-long
+    event_type: deconz_event
+    event_data:
+      device_id: !input controller_device
+      event: '1001'
+  - trigger: event
+    id: dcz-button-release
+    event_type: deconz_event
+    event_data:
+      device_id: !input controller_device
+      event: '1003'
+  - trigger: event
+    id: dcz-button-double
+    event_type: deconz_event
+    event_data:
+      device_id: !input controller_device
+      event: '1004'
+#
+# Conditions Block
 conditions:
   - condition: and
     conditions:
       # check that the button event is not empty
       - >-
         {%- set trigger_action -%}
-        {%- if integration_id == "zigbee2mqtt" -%}
+        {%- if integration_id == "z2m" -%}
         {{ trigger.payload }}
-        {%- elif integration_id == "deconz" -%}
-        {{ trigger.event.data.event }}
         {%- elif integration_id == "zha" -%}
         {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
+        {%- elif integration_id == "dcz" -%}
+        {{ trigger.event.data.event }}
         {%- endif -%}
         {%- endset -%}
-        {{ trigger_action not in ["","None"] }}
+        {{ trigger_action not in ["","None","unknown"] }}
+#
+# Actions Block
 actions:
-  # debouncing - when automation is triggered multiple times, the last automation run is the one which completes execution, due to mode restart
-  # therefore previous runs must wait for the debounce delay before executing any other action
-  # if the delay expires and the automation is still running it means it's the last run and execution can continue
-  - delay:
-      milliseconds: !input helper_debounce_delay
-  # extract button event from the trigger
-  # provide a single string value to check against
-  - variables:
-      trigger_action: >-
-        {%- if integration_id == "zigbee2mqtt" -%}
-        {{ trigger.payload }}
-        {%- elif integration_id == "deconz" -%}
-        {{ trigger.event.data.event }}
-        {%- elif integration_id == "zha" -%}
-        {{ trigger.event.data.command }}{{"_" if trigger.event.data.args|length > 0}}{{ trigger.event.data.args|join("_") }}
-        {%- endif -%}
-      trigger_delta: '{{ (as_timestamp(now()) - ((states(helper_last_controller_event) | from_json).t if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{((\"a\":\".*\"|\"t\":\d+\.\d+)(,)?){2}\}$")) else as_timestamp("1970-01-01 00:00:00"))) * 1000 }}'
-  # update helper
-  - action: input_text.set_value
-    data:
-      entity_id: !input helper_last_controller_event
-      value: '{{ {"a":trigger_action,"t":as_timestamp(now())} | to_json }}'
+  #
   # choose the sequence to run based on the received button event
   - choose:
-      - conditions: '{{ trigger_action | string in button_short }}'
+      #
+      # Actions for Button single press
+      - conditions:
+          - condition: trigger
+            id:
+              - z2m-button-short
+              - zha-button-short
+              - dcz-button-short
         sequence:
+          # fire the ahb hook event
+          - event: ahb_controller_event
+            event_data:
+              controller: '{{ controller_id }}'
+              action: button_short
+          # run the custom action
           - choose:
-              # if double press event is enabled
-              - conditions: '{{ button_double_press }}'
-                sequence:
-                  - choose:
-                      # if previous event was a short press
-                      - conditions: '{{ trigger_action | string == last_controller_event and trigger_delta | int <= helper_double_press_delay | int }}'
-                        sequence:
-                          # store the double press event in the last controller event helper
-                          - action: input_text.set_value
-                            data:
-                              entity_id: !input helper_last_controller_event
-                              value: '{{ {"a":"double_press","t":as_timestamp(now())} | to_json }}'
-                          # run the double press action
-                          # fire the event
-                          - event: ahb_controller_event
-                            event_data:
-                              controller: '{{ controller_id }}'
-                              action: button_double
-                          # run the custom action
-                          - choose:
-                              - conditions: []
-                                sequence: !input action_button_double
-                    # previous event was not a short press
-                    default:
-                      # wait for the double press event to occur, within the provided delay
-                      # if the second press is received, automation is restarted
-                      - delay:
-                          milliseconds: '{{ adjusted_double_press_delay }}'
-                      # if delay expires, no second press was received, therefore run the short press action
-                      # run the short press action
-                      # fire the event
-                      - event: ahb_controller_event
-                        event_data:
-                          controller: '{{ controller_id }}'
-                          action: button_short
-                      # run the custom action
-                      - choose:
-                          - conditions: []
-                            sequence: !input action_button_short
-            # if double press event is disabled run the action for the single short press
-            default:
-              # fire the event
-              - event: ahb_controller_event
-                event_data:
-                  controller: '{{ controller_id }}'
-                  action: button_short
-              # run the custom action
-              - choose:
-                  - conditions: []
-                    sequence: !input action_button_short
-      - conditions: '{{ trigger_action | string in button_long }}'
+              - conditions: []
+                sequence: !input action_button_short
+      #
+      # Actions for Button Long Press
+      - conditions:
+          - condition: trigger
+            id:
+              - z2m-button-long
+              - zha-button-long
+              - dcz-button-long
         sequence:
-          # fire the event only once before looping the action
+          # fire the ahb event only once, the ahb hook will take care of looping
           - event: ahb_controller_event
             event_data:
               controller: '{{ controller_id }}'
               action: button_long
+          # run the custom action only once before entering repeat
           - choose:
-              # if looping is enabled, loop the action for a finite number of iterations
+              - conditions: []
+                sequence: !input action_button_long
+          # handle custom action looping if looping is enabled
+          - choose:
               - conditions: '{{ button_long_loop }}'
                 sequence:
+                  # Repeat the Long Press Actions for the set number of loops
                   - repeat:
-                      while: '{{ repeat.index < button_long_max_loop_repeats | int }}'
-                      sequence: !input action_button_long
-            # if looping is not enabled run the custom action only once
-            default: !input action_button_long
-      - conditions: '{{ trigger_action | string in button_release }}'
+                      count: !input button_long_max_loop_repeats
+                      sequence:
+                        - parallel:
+                            - sequence: !input action_button_long
+                            - sequence:
+                                - choose:
+                                    - conditions: []
+                                      sequence:
+                                        # Wait for z2m/zha/dcz triggers for Button Long Press Release to stop looping
+                                        - wait_for_trigger:
+                                            # z2m triggers
+                                            - trigger: device
+                                              domain: mqtt
+                                              device_id: !input controller_device
+                                              type: action
+                                              subtype: stop
+                                            # zha triggers
+                                            - trigger: event
+                                              event_type: zha_event
+                                              event_data:
+                                                device_id: !input controller_device
+                                                command: stop
+                                                endpoint_id: 1
+                                                cluster_id: 8
+                                            # dcz triggers
+                                            - trigger: event
+                                              event_type: deconz_event
+                                              event_data:
+                                                device_id: !input controller_device
+                                                event: '1003'
+                                          timeout:
+                                            milliseconds: !input helper_long_press_delay
+                                          continue_on_timeout: true
+                                        # If a Button Long Release is triggered wait.trigger.idx will be defined stop the loop before long_max_loop_repeats
+                                        - if:
+                                            - condition: template
+                                              value_template: '{{ wait.trigger.idx is defined }}'
+                                          then:
+                                            # fire the event
+                                            - event: ahb_controller_event
+                                              event_data:
+                                                controller: '{{ controller_id }}'
+                                                action: button_release
+                                            # run the custom action
+                                            - choose:
+                                                - conditions: []
+                                                  sequence: !input action_button_release
+                                            # Stop the repeat loop
+                                            - stop: button_released
+      #
+      # Actions for Button Release Press
+      - conditions:
+          - condition: trigger
+            id:
+              - z2m-button-release
+              - zha-button-release
+              - dcz-button-release
         sequence:
           # fire the event
           - event: ahb_controller_event
@@ -322,3 +371,21 @@ actions:
           - choose:
               - conditions: []
                 sequence: !input action_button_release
+      #
+      # Actions for Button Double Press
+      - conditions:
+          - condition: trigger
+            id:
+              - z2m-button-double
+              - zha-button-double
+              - dcz-button-double
+        sequence:
+          # fire the event
+          - event: ahb_controller_event
+            event_data:
+              controller: '{{ controller_id }}'
+              action: button_double
+          # run the custom action
+          - choose:
+              - conditions: []
+                sequence: !input action_button_double

--- a/blueprints/controllers/ikea_e1812/ikea_e1812.yaml
+++ b/blueprints/controllers/ikea_e1812/ikea_e1812.yaml
@@ -15,7 +15,7 @@ blueprint:
 
     ## More Info
 
-    ℹ️ Version 2025.04.07
+    ℹ️ Version 2025.04.12
     📝 [Changelog](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/controllers/ikea_e1812/#changelog)
     📕 Full documentation regarding this blueprint is available [here](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/controllers/ikea_e1812).
 

--- a/website/docs/blueprints/controllers/ikea_e1812.mdx
+++ b/website/docs/blueprints/controllers/ikea_e1812.mdx
@@ -124,7 +124,7 @@ This Hook blueprint allows to build a controller-based automation to control a c
 
 - **2025-03-20**: Standardized input naming format for controller devices and virtual button actions. No functionality changes.
 - **2025-04-06**: Fix double-click detection logic. ([@danleongjy](https://github.com/danleongjy))
-- **2025-04-07**:
+- **2025-04-12**:
 
   :warning: **Breaking Change**:
 

--- a/website/docs/blueprints/controllers/ikea_e1812.mdx
+++ b/website/docs/blueprints/controllers/ikea_e1812.mdx
@@ -28,8 +28,6 @@ This blueprint provides universal support for running any custom action when a b
 
 In addition of being able to provide custom actions for every kind of button press supported by the remote, the blueprint allows to loop the long press actions while the corresponding button is being held. Once released, the loop stops. This is useful when holding down a button should result in a continuous action (such as lowering the volume of a media player, or controlling a light brightness).
 
-The blueprint also adds support for virtual double button press events, which are not exposed by the controller itself.
-
 :::tip
 Automations created with this blueprint can be connected with one or more [Hooks](/docs/blueprints/hooks) supported by this controller.
 Hooks allow to easily create controller-based automations for interacting with media players, lights, covers and more. See the list of [Hooks available for this controller](/docs/blueprints/controllers/ikea_e1812#available-hooks) for additional details.
@@ -37,27 +35,15 @@ Hooks allow to easily create controller-based automations for interacting with m
 
 ## Requirements
 
-<Requirement id='zigbee2mqtt'/>
-<Requirement id='zha'/>
-<Requirement id='deconz'/>
-<Requirement name='Input Text Integration' required>
-
-This integration provides the entity which must be provided to the blueprint in the **Helper - Last Controller Event** input. Learn more about this helper by reading the dedicated section in the [Additional Notes](#helper---last-controller-event).
-
-[Input Text Integration Docs](https://www.home-assistant.io/integrations/input_text/)
-
-</Requirement>
+<Requirement id='zigbee2mqtt' />
+<Requirement id='zha' />
+<Requirement id='deconz' />
 
 ## Inputs
 
 <Inputs category='controllers' id='ikea_e1812' />
 
 ## Available Hooks
-
-:::note Virtual double press actions
-Some of the following mappings might include actions for virtual double press events, which are disabled by default.
-If you are using a hook mapping which provides an action for a virtual double press event, please make sure to enable support for virtual double press on the corresponding buttons with the corresponding blueprint input.
-:::
 
 ### Light
 
@@ -66,7 +52,7 @@ This Hook blueprint allows to build a controller-based automation to control a l
 #### Default Mapping
 
 - Button short press -> Toggle
-- Button double press `Virtual` -> Color up
+- Button double press -> Color up
 
 [Light Hook docs](/docs/blueprints/hooks/light)
 
@@ -78,7 +64,7 @@ This Hook blueprint allows to build a controller-based automation to control a m
 
 - Button short press -> Play/Pause
 - Button long press -> Stop
-- Button double press `Virtual` -> Next track
+- Button double press -> Next track
 
 [Media Player Hook docs](/docs/blueprints/hooks/media_player)
 
@@ -90,19 +76,11 @@ This Hook blueprint allows to build a controller-based automation to control a c
 
 - Button short press -> Open cover
 - Button long press -> Stop cover and cover tilt
-- Button double press `Virtual` -> Close cover
+- Button double press -> Close cover
 
 [Cover Hook docs](/docs/blueprints/hooks/cover)
 
 ## Additional Notes
-
-### Helper - Last Controller Event
-
-The `helper_last_controller_event` (Helper - Last Controller Event) input serves as a permanent storage area for the automation. The stored info is used to implement the blueprint's core functionality. To learn more about the helper, how it's used and why it's required, you can read the dedicated section in the [Controllers-Hooks Ecosystem documentation](/docs/controllers-hooks-ecosystem#helper---last-controller-event-input).
-
-### Virtual double press events
-
-It's also important to note that the controller doesn't natively support double press events. Instead , this blueprint provides virtual double press events. You can read more about them in the [general Controllers-Hooks Ecosystem documentation](/docs/controllers-hooks-ecosystem#virtual-events).
 
 ## Changelog
 
@@ -146,3 +124,19 @@ It's also important to note that the controller doesn't natively support double 
 
 - **2025-03-20**: Standardized input naming format for controller devices and virtual button actions. No functionality changes.
 - **2025-04-06**: Fix double-click detection logic. ([@danleongjy](https://github.com/danleongjy))
+- **2025-04-07**:
+
+  :warning: **Breaking Change**:
+
+  Updated to add new double press to triggers and refactored blueprint to use triggers and trigger-id. ([@yarafie](https://github.com/yarafie))
+
+  The blueprint needs to be re-downloaded and automations using the blueprint needs to be set-up again.
+
+  This is due to the changes below:
+
+  - The need for selection of `integration` type has been removed from the inputs, the blueprint/automation will detect it automatically.
+  - The `helper_last_controller_event` text input is no longer needed and has been removed from the inputs.
+
+  **Other changes:**
+
+  Double press events are now natively supported.


### PR DESCRIPTION
Thank you for taking the time to work on a Pull Request. Your contribution is really appreciated! :tada:
**Please don't delete any part of the template**, since keeping the provided structure will help maintainers to review your work more rapidly.

Sections marked as \* are required and need to be filled in.

## Breaking change

Blueprint will need to be re-downloaded and automations re-configured due to refactoring.

## Proposed change\*

Refactored blueprint to use triggers.
Removed dependency on helper last controller event.
Added double press as supported natively by device.
Enhanced long press events looping if enabled to stop on release action.

## Checklist\*

- [Y] I followed sections of the [Contribution Guidelines](https://github.com/EPMatt/awesome-ha-blueprints/blob/main/CONTRIBUTING.md) relevant to changes I'm proposing.
- [Y] I properly tested proposed changes on my system and confirm that they are working as expected.
- [Y] I formatted files with Prettier using the command `npm run format` before submitting my Pull Request.
