### PR TITLE
Philips short button press fix

### DIFF
--- a/blueprints/controllers/philips_929002398602/philips_929002398602.yaml
+++ b/blueprints/controllers/philips_929002398602/philips_929002398602.yaml
@@ -309,10 +309,10 @@ variables:
   # mapping between actions and integrations
   actions_mapping:
     zha:
-      button_on_short: [on_press, on_press_release]
+      button_on_short: [on_press_release]
       button_on_long: [on_hold]
       button_on_release: [on_long_release]
-      button_off_short: [off_press, off_press_release]
+      button_off_short: [off_press_release]
       button_off_long: [off_hold]
       button_off_release: [off_long_release]
       button_up_short: [up_press]
@@ -323,10 +323,10 @@ variables:
       button_down_release: [down_long_release]
     zigbee2mqtt:
       # source: https://www.zigbee2mqtt.io/devices/929002398602.html#philips-929002398602
-      button_on_short: [on_press, on_press_release]
+      button_on_short: [on_press_release]
       button_on_long: [on_hold]
       button_on_release: [on_hold_release]
-      button_off_short: [off_press, off_press_release]
+      button_off_short: [off_press_release]
       button_off_long: [off_hold]
       button_off_release: [off_hold_release]
       button_up_short: [up_press]

--- a/website/docs/blueprints/controllers/philips_929002398602.mdx
+++ b/website/docs/blueprints/controllers/philips_929002398602.mdx
@@ -121,3 +121,4 @@ It's also important to note that the controller doesn't natively support double 
 - **2025-04-02**: Fix trigger_delta regex, with optional whitespacing. ([@TTvanWillegen](https://github.com/TTvanWillegen))
 - **2025-04-06**: Fix double-click detection logic. ([@danleongjy](https://github.com/danleongjy))
 - **2025-04-19**: Improve Last Controller Event Helper JSON Regex with more lenient matching.
+- **2025-06-28**: Stop actions from double-running for short on and off presses.


### PR DESCRIPTION
## Proposed change\*

There is a bug in the philips_929002398602 controller logic. The button_on_short and button_off_short are triggered by both the pressing and releasing of the button. This causes problems if the action for the button_on/off_short changes the behavior of future calls for the same action. For example, if the action calls "light.toggle", the net result of toggling a light that is off is that the light remains off, since toggle is called twice. 

This pull request fixes this issue by only triggering for on/off_press_release instead of both on/off_press and on/off_press_release. This is the same logic that is used in philips_324131092621.yaml.



## Checklist\*

- [X] I followed sections of the [Contribution Guidelines](https://github.com/EPMatt/awesome-ha-blueprints/blob/main/CONTRIBUTING.md) relevant to changes I'm proposing.
- [X] I properly tested proposed changes on my system and confirm that they are working as expected.
- [X] I formatted files with Prettier using the command `npm run format` before submitting my Pull Request.
