### PR TITLE
Fixes for modelname of IKEA E2201 remote and long press down action

### DIFF
--- a/blueprints/controllers/ikea_e2201/ikea_e2201.yaml
+++ b/blueprints/controllers/ikea_e2201/ikea_e2201.yaml
@@ -315,7 +315,7 @@ triggers:
     event_type: zha_event
     event_data:
       device_id: !input controller_device
-      command: stop
+      command: stop_with_on_off
       endpoint_id: 1
       cluster_id: 8
   # triggers for deCONZ
@@ -645,7 +645,7 @@ actions:
                                       event_type: zha_event
                                       event_data:
                                         device_id: !input controller_device
-                                        command: stop
+                                        command: stop_with_on_off
                                         cluster_id: 8
                                         endpoint_id: 1
                                     - trigger: event

--- a/blueprints/controllers/ikea_e2201/ikea_e2201.yaml
+++ b/blueprints/controllers/ikea_e2201/ikea_e2201.yaml
@@ -46,7 +46,7 @@ blueprint:
             # source: https://github.com/zigpy/zha-device-handlers/blob/dev/zhaquirks/ikea/twobtnremote.py#L206
             - integration: zha
               manufacturer: IKEA of Sweden
-              model: RODRET Dimmer
+              model: RODRET wireless dimmer
             # source: https://github.com/dresden-elektronik/deconz-rest-plugin/blob/8ae69a976bca13f22e8002a13ebe798d1e26c086/button_maps.json#L236
             - integration: deconz
               manufacturer: IKEA of Sweden


### PR DESCRIPTION
## Proposed change

Fixes two issues:

 `closes #917` https://github.com/EPMatt/awesome-ha-blueprints/issues/917
- Fixed by changing the model name from `RODRET Dimmer` to `RODRET wireless dimmer`. This allows the device to be properly matched and thus selectable in the Controller blueprint.

 `closes #871` https://github.com/EPMatt/awesome-ha-blueprints/issues/871
- Fixed by altering the command which is issued when `event id: zha-button-down-release occurs`. Changed the command from `stop` to `stop_with_on_off`.

## Checklist

- [x] I followed sections of the [Contribution Guidelines](https://github.com/EPMatt/awesome-ha-blueprints/blob/main/CONTRIBUTING.md) relevant to changes I'm proposing.
- [x] I properly tested proposed changes on my system and confirm that they are working as expected.
- [ ] I formatted files with Prettier using the command `npm run format` before submitting my Pull Request.
