### PR TITLE
Allow to disable turning on light with brightness up command

### DIFF
--- a/blueprints/hooks/light/light.yaml
+++ b/blueprints/hooks/light/light.yaml
@@ -513,6 +513,10 @@ actions:
                       entity_id: !input light
                   - delay:
                       milliseconds: !input light_transition
+                  - wait_template: '{{ is_number(state_attr(light,"brightness")) }}'
+                    timeout:
+                      seconds: 1
+                    continue_on_timeout: false
               # if light is off and smooth power on is enabled, turn it on at minimum brightness
               - conditions: '{{ states(light) == "off" and smooth_power_on}}'
                 sequence:
@@ -523,6 +527,10 @@ actions:
                       entity_id: !input light
                   - delay:
                       milliseconds: !input light_transition
+                  - wait_template: '{{ is_number(state_attr(light,"brightness")) }}'
+                    timeout:
+                      seconds: 1
+                    continue_on_timeout: false
           # else move on to the loop for increasing the light brightness until the maximum brightness is reached
           - repeat:
               while: '{{ state_attr(light,"brightness") < max_brightness }}'

--- a/blueprints/hooks/light/light.yaml
+++ b/blueprints/hooks/light/light.yaml
@@ -153,6 +153,12 @@ blueprint:
           step: 1
           unit_of_measurement: brightness
           mode: slider
+    allow_brightness_power_on:
+      name: (Optional) Allow brightness up command to power on
+      description: Turn on the light when a brightness up command (single or continuous) is triggered and light is off.
+      default: true
+      selector:
+        boolean:
     smooth_power_on:
       name: (Optional) Smooth power on
       description: Force the light to turn on at minimum brightness when a brightness up command (single or continuous) is triggered and light is off.
@@ -384,6 +390,7 @@ variables:
   brightness_steps_long: !input brightness_steps_long
   force_brightness: !input force_brightness
   on_brightness: !input on_brightness
+  allow_brightness_power_on: !input allow_brightness_power_on
   smooth_power_on: !input smooth_power_on
   smooth_power_off: !input smooth_power_off
   color_modes:
@@ -448,21 +455,27 @@ actions:
       - conditions: '{{ action == brightness_up }}'
         sequence:
           - choose:
-              # if light is off and smooth power on is disabled, turn it on at the previously saved brightness
-              - conditions: '{{ states(light) == "off" and not smooth_power_on}}'
+              # handle situation when light is off
+              - conditions: '{{ states(light) == "off"}}'
                 sequence:
-                  - action: light.turn_on
-                    data:
-                      transition: '{{ light_transition / 1000 }}'
-                      entity_id: !input light
-              # if light is off and smooth power on is enabled, turn it on at minimum brightness
-              - conditions: '{{ states(light) == "off" and smooth_power_on}}'
-                sequence:
-                  - action: light.turn_on
-                    data:
-                      brightness: '{{ min_brightness }}'
-                      transition: '{{ light_transition / 1000 }}'
-                      entity_id: !input light
+                  # only contiue if brightnes up is allowed to power on, otherwise do nothing
+                  - condition: '{{ allow_brightness_power_on }}'
+                  - choose:
+                      # if smooth power on is disabled, turn it on at the previously saved brightness
+                      - conditions: '{{ not smooth_power_on}}'
+                        sequence:
+                          - action: light.turn_on
+                            data:
+                              transition: '{{ light_transition / 1000 }}'
+                              entity_id: !input light
+                      # if smooth power on is enabled, turn it on at minimum brightness
+                      - conditions: '{{ smooth_power_on}}'
+                        sequence:
+                          - action: light.turn_on
+                            data:
+                              brightness: '{{ min_brightness }}'
+                              transition: '{{ light_transition / 1000 }}'
+                              entity_id: !input light
             # else the light is on, hence increase its brightness
             default:
               - action: light.turn_on
@@ -487,6 +500,8 @@ actions:
                   entity_id: !input light
       - conditions: '{{ action == brightness_up_repeat }}'
         sequence:
+          # only contiue if lights are alreay on or brightnes up is allowed to power on
+          - condition: '{{ states(light) == "on" or allow_brightness_power_on}}'
           # first step for the smooth power on feature: subsequent steps can skip this check since light will be already on
           - choose:
               # if light is off and smooth power on is disabled, turn it on at the previously saved brightness

--- a/website/docs/blueprints/hooks/light.mdx
+++ b/website/docs/blueprints/hooks/light.mdx
@@ -131,3 +131,4 @@ If you want to link multiple lights to the same controller you can either use [L
 - **2025-03-26**: Added support for IKEA E2213 SOMRIG shortcut button. ([@yarafie](https://github.com/yarafie))
 - **2025-03-28**: Added support for IKEA E2123 SYMFONISK sound remote, gen 2. ([@yarafie](https://github.com/yarafie))
 - **2025-03-29**: Added support for Tuya ERS-10TZBVK-AA Smart knob. ([@yarafie](https://github.com/yarafie))
+- **2025-05-15**: Added config option to disable turning on the light with a brightness up command ([@Alcoinus](https://github.com/Alcoinus))


### PR DESCRIPTION
Thank you for taking the time to work on a Pull Request. Your contribution is really appreciated! :tada:
**Please don't delete any part of the template**, since keeping the provided structure will help maintainers to review your work more rapidly.

Sections marked as \* are required and need to be filled in.

## Proposed change\*

This adds a configuration option to the light hook, which allows to disable turning on a light with brightness up command. Right now, when a light is turned off and brightness up command (both single or repeat) is received, the light will be turned on. As this might not be wanted all the time, when unchecking the option, brightness up commands will be dropped when a light is turned off.

The functionality of the smooth power on option stays unchanged but is now dependent of the newly added option.

The initial reason, why I looked into this, is fixed with the second commit of this PR. My particular light (a Zigbee group of two lights) takes some time to report the brightness value after being turned on. Even after the transition time, it takes another 50 to 100 milliseconds until a brightness value is reported. To deal with this, I introduced a wait action with a timeout of 1 second.

## Checklist\*

- [x] I followed sections of the [Contribution Guidelines](https://github.com/EPMatt/awesome-ha-blueprints/blob/main/CONTRIBUTING.md) relevant to changes I'm proposing.
- [x] I properly tested proposed changes on my system and confirm that they are working as expected.
- [x] I formatted files with Prettier using the command `npm run format` before submitting my Pull Request.
