### PR TITLE
Repeat hold action fix

### DIFF
--- a/blueprints/controllers/philips_929002398602/philips_929002398602.yaml
+++ b/blueprints/controllers/philips_929002398602/philips_929002398602.yaml
@@ -539,8 +539,10 @@ actions:
                   - repeat:
                       while: '{{ repeat.index < button_on_long_max_loop_repeats | int }}'
                       sequence: !input action_button_on_long
-            # if looping is not enabled run the custom action only once
-            default: !input action_button_on_long
+              # if looping is not enabled run the custom action only once
+              # Don't run custom action again if the controller sends more than one button_on_long requests
+              - conditions: '{{ deserialized_state.a != "on_hold" }}'
+                sequence: !input action_button_on_long
       - conditions: '{{ trigger_action | string in button_on_release }}'
         sequence:
           # fire the event
@@ -619,8 +621,10 @@ actions:
                   - repeat:
                       while: '{{ repeat.index < button_off_long_max_loop_repeats | int }}'
                       sequence: !input action_button_off_long
-            # if looping is not enabled run the custom action only once
-            default: !input action_button_off_long
+              # if looping is not enabled run the custom action only once
+              # Don't run custom action again if the controller sends more than one button_off_long requests
+              - conditions: '{{ deserialized_state.a != "off_hold" }}'
+                sequence: !input action_button_off_long
       - conditions: '{{ trigger_action | string in button_off_release }}'
         sequence:
           # fire the event
@@ -699,8 +703,10 @@ actions:
                   - repeat:
                       while: '{{ repeat.index < button_up_long_max_loop_repeats | int }}'
                       sequence: !input action_button_up_long
-            # if looping is not enabled run the custom action only once
-            default: !input action_button_up_long
+              # if looping is not enabled run the custom action only once
+              # Don't run custom action again if the controller sends more than one button_up_long requests
+              - conditions: '{{ deserialized_state.a != "up_hold" }}'
+                sequence: !input action_button_up_long
       - conditions: '{{ trigger_action | string in button_up_release }}'
         sequence:
           # fire the event
@@ -779,8 +785,10 @@ actions:
                   - repeat:
                       while: '{{ repeat.index < button_down_long_max_loop_repeats | int }}'
                       sequence: !input action_button_down_long
-            # if looping is not enabled run the custom action only once
-            default: !input action_button_down_long
+              # if looping is not enabled run the custom action only once
+              # Don't run custom action again if the controller sends more than one button_down_long requests
+              - conditions: '{{ deserialized_state.a != "down_hold" }}'
+                sequence: !input action_button_down_long
       - conditions: '{{ trigger_action | string in button_down_release }}'
         sequence:
           # fire the event

--- a/website/docs/blueprints/controllers/philips_929002398602.mdx
+++ b/website/docs/blueprints/controllers/philips_929002398602.mdx
@@ -121,3 +121,4 @@ It's also important to note that the controller doesn't natively support double 
 - **2025-04-02**: Fix trigger_delta regex, with optional whitespacing. ([@TTvanWillegen](https://github.com/TTvanWillegen))
 - **2025-04-06**: Fix double-click detection logic. ([@danleongjy](https://github.com/danleongjy))
 - **2025-04-19**: Improve Last Controller Event Helper JSON Regex with more lenient matching.
+- **2025-06-28**: Stop action from looping when holding buttons unless looping is explicitly set. 


### PR DESCRIPTION
## Proposed change\*

When holding a button on the Philips 929002398602 remote, the remote sends new _x_hold_ commands about every second until the hold is released at which point it sends an _x_hold_release_ command.

As the automation is currently written, this results in the action for _x_hold_ being re-run every time a new _x_hold_ command comes in. This can cause issues when you want a single action to run uninterrupted until _x_hold_release_ comes in. 

This uses the "Last Controller Event" to check and only run the _x_hold_ action if the last action **was not** _x_hold_. This results in the _x_hold_ action being run only a single time for a given button-hold event. This does not affect the loop if looping is enabled (in this case, the looping is desired).  


## Checklist\*

- [X] I followed sections of the [Contribution Guidelines](https://github.com/EPMatt/awesome-ha-blueprints/blob/main/CONTRIBUTING.md) relevant to changes I'm proposing.
- [X] I properly tested proposed changes on my system and confirm that they are working as expected.
- [X] I formatted files with Prettier using the command `npm run format` before submitting my Pull Request.
