### PR TITLE
Fixes to philips_929002398602 double click logic

### DIFF
--- a/blueprints/controllers/philips_929002398602/philips_929002398602.yaml
+++ b/blueprints/controllers/philips_929002398602/philips_929002398602.yaml
@@ -309,10 +309,10 @@ variables:
   # mapping between actions and integrations
   actions_mapping:
     zha:
-      button_on_short: [on_press, on_press_release]
+      button_on_short: [on_press_release]
       button_on_long: [on_hold]
       button_on_release: [on_long_release]
-      button_off_short: [off_press, off_press_release]
+      button_off_short: [off_press_release]
       button_off_long: [off_hold]
       button_off_release: [off_long_release]
       button_up_short: [up_press]
@@ -321,12 +321,13 @@ variables:
       button_down_short: [down_press]
       button_down_long: [down_hold]
       button_down_release: [down_long_release]
+      button_event_ignored: [on_press, off_press]
     zigbee2mqtt:
       # source: https://www.zigbee2mqtt.io/devices/929002398602.html#philips-929002398602
-      button_on_short: [on_press, on_press_release]
+      button_on_short: [on_press_release]
       button_on_long: [on_hold]
       button_on_release: [on_hold_release]
-      button_off_short: [off_press, off_press_release]
+      button_off_short: [off_press_release]
       button_off_long: [off_hold]
       button_off_release: [off_hold_release]
       button_up_short: [up_press]
@@ -335,6 +336,7 @@ variables:
       button_down_short: [down_press]
       button_down_long: [down_hold]
       button_down_release: [down_hold_release]
+      button_event_ignored: [on_press, off_press]
   # pre-choose actions for buttons based on configured integration
   # no need to perform this task at automation runtime
   button_on_short: '{{ actions_mapping[integration_id]["button_on_short"] }}'
@@ -349,6 +351,7 @@ variables:
   button_down_short: '{{ actions_mapping[integration_id]["button_down_short"] }}'
   button_down_long: '{{ actions_mapping[integration_id]["button_down_long"] }}'
   button_down_release: '{{ actions_mapping[integration_id]["button_down_release"] }}'
+  button_event_ignored: '{{ actions_mapping[integration_id]["button_event_ignored"] }}'
   # build data to send within a controller event
   controller_id: !input controller_device
 mode: restart
@@ -464,12 +467,16 @@ actions:
         {{ trigger.event.data.command }}
         {%- endif -%}
       deserialized_state: '{{ (states(helper_last_controller_event) | from_json) if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{\s*?((\"a\":\s*?\".*\"|\"t\":\s*?\d+\.\d+)(,\s*?)?){2}\s*?\}$")) else {} }}'
+      last_controller_event: "{{ deserialized_state.a | default('') }}"
       trigger_delta: '{{ (as_timestamp(now()) - (deserialized_state.t | default(0))) * 1000 }}'
-  # update helper
-  - action: input_text.set_value
-    data:
-      entity_id: !input helper_last_controller_event
-      value: '{{ {"a":trigger_action,"t":as_timestamp(now())} | to_json }}'
+  # update helper if event not ignored
+  - choose:
+      - conditions: '{{ trigger_action | string not in button_event_ignored }}'
+        sequence:
+        - action: input_text.set_value
+          data:
+            entity_id: !input helper_last_controller_event
+            value: '{{ {"a":trigger_action,"t":as_timestamp(now())} | to_json }}'
   # choose the sequence to run based on the received button event
   - choose:
       - conditions: '{{ trigger_action | string in button_on_short }}'


### PR DESCRIPTION
Thank you for taking the time to work on a Pull Request. Your contribution is really appreciated! :tada:
**Please don't delete any part of the template**, since keeping the provided structure will help maintainers to review your work more rapidly.

Sections marked as \* are required and need to be filled in.


## Proposed change\*

Describe the big picture of your changes here, and why your pull request should be accepted. If it fixes a bug or resolves a feature request, be sure to put `closes #XXXX` in this section to auto-close relevant issues.

Please note that for important and breaking changes it's always better to open an issue first for discussing the proposal.

Make sure to provide enough information so that your pull request can be reviewed.

Closes #858. 
Fixes philips_929002398602 broken double click logic by:
* defining the `last_controller_event` variable (previously undefined, bug introduced by #755)
    * assigned to the input_text helper's deserialized `a` value
* creating an ignored button event list `button_event_ignored`
    * used to ignore the `<button>_press` event for buttons with both `<button>_press` and `<button>_press_release` events.
    * ignored button events do not get stored in the input_text helper.
    * for this controller, this applies to the `on` and `off` (hue) buttons.

Despite ignoring two button events, the blueprint setup is exactly the same for the end user.

Tested only with Zigbee2MQTT.

## Checklist\*

- [x] I followed sections of the [Contribution Guidelines](https://github.com/EPMatt/awesome-ha-blueprints/blob/main/CONTRIBUTING.md) relevant to changes I'm proposing.
- [x] I properly tested proposed changes on my system and confirm that they are working as expected.
- [x] I formatted files with Prettier using the command `npm run format` before submitting my Pull Request.
