### PR TITLE
Update philips_929002398602.yaml

### DIFF
--- a/blueprints/controllers/philips_929002398602/philips_929002398602.yaml
+++ b/blueprints/controllers/philips_929002398602/philips_929002398602.yaml
@@ -51,6 +51,8 @@ blueprint:
             - integration: zha
               manufacturer: Philips
               # **TBConfirmed** model:
+            - integration: zha
+              model: RWL022
             - integration: deconz
               manufacturer: Philips
               # **TBConfirmed** model:


### PR DESCRIPTION
## Proposed change\*

This adds another instance of Philips Hue Dimmer v2 switch (bought in Croatia). It states the following model and manufacturer
<img width="208" alt="Screenshot 2025-04-22 at 22 01 24" src="https://github.com/user-attachments/assets/3b72e4ca-2d78-470e-b58b-72c794d953df" />

but I've been unable to get the manufacturer filter working properly.

## Checklist\*

- [x] I followed sections of the [Contribution Guidelines](https://github.com/EPMatt/awesome-ha-blueprints/blob/main/CONTRIBUTING.md) relevant to changes I'm proposing.
- [x] I properly tested proposed changes on my system and confirm that they are working as expected.
- [x] I formatted files with Prettier using the command `npm run format` before submitting my Pull Request.
