### PR TITLE
Follow-up: Fixes to Philips Hue Dimmer (324131092621) double click logic

### DIFF
--- a/blueprints/controllers/philips_324131092621/philips_324131092621.yaml
+++ b/blueprints/controllers/philips_324131092621/philips_324131092621.yaml
@@ -337,10 +337,10 @@ variables:
       button_down_release: [down_long_release]
     zigbee2mqtt:
       # source: https://www.zigbee2mqtt.io/devices/324131092621.html#philips-324131092621
-      button_on_short: [on_press]
+      button_on_short: [on_press_release]
       button_on_long: [on_hold]
       button_on_release: [on_hold_release]
-      button_off_short: [off_press]
+      button_off_short: [off_press_release]
       button_off_long: [off_hold]
       button_off_release: [off_hold_release]
       button_up_short: [up_press]
@@ -349,6 +349,7 @@ variables:
       button_down_short: [down_press]
       button_down_long: [down_hold]
       button_down_release: [down_hold_release]
+      button_event_ignored: [on_press, off_press]
   # pre-choose actions for buttons based on configured integration
   # no need to perform this task at automation runtime
   button_on_short: '{{ actions_mapping[integration_id]["button_on_short"] }}'
@@ -363,6 +364,7 @@ variables:
   button_down_short: '{{ actions_mapping[integration_id]["button_down_short"] }}'
   button_down_long: '{{ actions_mapping[integration_id]["button_down_long"] }}'
   button_down_release: '{{ actions_mapping[integration_id]["button_down_release"] }}'
+  button_event_ignored: '{{ actions_mapping[integration_id]["button_event_ignored"] }}'
   # build data to send within a controller event
   controller_id: !input controller_device
 mode: restart
@@ -378,6 +380,11 @@ triggers:
     domain: mqtt
     device_id: !input controller_device
     type: action
+    subtype: on_press_release
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
     subtype: on_hold
   - trigger: device
     domain: mqtt
@@ -389,6 +396,11 @@ triggers:
     device_id: !input controller_device
     type: action
     subtype: off_press
+  - trigger: device
+    domain: mqtt
+    device_id: !input controller_device
+    type: action
+    subtype: off_press_release
   - trigger: device
     domain: mqtt
     device_id: !input controller_device
@@ -469,12 +481,16 @@ actions:
         {{ trigger.event.data.command }}
         {%- endif -%}
       deserialized_state: '{{ (states(helper_last_controller_event) | from_json) if helper_last_controller_event is not none and (states(helper_last_controller_event) | regex_match("^\{\s*?((\"a\":\s*?\".*\"|\"t\":\s*?\d+\.\d+)(,\s*?)?){2}\s*?\}$")) else {} }}'
+      last_controller_event: "{{ deserialized_state.a | default('') }}"
       trigger_delta: '{{ (as_timestamp(now()) - (deserialized_state.t | default(0))) * 1000 }}'
-  # update helper
-  - action: input_text.set_value
-    data:
-      entity_id: !input helper_last_controller_event
-      value: '{{ {"a":trigger_action,"t":as_timestamp(now())} | to_json }}'
+  # update helper if event not ignored
+  - choose:
+      - conditions: '{{ trigger_action | string not in button_event_ignored }}'
+        sequence:
+        - action: input_text.set_value
+          data:
+            entity_id: !input helper_last_controller_event
+            value: '{{ {"a":trigger_action,"t":as_timestamp(now())} | to_json }}'
   # choose the sequence to run based on the received button event
   - choose:
       - conditions: '{{ trigger_action | string in button_on_short }}'


### PR DESCRIPTION
Thank you for taking the time to work on a Pull Request. Your contribution is really appreciated! :tada:
**Please don't delete any part of the template**, since keeping the provided structure will help maintainers to review your work more rapidly.

Sections marked as \* are required and need to be filled in.

## Proposed change\*

This PR is a follow-up to [#866](https://github.com/.../pull/866) (Fixes to philips_929002398602 double click logic).

While #866 addressed the philips_929002398602 model, this one extends the fix to handle another Philips Hue Dimmer model with the same issue.

Changes introduced
	•	Applied the same double click logic adjustments to the 324131092621 Philips Hue Dimmer model.
	•	Scope is limited to Zigbee2MQTT (Z2M) since I am not familiar with the events on other platforms.
	•	Ensured compatibility without breaking the logic implemented in #866.

Notes
	•	Tested locally with the new model on Z2M.
	•	Behavior now matches the expected single/double click consistency.

## Checklist\*

- [ ] I followed sections of the [Contribution Guidelines](https://github.com/EPMatt/awesome-ha-blueprints/blob/main/CONTRIBUTING.md) relevant to changes I'm proposing.
- [ ] I properly tested proposed changes on my system and confirm that they are working as expected.
- [ ] I formatted files with Prettier using the command `npm run format` before submitting my Pull Request.
