### PR TITLE
Phillips Dimmer v2 controller blueprint couldn't find the remote

### DIFF
--- a/blueprints/controllers/philips_929002398602/philips_929002398602.yaml
+++ b/blueprints/controllers/philips_929002398602/philips_929002398602.yaml
@@ -54,6 +54,8 @@ blueprint:
             - integration: deconz
               manufacturer: Philips
               # **TBConfirmed** model:
+            - integration: zha
+              manufacturer: "Signify Netherlands B.V."
           multiple: false
     helper_last_controller_event:
       name: (Required) Helper - Last Controller Event


### PR DESCRIPTION
As reported in https://github.com/EPMatt/awesome-ha-blueprints/issues/909, I had the same issue and I can see that the manufacturer in the blueprint doesn't match.

I've confirmed locally that my change works, however I have not added the same manufacturer for the other integrations as I don't know if it makes sense or not and I can't test it.

----

Thank you for taking the time to work on a Pull Request. Your contribution is really appreciated! :tada:
**Please don't delete any part of the template**, since keeping the provided structure will help maintainers to review your work more rapidly.

Sections marked as \* are required and need to be filled in.

## Breaking change

If your PR contains a breaking change for existing users, it is important to describe what breaks, how to make it work again and why we did this. This section will be used to craft the changelog entry, after your PR gets approved and merged.

Note: Remove this section if this PR is NOT a breaking change.

## Proposed change\*

Describe the big picture of your changes here, and why your pull request should be accepted. If it fixes a bug or resolves a feature request, be sure to put `closes #XXXX` in this section to auto-close relevant issues.

Please note that for important and breaking changes it's always better to open an issue first for discussing the proposal.

Make sure to provide enough information so that your pull request can be reviewed.

## Checklist\*

- [ ] I followed sections of the [Contribution Guidelines](https://github.com/EPMatt/awesome-ha-blueprints/blob/main/CONTRIBUTING.md) relevant to changes I'm proposing.
- [ ] I properly tested proposed changes on my system and confirm that they are working as expected.
- [ ] I formatted files with Prettier using the command `npm run format` before submitting my Pull Request.
