### PR TITLE
philips_929002398602: Add Native double press support for RWL022

### DIFF
--- a/blueprints/controllers/philips_929002398602/philips_929002398602.yaml
+++ b/blueprints/controllers/philips_929002398602/philips_929002398602.yaml
@@ -13,7 +13,7 @@ blueprint:
 
     ## More Info
 
-    ℹ️ Version 2025.04.19
+    ℹ️ Version 2025.07.15
     📝 [Changelog](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/controllers/philips_929002398602/#changelog)
     📕 Full documentation regarding this blueprint is available [here](https://epmatt.github.io/awesome-ha-blueprints/docs/blueprints/controllers/philips_929002398602).
 
@@ -51,8 +51,14 @@ blueprint:
             - integration: zha
               manufacturer: Philips
               # **TBConfirmed** model:
+            - integration: zha
+              manufacturer: Signify Netherlands B.V.
+              # **TBConfirmed** model:
             - integration: deconz
               manufacturer: Philips
+              # **TBConfirmed** model:
+            - integration: deconz
+              manufacturer: Signify Netherlands B.V.
               # **TBConfirmed** model:
           multiple: false
     helper_last_controller_event:
@@ -82,8 +88,8 @@ blueprint:
       selector:
         action:
     action_button_on_double:
-      name: (Optional) (Virtual) On button double press
-      description: Action to run on double on button press.
+      name: (Optional) On button double press
+      description: Action to run on double on button press (Native for RWL022, Virtual for RWL020/RWL21).
       default: []
       selector:
         action:
@@ -106,8 +112,8 @@ blueprint:
       selector:
         action:
     action_button_off_double:
-      name: (Optional) (Virtual) Off button double press
-      description: Action to run on double off button press.
+      name: (Optional) Off button double press
+      description: Action to run on double off button press (Native for RWL022, Virtual for RWL020/RWL21).
       default: []
       selector:
         action:
@@ -130,8 +136,8 @@ blueprint:
       selector:
         action:
     action_button_up_double:
-      name: (Optional) (Virtual) Up button double press
-      description: Action to run on double up button press.
+      name: (Optional) Up button double press
+      description: Action to run on double up button press (Native for RWL022, Virtual for RWL020/RWL21).
       default: []
       selector:
         action:
@@ -154,8 +160,8 @@ blueprint:
       selector:
         action:
     action_button_down_double:
-      name: (Optional) (Virtual) Down button double press
-      description: Action to run on double down button press.
+      name: (Optional) Down button double press
+      description: Action to run on double down button press (Native for RWL022, Virtual for RWL020/RWL21).
       default: []
       selector:
         action:
@@ -233,26 +239,26 @@ blueprint:
           mode: slider
           step: 1
     # inputs for enabling double press events
-    button_on_double_press:
-      name: (Optional) Expose on button double press event
+    button_on_double_press_virtual:
+      name: (Optional) Expose Virtual on button double press event
       description: Choose whether or not to expose the virtual double press event for the on button. Turn this on if you are providing an action for the on button double press event.
       default: false
       selector:
         boolean:
-    button_off_double_press:
-      name: (Optional) Expose off button double press event
+    button_off_double_press_virtual:
+      name: (Optional) Expose Virtual off button double press event
       description: Choose whether or not to expose the virtual double press event for the off button. Turn this on if you are providing an action for the off button double press event.
       default: false
       selector:
         boolean:
-    button_up_double_press:
-      name: (Optional) Expose up button double press event
+    button_up_double_press_virtual:
+      name: (Optional) Expose Vritual up button double press event
       description: Choose whether or not to expose the virtual double press event for the up button. Turn this on if you are providing an action for the up button double press event.
       default: false
       selector:
         boolean:
-    button_down_double_press:
-      name: (Optional) Expose down button double press event
+    button_down_double_press_virtual:
+      name: (Optional) Expose Virtual down button double press event
       description: Choose whether or not to expose the virtual double press event for the down button. Turn this on if you are providing an action for the down button double press event.
       default: false
       selector:
@@ -288,16 +294,16 @@ variables:
   integration: !input integration
   button_on_long_loop: !input button_on_long_loop
   button_on_long_max_loop_repeats: !input button_on_long_max_loop_repeats
-  button_on_double_press: !input button_on_double_press
+  button_on_double_press_virtual: !input button_on_double_press_virtual
   button_off_long_loop: !input button_off_long_loop
   button_off_long_max_loop_repeats: !input button_off_long_max_loop_repeats
-  button_off_double_press: !input button_off_double_press
+  button_off_double_press_virtual: !input button_off_double_press_virtual
   button_up_long_loop: !input button_up_long_loop
   button_up_long_max_loop_repeats: !input button_up_long_max_loop_repeats
-  button_up_double_press: !input button_up_double_press
+  button_up_double_press_virtual: !input button_up_double_press_virtual
   button_down_long_loop: !input button_down_long_loop
   button_down_long_max_loop_repeats: !input button_down_long_max_loop_repeats
-  button_down_double_press: !input button_down_double_press
+  button_down_double_press_virtual: !input button_down_double_press_virtual
   helper_last_controller_event: !input helper_last_controller_event
   helper_double_press_delay: !input helper_double_press_delay
   helper_debounce_delay: !input helper_debounce_delay
@@ -312,43 +318,55 @@ variables:
       button_on_short: [on_press, on_press_release]
       button_on_long: [on_hold]
       button_on_release: [on_long_release]
+      button_on_double: [on_double_press]
       button_off_short: [off_press, off_press_release]
       button_off_long: [off_hold]
       button_off_release: [off_long_release]
+      button_off_double: [off_double_press]
       button_up_short: [up_press]
       button_up_long: [up_hold]
       button_up_release: [up_long_release]
+      button_up_double: [up_double_press]
       button_down_short: [down_press]
       button_down_long: [down_hold]
       button_down_release: [down_long_release]
+      button_down_double: [down_double_press]
     zigbee2mqtt:
       # source: https://www.zigbee2mqtt.io/devices/929002398602.html#philips-929002398602
       button_on_short: [on_press, on_press_release]
       button_on_long: [on_hold]
       button_on_release: [on_hold_release]
+      button_on_double: [on_double_press]
       button_off_short: [off_press, off_press_release]
       button_off_long: [off_hold]
       button_off_release: [off_hold_release]
+      button_off_double: [off_double_press]
       button_up_short: [up_press]
       button_up_long: [up_hold]
       button_up_release: [up_hold_release]
+      button_up_double: [up_double_press]
       button_down_short: [down_press]
       button_down_long: [down_hold]
       button_down_release: [down_hold_release]
+      button_down_double: [down_double_press]
   # pre-choose actions for buttons based on configured integration
   # no need to perform this task at automation runtime
   button_on_short: '{{ actions_mapping[integration_id]["button_on_short"] }}'
   button_on_long: '{{ actions_mapping[integration_id]["button_on_long"] }}'
   button_on_release: '{{ actions_mapping[integration_id]["button_on_release"] }}'
+  button_on_double: '{{ actions_mapping[integration_id]["button_on_double"] }}'
   button_off_short: '{{ actions_mapping[integration_id]["button_off_short"] }}'
   button_off_long: '{{ actions_mapping[integration_id]["button_off_long"] }}'
   button_off_release: '{{ actions_mapping[integration_id]["button_off_release"] }}'
+  button_off_double: '{{ actions_mapping[integration_id]["button_off_double"] }}'
   button_up_short: '{{ actions_mapping[integration_id]["button_up_short"] }}'
   button_up_long: '{{ actions_mapping[integration_id]["button_up_long"] }}'
   button_up_release: '{{ actions_mapping[integration_id]["button_up_release"] }}'
+  button_up_double: '{{ actions_mapping[integration_id]["button_up_double"] }}'
   button_down_short: '{{ actions_mapping[integration_id]["button_down_short"] }}'
   button_down_long: '{{ actions_mapping[integration_id]["button_down_long"] }}'
   button_down_release: '{{ actions_mapping[integration_id]["button_down_release"] }}'
+  button_down_double: '{{ actions_mapping[integration_id]["button_down_double"] }}'
   # build data to send within a controller event
   controller_id: !input controller_device
 mode: restart
@@ -379,6 +397,11 @@ triggers:
     domain: mqtt
     device_id: !input controller_device
     type: action
+    subtype: on_double_press
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
     subtype: off_press
   - trigger: device
     domain: mqtt
@@ -399,6 +422,11 @@ triggers:
     domain: mqtt
     device_id: !input controller_device
     type: action
+    subtype: off_double_press
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
     subtype: up_press
   - trigger: device
     domain: mqtt
@@ -414,6 +442,11 @@ triggers:
     domain: mqtt
     device_id: !input controller_device
     type: action
+    subtype: up_double_press
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
     subtype: down_press
   - trigger: device
     domain: mqtt
@@ -425,6 +458,11 @@ triggers:
     device_id: !input controller_device
     type: action
     subtype: down_hold_release
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: down_double_press
   # triggers for other integrations
   - trigger: event
     event_type:
@@ -475,8 +513,8 @@ actions:
       - conditions: '{{ trigger_action | string in button_on_short }}'
         sequence:
           - choose:
-              # if double press event is enabled
-              - conditions: '{{ button_on_double_press }}'
+              # if virtual double press event is enabled
+              - conditions: '{{ button_on_double_press_virtual }}'
                 sequence:
                   - choose:
                       # if previous event was a short press
@@ -525,6 +563,17 @@ actions:
               - choose:
                   - conditions: []
                     sequence: !input action_button_on_short
+      - conditions: '{{ trigger_action | string in button_on_double }}'
+        sequence:
+          # fire the event only once before looping the action
+          - event: ahb_controller_event
+            event_data:
+              controller: '{{ controller_id }}'
+              action: button_on_double
+          # run the custom action
+          - choose:
+              - conditions: []
+                sequence: !input action_button_on_double
       - conditions: '{{ trigger_action | string in button_on_long }}'
         sequence:
           # fire the event only once before looping the action
@@ -605,6 +654,17 @@ actions:
               - choose:
                   - conditions: []
                     sequence: !input action_button_off_short
+      - conditions: '{{ trigger_action | string in button_off_double }}'
+        sequence:
+          # fire the event only once before looping the action
+          - event: ahb_controller_event
+            event_data:
+              controller: '{{ controller_id }}'
+              action: button_off_double
+          # run the custom action
+          - choose:
+              - conditions: []
+                sequence: !input action_button_off_double
       - conditions: '{{ trigger_action | string in button_off_long }}'
         sequence:
           # fire the event only once before looping the action
@@ -685,6 +745,17 @@ actions:
               - choose:
                   - conditions: []
                     sequence: !input action_button_up_short
+      - conditions: '{{ trigger_action | string in button_up_double }}'
+        sequence:
+          # fire the event only once before looping the action
+          - event: ahb_controller_event
+            event_data:
+              controller: '{{ controller_id }}'
+              action: button_up_double
+          # run the custom action
+          - choose:
+              - conditions: []
+                sequence: !input action_button_up_double
       - conditions: '{{ trigger_action | string in button_up_long }}'
         sequence:
           # fire the event only once before looping the action
@@ -765,6 +836,17 @@ actions:
               - choose:
                   - conditions: []
                     sequence: !input action_button_down_short
+      - conditions: '{{ trigger_action | string in button_down_double }}'
+        sequence:
+          # fire the event only once before looping the action
+          - event: ahb_controller_event
+            event_data:
+              controller: '{{ controller_id }}'
+              action: button_down_double
+          # run the custom action
+          - choose:
+              - conditions: []
+                sequence: !input action_button_down_double
       - conditions: '{{ trigger_action | string in button_down_long }}'
         sequence:
           # fire the event only once before looping the action

--- a/website/docs/blueprints/controllers/philips_929002398602.mdx
+++ b/website/docs/blueprints/controllers/philips_929002398602.mdx
@@ -28,7 +28,7 @@ This blueprint provides universal support for running any custom action when a b
 
 In addition of being able to provide custom actions for every kind of button press supported by the remote, the blueprint allows to loop the long press actions while the corresponding button is being held. Once released, the loop stops. This is useful when holding down a button should result in a continuous action (such as lowering the volume of a media player, or controlling a light brightness).
 
-The blueprint also adds support for virtual double button press events, which are not exposed by the controller itself.
+The blueprint also adds support for virtual double button press events, which are not exposed by the controller itself on HW revisions RWL020 and RWL021.
 
 :::tip
 Automations created with this blueprint can be connected with one or more [Hooks](/docs/blueprints/hooks) supported by this controller.
@@ -121,3 +121,4 @@ It's also important to note that the controller doesn't natively support double 
 - **2025-04-02**: Fix trigger_delta regex, with optional whitespacing. ([@TTvanWillegen](https://github.com/TTvanWillegen))
 - **2025-04-06**: Fix double-click detection logic. ([@danleongjy](https://github.com/danleongjy))
 - **2025-04-19**: Improve Last Controller Event Helper JSON Regex with more lenient matching.
+- **2025-07-15**: Add support for Native double events for RWL022.


### PR DESCRIPTION
- Adds: on_double_press, off_double_press, up_double_press and down_double_press.

## Proposed change

Currently the template for philips_929002398602 supports a "Virtual" double press set of events by keeping track of the single presses. This is required for the HW versions RWL020 and RWL021, but the RWL022 (the one I have) seems to support the double event natively. I've tested this with ZHA.

This PR adds support for this double event while keeping the ability to enable Virtual double events.

## Checklist

- [X] I followed sections of the [Contribution Guidelines](https://github.com/EPMatt/awesome-ha-blueprints/blob/main/CONTRIBUTING.md) relevant to changes I'm proposing.
- [X] I properly tested proposed changes on my system and confirm that they are working as expected.
- [X] I formatted files with Prettier using the command `npm run format` before submitting my Pull Request.

## Notes
This PR includes the changes in this other PR as they're required for my devices to work. This should be easily fixed with a forward rebase: https://github.com/EPMatt/awesome-ha-blueprints/pull/767

This is an extract from ZHA's debug logs showing the on_double_press event being fired:

```
2025-07-14 22:53:57.248 DEBUG (MainThread) [zhaquirks.philips] PhilipsRwlRemoteCluster - send_press_event evaluated press_type: [<PressType name=remote_button_double_press, action=double_press, trigger=remote_button_double_press, arg=double_press>]
2025-07-14 22:53:57.248 DEBUG (MainThread) [zhaquirks.philips] PhilipsRwlRemoteCluster - send_press_event emitting action: [on_double_press] event_args: {'button': 'on', 'press_type': 'double_press', 'command_id': 0, 'duration': 1, 'args': [1, 3145728, 4, 33, 1]}
2025-07-14 22:53:57.248 DEBUG (MainThread) [zha] Emitting event zha_event with data ZHAEvent(device_ieee=00:17:88:01:0b:72:9f:98, unique_id='00:17:88:01:0b:72:9f:98', data={'unique_id': '00:17:88:01:0b:72:9f:98:1:0xfc00', 'endpoint_id': 1, 'cluster_id': 64512, 'command': 'on_double_press', 'args': {'button': 'on', 'press_type': 'double_press', 'command_id': 0, 'duration': 1, 'args': [1, 3145728, 4, 33, 1]}, 'params': {}}, event_type='zha_event', event='zha_event') (1 listeners)
2025-07-14 22:53:57.248 DEBUG (MainThread) [zha] (ZHADeviceProxy) handling event protocol for event: ZHAEvent(device_ieee=00:17:88:01:0b:72:9f:98, unique_id='00:17:88:01:0b:72:9f:98', data={'unique_id': '00:17:88:01:0b:72:9f:98:1:0xfc00', 'endpoint_id': 1, 'cluster_id': 64512, 'command': 'on_double_press', 'args': {'button': 'on', 'press_type': 'double_press', 'command_id': 0, 'duration': 1, 'args': [1, 3145728, 4, 33, 1]}, 'params': {}}, event_type='zha_event', event='zha_event')

```

