### PR TITLE
docs: split changelog in separate json files

### DIFF
--- a/blueprints/automation/addon_update_notification/changelog.json
+++ b/blueprints/automation/addon_update_notification/changelog.json
@@ -3,7 +3,7 @@
     "date": "2021-04-25",
     "changes": [
       {
-        "description": "First blueprint version :tada:",
+        "description": "First blueprint version 🎉",
         "breaking": false
       }
     ]

--- a/blueprints/automation/addon_update_notification/changelog.json
+++ b/blueprints/automation/addon_update_notification/changelog.json
@@ -1,0 +1,20 @@
+[
+  {
+    "date": "2021-04-25",
+    "changes": [
+      {
+        "description": "First blueprint version :tada:",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-10-26",
+    "changes": [
+      {
+        "description": "Standardize blueprint structure and input naming across the collection. Improve blueprint documentation. No functionality change.",
+        "breaking": false
+      }
+    ]
+  }
+]

--- a/blueprints/automation/on_off_schedule_state_persistence/changelog.json
+++ b/blueprints/automation/on_off_schedule_state_persistence/changelog.json
@@ -3,7 +3,7 @@
     "date": "2021-02-01",
     "changes": [
       {
-        "description": "First blueprint version :tada:",
+        "description": "First blueprint version 🎉",
         "breaking": false
       }
     ]

--- a/blueprints/automation/on_off_schedule_state_persistence/changelog.json
+++ b/blueprints/automation/on_off_schedule_state_persistence/changelog.json
@@ -1,0 +1,20 @@
+[
+  {
+    "date": "2021-02-01",
+    "changes": [
+      {
+        "description": "First blueprint version :tada:",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-10-26",
+    "changes": [
+      {
+        "description": "Standardize blueprint structure and input naming across the collection. Improve blueprint documentation. Remove default values from required inputs. No functionality change.",
+        "breaking": false
+      }
+    ]
+  }
+]

--- a/blueprints/automation/persistent_notification_to_mobile/changelog.json
+++ b/blueprints/automation/persistent_notification_to_mobile/changelog.json
@@ -3,7 +3,7 @@
     "date": "2021-02-01",
     "changes": [
       {
-        "description": "First blueprint version :tada:",
+        "description": "First blueprint version 🎉",
         "breaking": false
       }
     ]

--- a/blueprints/automation/persistent_notification_to_mobile/changelog.json
+++ b/blueprints/automation/persistent_notification_to_mobile/changelog.json
@@ -1,0 +1,20 @@
+[
+  {
+    "date": "2021-02-01",
+    "changes": [
+      {
+        "description": "First blueprint version :tada:",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-10-26",
+    "changes": [
+      {
+        "description": "Standardize blueprint structure and input naming across the collection. Improve blueprint documentation. No functionality change.",
+        "breaking": false
+      }
+    ]
+  }
+]

--- a/blueprints/automation/simple_safe_scheduler/changelog.json
+++ b/blueprints/automation/simple_safe_scheduler/changelog.json
@@ -1,0 +1,11 @@
+[
+  {
+    "date": "2021-10-22",
+    "changes": [
+      {
+        "description": "First blueprint version :tada:",
+        "breaking": false
+      }
+    ]
+  }
+]

--- a/blueprints/automation/simple_safe_scheduler/changelog.json
+++ b/blueprints/automation/simple_safe_scheduler/changelog.json
@@ -3,7 +3,7 @@
     "date": "2021-10-22",
     "changes": [
       {
-        "description": "First blueprint version :tada:",
+        "description": "First blueprint version 🎉",
         "breaking": false
       }
     ]

--- a/blueprints/controllers/ikea_e1524_e1810/changelog.json
+++ b/blueprints/controllers/ikea_e1524_e1810/changelog.json
@@ -27,15 +27,6 @@
     ]
   },
   {
-    "date": "2021-03-18",
-    "changes": [
-      {
-        "description": "Add example for fully controlling an RGB light (Thanks [@kks36](https://github.com/kks36))!).",
-        "breaking": false
-      }
-    ]
-  },
-  {
     "date": "2021-02-21",
     "changes": [
       {
@@ -57,6 +48,15 @@
     "changes": [
       {
         "description": "Move the blueprint into the Controllers-Hooks Ecosystem.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-03-18",
+    "changes": [
+      {
+        "description": "Add example for fully controlling an RGB light (Thanks [@kks36](https://github.com/kks36))!).",
         "breaking": false
       }
     ]

--- a/blueprints/controllers/ikea_e1524_e1810/changelog.json
+++ b/blueprints/controllers/ikea_e1524_e1810/changelog.json
@@ -1,0 +1,215 @@
+[
+  {
+    "date": "2021-02-05",
+    "changes": [
+      {
+        "description": "First blueprint version :tada:",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-02-07",
+    "changes": [
+      {
+        "description": "Fix an issue which prevented creating automations for ZHA or deCONZ.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-02-08",
+    "changes": [
+      {
+        "description": "Update example and fix an issue which executed actions twice when the remote was connected via Zigbee2MQTT.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-03-18",
+    "changes": [
+      {
+        "description": "Add example for fully controlling an RGB light (thanks @kks36!).",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-02-21",
+    "changes": [
+      {
+        "description": "Add support for virtual double press events.",
+        "breaking": false
+      },
+      {
+        "description": "Block automation runs for empty and repeated messages.",
+        "breaking": false
+      },
+      {
+        "description": "Reduce input_text helper writes.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-03-03",
+    "changes": [
+      {
+        "description": "Move the blueprint into the Controllers-Hooks Ecosystem.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-03-25",
+    "changes": [
+      {
+        "description": "Standardize input names across all the Controller blueprints. If you plan to update this blueprint, please update the inputs in your automations as follows:\n- remote -> controller_device\n- zigbee2mqtt_remote -> controller_entity\n- action_* inputs -> action_button_*\n- helper_last_loop_event_input -> helper_last_controller_event",
+        "breaking": true
+      }
+    ]
+  },
+  {
+    "date": "2021-03-26",
+    "changes": [
+      {
+        "description": "Add support for the Cover Hook.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-03-30",
+    "changes": [
+      {
+        "description": "Fix event mappings for ZHA and deCONZ.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-04-19",
+    "changes": [
+      {
+        "description": "Fix double press events not being detected with deCONZ.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-04-23",
+    "changes": [
+      {
+        "description": "Fix deCONZ events not being recognized.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-05-26",
+    "changes": [
+      {
+        "description": "Make helper_last_controller_event a mandatory input to simplify setup and enable future advanced features. When updating, ensure to provide a dedicated input_text entity for this input.",
+        "breaking": true
+      },
+      {
+        "description": ":tada: Add Debouncing support to avoid duplicate action runs.",
+        "breaking": false
+      },
+      {
+        "description": "Prevent undesired endless loops by running loop actions a finite number of times, customizable with new blueprint inputs.",
+        "breaking": false
+      },
+      {
+        "description": "Fix inputs wrongly marked as required.",
+        "breaking": false
+      },
+      {
+        "description": "Fix Zigbee2MQTT reporting null state changes.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-07-04",
+    "changes": [
+      {
+        "description": "Fix deCONZ button release events not being properly recognized.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-08-02",
+    "changes": [
+      {
+        "description": "Improve inputs documentation and organization.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-10-26",
+    "changes": [
+      {
+        "description": "Standardize blueprints structure and inputs naming across the collection. Improve blueprint documentation.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2022-08-08",
+    "changes": [
+      {
+        "description": "Optimize characters usage for the helper_last_controller_event text input.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2025-01-03",
+    "changes": [
+      {
+        "description": "Fix double press events not triggered due to changes in Home Assistant 2023.5.x. (Thanks @ZtormTheCat)",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2025-02-13",
+    "changes": [
+      {
+        "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The controller_entity input is deprecated and controller_device is now mandatory. Remove controller_entity from your automation and configure the controller_device input with your controller device ID.",
+        "breaking": true
+      }
+    ]
+  },
+  {
+    "date": "2025-03-20",
+    "changes": [
+      {
+        "description": "Standardize input naming format for controller devices and virtual button actions. No functionality changes.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2025-04-01",
+    "changes": [
+      {
+        "description": "Fix double-click detection logic. (Thanks @danleongjy)",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2025-04-19",
+    "changes": [
+      {
+        "description": "Improve Last Controller Event Helper JSON Regex with more lenient matching.",
+        "breaking": false
+      }
+    ]
+  }
+]

--- a/blueprints/controllers/ikea_e1524_e1810/changelog.json
+++ b/blueprints/controllers/ikea_e1524_e1810/changelog.json
@@ -180,7 +180,7 @@
     "date": "2025-02-13",
     "changes": [
       {
-        "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The `controller_entity` input is deprecated and `controller_device` is now mandatory. Remove `controller_entity` from your automation and configure the `controller_device` input with your controller device ID.",
+        "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The `controller_entity` input is deprecated and `controller_device` is now mandatory. Remove `controller_entity` from your automation and configure the `controller_device` input with your controller device ID. (Thanks [@yarafie](https://github.com/yarafie))",
         "breaking": true
       }
     ]

--- a/blueprints/controllers/ikea_e1524_e1810/changelog.json
+++ b/blueprints/controllers/ikea_e1524_e1810/changelog.json
@@ -56,7 +56,7 @@
     "date": "2021-03-18",
     "changes": [
       {
-        "description": "Add example for fully controlling an RGB light (Thanks [@kks36](https://github.com/kks36))!).",
+        "description": "Add example for fully controlling an RGB light (Thanks [@kks36](https://github.com/kks36)!).",
         "breaking": false
       }
     ]

--- a/blueprints/controllers/ikea_e1524_e1810/changelog.json
+++ b/blueprints/controllers/ikea_e1524_e1810/changelog.json
@@ -3,7 +3,7 @@
     "date": "2021-02-05",
     "changes": [
       {
-        "description": "First blueprint version :tada:",
+        "description": "First blueprint version 🎉",
         "breaking": false
       }
     ]
@@ -30,7 +30,7 @@
     "date": "2021-03-18",
     "changes": [
       {
-        "description": "Add example for fully controlling an RGB light (thanks @kks36!).",
+        "description": "Add example for fully controlling an RGB light (Thanks [@kks36](https://github.com/kks36))!).",
         "breaking": false
       }
     ]
@@ -65,7 +65,7 @@
     "date": "2021-03-25",
     "changes": [
       {
-        "description": "Standardize input names across all the Controller blueprints. If you plan to update this blueprint, please update the inputs in your automations as follows:\n- remote -> controller_device\n- zigbee2mqtt_remote -> controller_entity\n- action_* inputs -> action_button_*\n- helper_last_loop_event_input -> helper_last_controller_event",
+        "description": "Standardize input names across all the Controller blueprints. If you plan to update this blueprint, please update the inputs in your automations as follows:\n- `remote` -> `controller_device`\n- `zigbee2mqtt_remote` -> `controller_entity`\n- `action_* inputs` -> `action_button_*`\n- `helper_last_loop_event_input` -> `helper_last_controller_event`",
         "breaking": true
       }
     ]
@@ -110,11 +110,11 @@
     "date": "2021-05-26",
     "changes": [
       {
-        "description": "Make helper_last_controller_event a mandatory input to simplify setup and enable future advanced features. When updating, ensure to provide a dedicated input_text entity for this input.",
+        "description": "Make `helper_last_controller_event` a mandatory input to simplify setup and enable future advanced features. When updating, ensure to provide a dedicated input_text entity for this input.",
         "breaking": true
       },
       {
-        "description": ":tada: Add Debouncing support to avoid duplicate action runs.",
+        "description": "🎉 Add Debouncing support to avoid duplicate action runs.",
         "breaking": false
       },
       {
@@ -162,7 +162,7 @@
     "date": "2022-08-08",
     "changes": [
       {
-        "description": "Optimize characters usage for the helper_last_controller_event text input.",
+        "description": "Optimize characters usage for the `helper_last_controller_event` text input.",
         "breaking": false
       }
     ]
@@ -171,7 +171,7 @@
     "date": "2025-01-03",
     "changes": [
       {
-        "description": "Fix double press events not triggered due to changes in Home Assistant 2023.5.x. (Thanks @ZtormTheCat)",
+        "description": "Fix double press events not triggered due to changes in Home Assistant 2023.5.x. (Thanks [@ZtormTheCat](https://github.com/ZtormTheCat))",
         "breaking": false
       }
     ]
@@ -180,7 +180,7 @@
     "date": "2025-02-13",
     "changes": [
       {
-        "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The controller_entity input is deprecated and controller_device is now mandatory. Remove controller_entity from your automation and configure the controller_device input with your controller device ID.",
+        "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The `controller_entity` input is deprecated and `controller_device` is now mandatory. Remove `controller_entity` from your automation and configure the `controller_device` input with your controller device ID.",
         "breaking": true
       }
     ]
@@ -198,7 +198,7 @@
     "date": "2025-04-01",
     "changes": [
       {
-        "description": "Fix double-click detection logic. (Thanks @danleongjy)",
+        "description": "Fix double-click detection logic. (Thanks [@danleongjy](https://github.com/danleongjy))",
         "breaking": false
       }
     ]

--- a/blueprints/controllers/ikea_e1743/changelog.json
+++ b/blueprints/controllers/ikea_e1743/changelog.json
@@ -1,0 +1,215 @@
+[
+  {
+    "date": "2021-02-07",
+    "changes": [
+      {
+        "description": "First blueprint version :tada:",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-02-07",
+    "changes": [
+      {
+        "description": "Fix an issue on Zigbee2MQTT triggering rules.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-02-07",
+    "changes": [
+      {
+        "description": "Fix an issue which prevented creating automations for ZHA or deCONZ. (Thanks @kks36! :tada:)",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-02-08",
+    "changes": [
+      {
+        "description": "Update example and fix an issue which executed actions twice when the remote was connected via Zigbee2MQTT.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-02-23",
+    "changes": [
+      {
+        "description": "Add support for virtual double press events.",
+        "breaking": false
+      },
+      {
+        "description": "Block automation runs for empty and repeated messages.",
+        "breaking": false
+      },
+      {
+        "description": "Reduce input_text helper writes.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-03-03",
+    "changes": [
+      {
+        "description": "Move the blueprint into the Controllers-Hooks Ecosystem.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-03-25",
+    "changes": [
+      {
+        "description": "Standardize input names across all the Controller blueprints. If you plan to update this blueprint, please update the inputs in your automations as follows:\n- remote -> controller_device\n- zigbee2mqtt_remote -> controller_entity\n- action_* inputs -> action_button_*\n- helper_last_loop_event_input -> helper_last_controller_event",
+        "breaking": true
+      }
+    ]
+  },
+  {
+    "date": "2021-03-26",
+    "changes": [
+      {
+        "description": "Add support for the Cover Hook.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-04-19",
+    "changes": [
+      {
+        "description": "Fix double press events not being detected with deCONZ.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-04-23",
+    "changes": [
+      {
+        "description": "Fix deCONZ events not being recognized.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-05-26",
+    "changes": [
+      {
+        "description": "Make helper_last_controller_event a mandatory input to simplify setup and enable future advanced features. When updating, provide a dedicated input_text entity for this input.",
+        "breaking": true
+      },
+      {
+        "description": ":tada: Add Debouncing support to avoid duplicate action runs.",
+        "breaking": false
+      },
+      {
+        "description": "Prevent undesired endless loops by running loop actions a finite number of times, configurable through two new blueprint inputs.",
+        "breaking": false
+      },
+      {
+        "description": "Fix inputs wrongly marked as required.",
+        "breaking": false
+      },
+      {
+        "description": "Fix Zigbee2MQTT reporting null state changes.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-07-04",
+    "changes": [
+      {
+        "description": "Fix deCONZ button release events not being properly recognized.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-08-02",
+    "changes": [
+      {
+        "description": "Improve inputs documentation and organization.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-10-26",
+    "changes": [
+      {
+        "description": "Standardize blueprint structure and input naming across the collection. Improve blueprint documentation. No functionality change.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2022-08-08",
+    "changes": [
+      {
+        "description": "Optimize characters usage for the helper_last_controller_event text input.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2025-01-02",
+    "changes": [
+      {
+        "description": "Remove spaces to match the new helper format in Home Assistant 2023.5.x. (Thanks @LordSushiPhoenix)",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2025-01-23",
+    "changes": [
+      {
+        "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The controller_entity input is deprecated and controller_device is now mandatory. Remove controller_entity from your automation and configure controller_device with your controller device ID. (Thanks @yarafie)",
+        "breaking": true
+      }
+    ]
+  },
+  {
+    "date": "2025-03-20",
+    "changes": [
+      {
+        "description": "Standardize input naming format for controller devices and virtual button actions. No functionality changes.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2025-04-01",
+    "changes": [
+      {
+        "description": "Fix double-click detection logic. (Thanks @danleongjy)",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2025-04-16",
+    "changes": [
+      {
+        "description": "Update ZHA long press and release actions. (Thanks @notherealmarco)",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2025-04-19",
+    "changes": [
+      {
+        "description": "Improve Last Controller Event Helper JSON Regex with more lenient matching.",
+        "breaking": false
+      }
+    ]
+  }
+]

--- a/blueprints/controllers/ikea_e1743/changelog.json
+++ b/blueprints/controllers/ikea_e1743/changelog.json
@@ -3,7 +3,7 @@
     "date": "2021-02-07",
     "changes": [
       {
-        "description": "First blueprint version :tada:",
+        "description": "First blueprint version 🎉",
         "breaking": false
       }
     ]
@@ -21,7 +21,7 @@
     "date": "2021-02-07",
     "changes": [
       {
-        "description": "Fix an issue which prevented creating automations for ZHA or deCONZ. (Thanks @kks36! :tada:)",
+        "description": "Fix an issue which prevented creating automations for ZHA or deCONZ. (Thanks [@kks36](https://github.com/kks36))! 🎉)",
         "breaking": false
       }
     ]
@@ -65,7 +65,7 @@
     "date": "2021-03-25",
     "changes": [
       {
-        "description": "Standardize input names across all the Controller blueprints. If you plan to update this blueprint, please update the inputs in your automations as follows:\n- remote -> controller_device\n- zigbee2mqtt_remote -> controller_entity\n- action_* inputs -> action_button_*\n- helper_last_loop_event_input -> helper_last_controller_event",
+        "description": "Standardize input names across all the Controller blueprints. If you plan to update this blueprint, please update the inputs in your automations as follows:\n- `remote` -> `controller_device`\n- `zigbee2mqtt_remote` -> `controller_entity`\n- `action_* inputs` -> `action_button_*`\n- `helper_last_loop_event_input` -> `helper_last_controller_event`",
         "breaking": true
       }
     ]
@@ -101,11 +101,11 @@
     "date": "2021-05-26",
     "changes": [
       {
-        "description": "Make helper_last_controller_event a mandatory input to simplify setup and enable future advanced features. When updating, provide a dedicated input_text entity for this input.",
+        "description": "Make `helper_last_controller_event` a mandatory input to simplify setup and enable future advanced features. When updating, provide a dedicated input_text entity for this input.",
         "breaking": true
       },
       {
-        "description": ":tada: Add Debouncing support to avoid duplicate action runs.",
+        "description": "🎉 Add Debouncing support to avoid duplicate action runs.",
         "breaking": false
       },
       {
@@ -153,7 +153,7 @@
     "date": "2022-08-08",
     "changes": [
       {
-        "description": "Optimize characters usage for the helper_last_controller_event text input.",
+        "description": "Optimize characters usage for the `helper_last_controller_event` text input.",
         "breaking": false
       }
     ]
@@ -162,7 +162,7 @@
     "date": "2025-01-02",
     "changes": [
       {
-        "description": "Remove spaces to match the new helper format in Home Assistant 2023.5.x. (Thanks @LordSushiPhoenix)",
+        "description": "Remove spaces to match the new helper format in Home Assistant 2023.5.x. (Thanks [@LordSushiPhoenix](https://github.com/LordSushiPhoenix))",
         "breaking": false
       }
     ]
@@ -171,7 +171,7 @@
     "date": "2025-01-23",
     "changes": [
       {
-        "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The controller_entity input is deprecated and controller_device is now mandatory. Remove controller_entity from your automation and configure controller_device with your controller device ID. (Thanks @yarafie)",
+        "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The `controller_entity` input is deprecated and `controller_device` is now mandatory. Remove `controller_entity` from your automation and configure `controller_device` with your controller device ID. (Thanks [@yarafie](https://github.com/yarafie))",
         "breaking": true
       }
     ]
@@ -189,7 +189,7 @@
     "date": "2025-04-01",
     "changes": [
       {
-        "description": "Fix double-click detection logic. (Thanks @danleongjy)",
+        "description": "Fix double-click detection logic. (Thanks [@danleongjy](https://github.com/danleongjy))",
         "breaking": false
       }
     ]
@@ -198,7 +198,7 @@
     "date": "2025-04-16",
     "changes": [
       {
-        "description": "Update ZHA long press and release actions. (Thanks @notherealmarco)",
+        "description": "Update ZHA long press and release actions. (Thanks [@notherealmarco](https://github.com/notherealmarco))",
         "breaking": false
       }
     ]

--- a/blueprints/controllers/ikea_e1744/changelog.json
+++ b/blueprints/controllers/ikea_e1744/changelog.json
@@ -1,0 +1,144 @@
+[
+  {
+    "date": "2021-03-07",
+    "changes": [
+      {
+        "description": "First blueprint version :tada:",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-03-25",
+    "changes": [
+      {
+        "description": "Standardize input names across all the Controller blueprints. Update your automation inputs as follows:\n- remote -> controller_device\n- zigbee2mqtt_remote -> controller_entity\n- action_click -> action_click_short",
+        "breaking": true
+      }
+    ]
+  },
+  {
+    "date": "2021-04-19",
+    "changes": [
+      {
+        "description": "Align action mapping format for deCONZ across all the Controller blueprints.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-04-23",
+    "changes": [
+      {
+        "description": "Fix deCONZ events not being recognized.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-05-14",
+    "changes": [
+      {
+        "description": "Make helper_last_controller_event a mandatory input to simplify setup and enable future advanced features. When updating, provide a dedicated input_text entity for this input.",
+        "breaking": true
+      },
+      {
+        "description": ":tada: Add Debouncing support to avoid duplicate action runs.",
+        "breaking": false
+      },
+      {
+        "description": "Prevent undesired endless loops by running loop actions a finite number of times, configurable through two new blueprint inputs.",
+        "breaking": false
+      },
+      {
+        "description": "Use any RAW stop event (left/right) to identify the stop event corresponding to the current remote rotation.",
+        "breaking": false
+      },
+      {
+        "description": "Fix inputs wrongly marked as required.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-05-26",
+    "changes": [
+      {
+        "description": "Fix Zigbee2MQTT reporting null state changes.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-07-04",
+    "changes": [
+      {
+        "description": "Fix deCONZ rotation stop events not being properly recognized.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-08-02",
+    "changes": [
+      {
+        "description": "Improve inputs documentation and organization.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-10-26",
+    "changes": [
+      {
+        "description": "Standardize blueprint structure and input naming across the collection. Improve blueprint documentation. No functionality change.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2022-08-08",
+    "changes": [
+      {
+        "description": "Optimize characters usage for the helper_last_controller_event text input.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2025-01-05",
+    "changes": [
+      {
+        "description": "Update ZHA event data to match what ZHA provides in Home Assistant 2024.03.01. (Thanks @ogajduse)",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2025-02-13",
+    "changes": [
+      {
+        "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The controller_entity input is deprecated and controller_device is now mandatory. Remove controller_entity from your automation and configure controller_device with your controller device ID. (Thanks @yarafie)",
+        "breaking": true
+      }
+    ]
+  },
+  {
+    "date": "2025-03-20",
+    "changes": [
+      {
+        "description": "Standardize input naming format for controller devices and virtual button actions. No functionality changes.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2025-04-19",
+    "changes": [
+      {
+        "description": "Improve Last Controller Event Helper JSON Regex with more lenient matching.",
+        "breaking": false
+      }
+    ]
+  }
+]

--- a/blueprints/controllers/ikea_e1744/changelog.json
+++ b/blueprints/controllers/ikea_e1744/changelog.json
@@ -3,7 +3,7 @@
     "date": "2021-03-07",
     "changes": [
       {
-        "description": "First blueprint version :tada:",
+        "description": "First blueprint version 🎉",
         "breaking": false
       }
     ]
@@ -12,7 +12,7 @@
     "date": "2021-03-25",
     "changes": [
       {
-        "description": "Standardize input names across all the Controller blueprints. Update your automation inputs as follows:\n- remote -> controller_device\n- zigbee2mqtt_remote -> controller_entity\n- action_click -> action_click_short",
+        "description": "Standardize input names across all the Controller blueprints. Update your automation inputs as follows:\n- `remote` -> `controller_device`\n- `zigbee2mqtt_remote` -> `controller_entity`\n- `action_click` -> `action_click_short`",
         "breaking": true
       }
     ]
@@ -39,11 +39,11 @@
     "date": "2021-05-14",
     "changes": [
       {
-        "description": "Make helper_last_controller_event a mandatory input to simplify setup and enable future advanced features. When updating, provide a dedicated input_text entity for this input.",
+        "description": "Make `helper_last_controller_event` a mandatory input to simplify setup and enable future advanced features. When updating, provide a dedicated input_text entity for this input.",
         "breaking": true
       },
       {
-        "description": ":tada: Add Debouncing support to avoid duplicate action runs.",
+        "description": "🎉 Add Debouncing support to avoid duplicate action runs.",
         "breaking": false
       },
       {
@@ -100,7 +100,7 @@
     "date": "2022-08-08",
     "changes": [
       {
-        "description": "Optimize characters usage for the helper_last_controller_event text input.",
+        "description": "Optimize characters usage for the `helper_last_controller_event` text input.",
         "breaking": false
       }
     ]
@@ -109,7 +109,7 @@
     "date": "2025-01-05",
     "changes": [
       {
-        "description": "Update ZHA event data to match what ZHA provides in Home Assistant 2024.03.01. (Thanks @ogajduse)",
+        "description": "Update ZHA event data to match what ZHA provides in Home Assistant 2024.03.01. (Thanks [@ogajduse](https://github.com/ogajduse))",
         "breaking": false
       }
     ]
@@ -118,7 +118,7 @@
     "date": "2025-02-13",
     "changes": [
       {
-        "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The controller_entity input is deprecated and controller_device is now mandatory. Remove controller_entity from your automation and configure controller_device with your controller device ID. (Thanks @yarafie)",
+        "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The `controller_entity` input is deprecated and `controller_device` is now mandatory. Remove `controller_entity` from your automation and configure `controller_device` with your controller device ID. (Thanks [@yarafie](https://github.com/yarafie))",
         "breaking": true
       }
     ]

--- a/blueprints/controllers/ikea_e1766/changelog.json
+++ b/blueprints/controllers/ikea_e1766/changelog.json
@@ -1,0 +1,56 @@
+[
+  {
+    "date": "2021-10-29",
+    "changes": [
+      {
+        "description": "First blueprint version :tada:",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2022-08-08",
+    "changes": [
+      {
+        "description": "Optimize characters usage for the helper_last_controller_event text input.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2025-02-13",
+    "changes": [
+      {
+        "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The controller_entity input is deprecated and controller_device is now mandatory. Remove controller_entity from your automation and configure controller_device with your controller device ID. (Thanks @yarafie)",
+        "breaking": true
+      }
+    ]
+  },
+  {
+    "date": "2025-03-20",
+    "changes": [
+      {
+        "description": "Standardize input naming format for controller devices and virtual button actions. No functionality changes.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2025-04-01",
+    "changes": [
+      {
+        "description": "Fix double-click detection logic. (Thanks @danleongjy)",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2025-04-19",
+    "changes": [
+      {
+        "description": "Improve Last Controller Event Helper JSON Regex with more lenient matching.",
+        "breaking": false
+      }
+    ]
+  }
+]

--- a/blueprints/controllers/ikea_e1766/changelog.json
+++ b/blueprints/controllers/ikea_e1766/changelog.json
@@ -3,7 +3,7 @@
     "date": "2021-10-29",
     "changes": [
       {
-        "description": "First blueprint version :tada:",
+        "description": "First blueprint version 🎉",
         "breaking": false
       }
     ]
@@ -12,7 +12,7 @@
     "date": "2022-08-08",
     "changes": [
       {
-        "description": "Optimize characters usage for the helper_last_controller_event text input.",
+        "description": "Optimize characters usage for the `helper_last_controller_event` text input.",
         "breaking": false
       }
     ]
@@ -21,7 +21,7 @@
     "date": "2025-02-13",
     "changes": [
       {
-        "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The controller_entity input is deprecated and controller_device is now mandatory. Remove controller_entity from your automation and configure controller_device with your controller device ID. (Thanks @yarafie)",
+        "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The `controller_entity` input is deprecated and `controller_device` is now mandatory. Remove `controller_entity` from your automation and configure `controller_device` with your controller device ID. (Thanks [@yarafie](https://github.com/yarafie))",
         "breaking": true
       }
     ]
@@ -39,7 +39,7 @@
     "date": "2025-04-01",
     "changes": [
       {
-        "description": "Fix double-click detection logic. (Thanks @danleongjy)",
+        "description": "Fix double-click detection logic. (Thanks [@danleongjy](https://github.com/danleongjy))",
         "breaking": false
       }
     ]

--- a/blueprints/controllers/ikea_e1812/changelog.json
+++ b/blueprints/controllers/ikea_e1812/changelog.json
@@ -1,0 +1,153 @@
+[
+  {
+    "date": "2021-03-14",
+    "changes": [
+      {
+        "description": "First blueprint version :tada:",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-03-25",
+    "changes": [
+      {
+        "description": "Standardize input names across all the Controller blueprints. If you plan to update this blueprint, please update the inputs in your automations as follows:\n- remote -> controller_device\n- zigbee2mqtt_remote -> controller_entity\n- helper_last_loop_event_input -> helper_last_controller_event",
+        "breaking": true
+      }
+    ]
+  },
+  {
+    "date": "2021-03-26",
+    "changes": [
+      {
+        "description": "Add support for the Cover Hook.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-04-19",
+    "changes": [
+      {
+        "description": "Fix double press events not being detected with deCONZ.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-04-23",
+    "changes": [
+      {
+        "description": "Fix deCONZ events not being recognized.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-05-15",
+    "changes": [
+      {
+        "description": "Make helper_last_controller_event a mandatory input to simplify setup and enable future advanced features. Provide a dedicated input_text entity for this input when updating.",
+        "breaking": true
+      },
+      {
+        "description": ":tada: Add Debouncing support to avoid duplicate action runs.",
+        "breaking": false
+      },
+      {
+        "description": "Prevent undesired endless loops by running loop actions a finite number of times, configurable through a new blueprint input.",
+        "breaking": false
+      },
+      {
+        "description": "Fix inputs wrongly marked as required.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-05-26",
+    "changes": [
+      {
+        "description": "Fix Zigbee2MQTT reporting null state changes.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-08-02",
+    "changes": [
+      {
+        "description": "Improve inputs documentation and organization.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-10-26",
+    "changes": [
+      {
+        "description": "Standardize blueprint structure and input naming across the collection. Improve blueprint documentation. No functionality change.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2022-08-08",
+    "changes": [
+      {
+        "description": "Optimize characters usage for the helper_last_controller_event text input.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2025-01-03",
+    "changes": [
+      {
+        "description": "Fix double press events not triggered due to changes in Home Assistant 2023.5.x.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2025-02-13",
+    "changes": [
+      {
+        "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The controller_entity input is deprecated and controller_device is now mandatory. Remove controller_entity from your automation and configure controller_device with your controller device ID. (Thanks @yarafie)",
+        "breaking": true
+      }
+    ]
+  },
+  {
+    "date": "2025-03-20",
+    "changes": [
+      {
+        "description": "Standardize input naming format for controller devices and virtual button actions. No functionality changes.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2025-04-06",
+    "changes": [
+      {
+        "description": "Fix double-click detection logic. (Thanks @danleongjy)",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2025-04-12",
+    "changes": [
+      {
+        "description": "Add native double press triggers and refactor the blueprint to use triggers and trigger IDs. The integration selector input is removed, and helper_last_controller_event is no longer required. Re-download the blueprint and reconfigure existing automations to apply the changes. (Thanks @yarafie)",
+        "breaking": true
+      },
+      {
+        "description": "Double press events are now natively supported.",
+        "breaking": false
+      }
+    ]
+  }
+]

--- a/blueprints/controllers/ikea_e1812/changelog.json
+++ b/blueprints/controllers/ikea_e1812/changelog.json
@@ -3,7 +3,7 @@
     "date": "2021-03-14",
     "changes": [
       {
-        "description": "First blueprint version :tada:",
+        "description": "First blueprint version 🎉",
         "breaking": false
       }
     ]
@@ -12,7 +12,7 @@
     "date": "2021-03-25",
     "changes": [
       {
-        "description": "Standardize input names across all the Controller blueprints. If you plan to update this blueprint, please update the inputs in your automations as follows:\n- remote -> controller_device\n- zigbee2mqtt_remote -> controller_entity\n- helper_last_loop_event_input -> helper_last_controller_event",
+        "description": "Standardize input names across all the Controller blueprints. If you plan to update this blueprint, please update the inputs in your automations as follows:\n- `remote` -> `controller_device`\n- `zigbee2mqtt_remote` -> `controller_entity`\n- `helper_last_loop_event_input` -> `helper_last_controller_event`",
         "breaking": true
       }
     ]
@@ -48,11 +48,11 @@
     "date": "2021-05-15",
     "changes": [
       {
-        "description": "Make helper_last_controller_event a mandatory input to simplify setup and enable future advanced features. Provide a dedicated input_text entity for this input when updating.",
+        "description": "Make `helper_last_controller_event` a mandatory input to simplify setup and enable future advanced features. Provide a dedicated input_text entity for this input when updating.",
         "breaking": true
       },
       {
-        "description": ":tada: Add Debouncing support to avoid duplicate action runs.",
+        "description": "🎉 Add Debouncing support to avoid duplicate action runs.",
         "breaking": false
       },
       {
@@ -96,7 +96,7 @@
     "date": "2022-08-08",
     "changes": [
       {
-        "description": "Optimize characters usage for the helper_last_controller_event text input.",
+        "description": "Optimize characters usage for the `helper_last_controller_event` text input.",
         "breaking": false
       }
     ]
@@ -114,7 +114,7 @@
     "date": "2025-02-13",
     "changes": [
       {
-        "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The controller_entity input is deprecated and controller_device is now mandatory. Remove controller_entity from your automation and configure controller_device with your controller device ID. (Thanks @yarafie)",
+        "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The `controller_entity` input is deprecated and `controller_device` is now mandatory. Remove `controller_entity` from your automation and configure `controller_device` with your controller device ID. (Thanks [@yarafie](https://github.com/yarafie))",
         "breaking": true
       }
     ]
@@ -132,7 +132,7 @@
     "date": "2025-04-06",
     "changes": [
       {
-        "description": "Fix double-click detection logic. (Thanks @danleongjy)",
+        "description": "Fix double-click detection logic. (Thanks [@danleongjy](https://github.com/danleongjy))",
         "breaking": false
       }
     ]
@@ -141,7 +141,7 @@
     "date": "2025-04-12",
     "changes": [
       {
-        "description": "Add native double press triggers and refactor the blueprint to use triggers and trigger IDs. The integration selector input is removed, and helper_last_controller_event is no longer required. Re-download the blueprint and reconfigure existing automations to apply the changes. (Thanks @yarafie)",
+        "description": "Add native double press triggers and refactor the blueprint to use triggers and trigger IDs. The integration selector input is removed, and `helper_last_controller_event` is no longer required. Re-download the blueprint and reconfigure existing automations to apply the changes. (Thanks [@yarafie](https://github.com/yarafie))",
         "breaking": true
       },
       {

--- a/blueprints/controllers/ikea_e2001_e2002/changelog.json
+++ b/blueprints/controllers/ikea_e2001_e2002/changelog.json
@@ -3,7 +3,7 @@
     "date": "2021-11-07",
     "changes": [
       {
-        "description": "First blueprint version :tada:",
+        "description": "First blueprint version 🎉",
         "breaking": false
       }
     ]
@@ -12,7 +12,7 @@
     "date": "2022-08-08",
     "changes": [
       {
-        "description": "Optimize characters usage for the helper_last_controller_event text input.",
+        "description": "Optimize characters usage for the `helper_last_controller_event` text input.",
         "breaking": false
       }
     ]
@@ -21,11 +21,11 @@
     "date": "2025-01-02",
     "changes": [
       {
-        "description": "(ZHA) Fix a bug preventing long press actions from being triggered. (Thanks @Ivarvdb)",
+        "description": "(ZHA) Fix a bug preventing long press actions from being triggered. (Thanks [@Ivarvdb](https://github.com/Ivarvdb))",
         "breaking": false
       },
       {
-        "description": "(Zigbee2MQTT) Handle \"unknown\" state. (Thanks @beardhatcode)",
+        "description": "(Zigbee2MQTT) Handle \"unknown\" state. (Thanks [@beardhatcode](https://github.com/beardhatcode))",
         "breaking": false
       }
     ]
@@ -34,7 +34,7 @@
     "date": "2025-01-03",
     "changes": [
       {
-        "description": "Remove spaces to match the new helper format in Home Assistant 2023.5.x. (Thanks @LordSushiPhoenix)",
+        "description": "Remove spaces to match the new helper format in Home Assistant 2023.5.x. (Thanks [@LordSushiPhoenix](https://github.com/LordSushiPhoenix))",
         "breaking": false
       }
     ]
@@ -43,7 +43,7 @@
     "date": "2025-02-13",
     "changes": [
       {
-        "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The controller_entity input is deprecated and controller_device is now mandatory. Remove controller_entity from your automation and configure controller_device with your controller device ID. (Thanks @yarafie)",
+        "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The `controller_entity` input is deprecated and `controller_device` is now mandatory. Remove `controller_entity` from your automation and configure `controller_device` with your controller device ID. (Thanks [@yarafie](https://github.com/yarafie))",
         "breaking": true
       }
     ]
@@ -61,7 +61,7 @@
     "date": "2025-04-01",
     "changes": [
       {
-        "description": "Fix double-click detection logic. (Thanks @danleongjy)",
+        "description": "Fix double-click detection logic. (Thanks [@danleongjy](https://github.com/danleongjy))",
         "breaking": false
       }
     ]
@@ -70,7 +70,7 @@
     "date": "2025-04-16",
     "changes": [
       {
-        "description": "Fix long press down not releasing. (Thanks @kkthxbye-code)",
+        "description": "Fix long press down not releasing. (Thanks [@kkthxbye-code](https://github.com/kkthxbye-code))",
         "breaking": false
       }
     ]

--- a/blueprints/controllers/ikea_e2001_e2002/changelog.json
+++ b/blueprints/controllers/ikea_e2001_e2002/changelog.json
@@ -1,0 +1,87 @@
+[
+  {
+    "date": "2021-11-07",
+    "changes": [
+      {
+        "description": "First blueprint version :tada:",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2022-08-08",
+    "changes": [
+      {
+        "description": "Optimize characters usage for the helper_last_controller_event text input.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2025-01-02",
+    "changes": [
+      {
+        "description": "(ZHA) Fix a bug preventing long press actions from being triggered. (Thanks @Ivarvdb)",
+        "breaking": false
+      },
+      {
+        "description": "(Zigbee2MQTT) Handle \"unknown\" state. (Thanks @beardhatcode)",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2025-01-03",
+    "changes": [
+      {
+        "description": "Remove spaces to match the new helper format in Home Assistant 2023.5.x. (Thanks @LordSushiPhoenix)",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2025-02-13",
+    "changes": [
+      {
+        "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The controller_entity input is deprecated and controller_device is now mandatory. Remove controller_entity from your automation and configure controller_device with your controller device ID. (Thanks @yarafie)",
+        "breaking": true
+      }
+    ]
+  },
+  {
+    "date": "2025-03-20",
+    "changes": [
+      {
+        "description": "Standardize input naming format for controller devices and virtual button actions. No functionality changes.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2025-04-01",
+    "changes": [
+      {
+        "description": "Fix double-click detection logic. (Thanks @danleongjy)",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2025-04-16",
+    "changes": [
+      {
+        "description": "Fix long press down not releasing. (Thanks @kkthxbye-code)",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2025-04-19",
+    "changes": [
+      {
+        "description": "Improve Last Controller Event Helper JSON Regex with more lenient matching.",
+        "breaking": false
+      }
+    ]
+  }
+]

--- a/blueprints/controllers/ikea_e2123/changelog.json
+++ b/blueprints/controllers/ikea_e2123/changelog.json
@@ -1,0 +1,11 @@
+[
+  {
+    "date": "2025-03-28",
+    "changes": [
+      {
+        "description": "Initial release. (Thanks @yarafie) :tada:",
+        "breaking": false
+      }
+    ]
+  }
+]

--- a/blueprints/controllers/ikea_e2123/changelog.json
+++ b/blueprints/controllers/ikea_e2123/changelog.json
@@ -3,7 +3,7 @@
     "date": "2025-03-28",
     "changes": [
       {
-        "description": "Initial release. (Thanks @yarafie) :tada:",
+        "description": "Initial release. (Thanks [@yarafie](https://github.com/yarafie)) 🎉",
         "breaking": false
       }
     ]

--- a/blueprints/controllers/ikea_e2201/changelog.json
+++ b/blueprints/controllers/ikea_e2201/changelog.json
@@ -3,11 +3,11 @@
     "date": "2025-03-20",
     "changes": [
       {
-        "description": "Initial release. (Thanks @yarafie) :tada:",
+        "description": "Initial release. (Thanks [@yarafie](https://github.com/yarafie)) 🎉",
         "breaking": false
       },
       {
-        "description": "Fix automation triggers. (Thanks @yarafie)",
+        "description": "Fix automation triggers. (Thanks [@yarafie](https://github.com/yarafie))",
         "breaking": false
       },
       {

--- a/blueprints/controllers/ikea_e2201/changelog.json
+++ b/blueprints/controllers/ikea_e2201/changelog.json
@@ -1,0 +1,19 @@
+[
+  {
+    "date": "2025-03-20",
+    "changes": [
+      {
+        "description": "Initial release. (Thanks @yarafie) :tada:",
+        "breaking": false
+      },
+      {
+        "description": "Fix automation triggers. (Thanks @yarafie)",
+        "breaking": false
+      },
+      {
+        "description": "Standardize input naming format for controller devices and virtual button actions. No functionality changes.",
+        "breaking": false
+      }
+    ]
+  }
+]

--- a/blueprints/controllers/ikea_e2213/changelog.json
+++ b/blueprints/controllers/ikea_e2213/changelog.json
@@ -1,0 +1,11 @@
+[
+  {
+    "date": "2025-03-26",
+    "changes": [
+      {
+        "description": "Initial release. (Thanks @yarafie) :tada:",
+        "breaking": false
+      }
+    ]
+  }
+]

--- a/blueprints/controllers/ikea_e2213/changelog.json
+++ b/blueprints/controllers/ikea_e2213/changelog.json
@@ -3,7 +3,7 @@
     "date": "2025-03-26",
     "changes": [
       {
-        "description": "Initial release. (Thanks @yarafie) :tada:",
+        "description": "Initial release. (Thanks [@yarafie](https://github.com/yarafie)) 🎉",
         "breaking": false
       }
     ]

--- a/blueprints/controllers/ikea_ictc_g_1/changelog.json
+++ b/blueprints/controllers/ikea_ictc_g_1/changelog.json
@@ -3,7 +3,7 @@
     "date": "2021-03-26",
     "changes": [
       {
-        "description": "First blueprint version :tada:",
+        "description": "First blueprint version 🎉",
         "breaking": false
       }
     ]
@@ -30,11 +30,11 @@
     "date": "2021-05-26",
     "changes": [
       {
-        "description": "Make helper_last_controller_event a mandatory input to simplify setup and enable future advanced features. When updating, provide a dedicated input_text entity for this input.",
+        "description": "Make `helper_last_controller_event` a mandatory input to simplify setup and enable future advanced features. When updating, provide a dedicated input_text entity for this input.",
         "breaking": true
       },
       {
-        "description": ":tada: Add Debouncing support to avoid duplicate action runs.",
+        "description": "🎉 Add Debouncing support to avoid duplicate action runs.",
         "breaking": false
       },
       {
@@ -86,7 +86,7 @@
     "date": "2022-08-08",
     "changes": [
       {
-        "description": "Optimize characters usage for the helper_last_controller_event text input.",
+        "description": "Optimize characters usage for the `helper_last_controller_event` text input.",
         "breaking": false
       }
     ]
@@ -95,7 +95,7 @@
     "date": "2025-02-13",
     "changes": [
       {
-        "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The controller_entity input is deprecated and controller_device is now mandatory. Remove controller_entity from your automation and configure controller_device with your controller device ID. (Thanks @yarafie)",
+        "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The `controller_entity` input is deprecated and `controller_device` is now mandatory. Remove `controller_entity` from your automation and configure `controller_device` with your controller device ID. (Thanks [@yarafie](https://github.com/yarafie))",
         "breaking": true
       }
     ]

--- a/blueprints/controllers/ikea_ictc_g_1/changelog.json
+++ b/blueprints/controllers/ikea_ictc_g_1/changelog.json
@@ -1,0 +1,121 @@
+[
+  {
+    "date": "2021-03-26",
+    "changes": [
+      {
+        "description": "First blueprint version :tada:",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-04-19",
+    "changes": [
+      {
+        "description": "Fix stop rotation events not being detected with deCONZ.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-04-23",
+    "changes": [
+      {
+        "description": "Fix deCONZ events not being recognized.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-05-26",
+    "changes": [
+      {
+        "description": "Make helper_last_controller_event a mandatory input to simplify setup and enable future advanced features. When updating, provide a dedicated input_text entity for this input.",
+        "breaking": true
+      },
+      {
+        "description": ":tada: Add Debouncing support to avoid duplicate action runs.",
+        "breaking": false
+      },
+      {
+        "description": "Prevent undesired endless loops by running loop actions a finite number of times, configurable through two new blueprint inputs.",
+        "breaking": false
+      },
+      {
+        "description": "Use any RAW stop event (left/right) to identify the stop event corresponding to the current remote rotation.",
+        "breaking": false
+      },
+      {
+        "description": "Fix inputs wrongly marked as required.",
+        "breaking": false
+      },
+      {
+        "description": "Fix Zigbee2MQTT reporting null state changes.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-07-04",
+    "changes": [
+      {
+        "description": "Fix deCONZ rotation stop events not being properly recognized.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-08-02",
+    "changes": [
+      {
+        "description": "Improve inputs documentation and organization.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-10-26",
+    "changes": [
+      {
+        "description": "Standardize blueprint structure and input naming across the collection. Improve blueprint documentation. No functionality change.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2022-08-08",
+    "changes": [
+      {
+        "description": "Optimize characters usage for the helper_last_controller_event text input.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2025-02-13",
+    "changes": [
+      {
+        "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The controller_entity input is deprecated and controller_device is now mandatory. Remove controller_entity from your automation and configure controller_device with your controller device ID. (Thanks @yarafie)",
+        "breaking": true
+      }
+    ]
+  },
+  {
+    "date": "2025-03-20",
+    "changes": [
+      {
+        "description": "Standardize input naming format for controller devices and virtual button actions. No functionality changes.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2025-04-19",
+    "changes": [
+      {
+        "description": "Improve Last Controller Event Helper JSON Regex with more lenient matching.",
+        "breaking": false
+      }
+    ]
+  }
+]

--- a/blueprints/controllers/osram_ac025xx00nj/changelog.json
+++ b/blueprints/controllers/osram_ac025xx00nj/changelog.json
@@ -3,7 +3,7 @@
     "date": "2021-05-18",
     "changes": [
       {
-        "description": "First blueprint version :tada:",
+        "description": "First blueprint version 🎉",
         "breaking": false
       }
     ]
@@ -39,7 +39,7 @@
     "date": "2022-08-08",
     "changes": [
       {
-        "description": "Optimize characters usage for the helper_last_controller_event text input.",
+        "description": "Optimize characters usage for the `helper_last_controller_event` text input.",
         "breaking": false
       }
     ]
@@ -48,7 +48,7 @@
     "date": "2025-01-05",
     "changes": [
       {
-        "description": "Update actions mapping to align with the latest Zigbee2MQTT documentation for the device. (Thanks @alexdelprete)",
+        "description": "Update actions mapping to align with the latest Zigbee2MQTT documentation for the device. (Thanks [@alexdelprete](https://github.com/alexdelprete))",
         "breaking": false
       },
       {
@@ -61,7 +61,7 @@
     "date": "2025-02-13",
     "changes": [
       {
-        "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The controller_entity input is deprecated and controller_device is now mandatory. Remove controller_entity from your automation and configure controller_device with your controller device ID. (Thanks @yarafie)",
+        "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The `controller_entity` input is deprecated and `controller_device` is now mandatory. Remove `controller_entity` from your automation and configure `controller_device` with your controller device ID. (Thanks [@yarafie](https://github.com/yarafie))",
         "breaking": true
       }
     ]
@@ -79,7 +79,7 @@
     "date": "2025-04-06",
     "changes": [
       {
-        "description": "Fix double-click detection logic. (Thanks @danleongjy)",
+        "description": "Fix double-click detection logic. (Thanks [@danleongjy](https://github.com/danleongjy))",
         "breaking": false
       }
     ]

--- a/blueprints/controllers/osram_ac025xx00nj/changelog.json
+++ b/blueprints/controllers/osram_ac025xx00nj/changelog.json
@@ -1,0 +1,96 @@
+[
+  {
+    "date": "2021-05-18",
+    "changes": [
+      {
+        "description": "First blueprint version :tada:",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-05-26",
+    "changes": [
+      {
+        "description": "Fix Zigbee2MQTT reporting null state changes.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-08-02",
+    "changes": [
+      {
+        "description": "Improve inputs documentation and organization.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-10-26",
+    "changes": [
+      {
+        "description": "Standardize blueprint structure and input naming across the collection. Improve blueprint documentation. No functionality change.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2022-08-08",
+    "changes": [
+      {
+        "description": "Optimize characters usage for the helper_last_controller_event text input.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2025-01-05",
+    "changes": [
+      {
+        "description": "Update actions mapping to align with the latest Zigbee2MQTT documentation for the device. (Thanks @alexdelprete)",
+        "breaking": false
+      },
+      {
+        "description": "Fix regex for updated helper JSON serialization starting from Home Assistant 2023.5.0.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2025-02-13",
+    "changes": [
+      {
+        "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The controller_entity input is deprecated and controller_device is now mandatory. Remove controller_entity from your automation and configure controller_device with your controller device ID. (Thanks @yarafie)",
+        "breaking": true
+      }
+    ]
+  },
+  {
+    "date": "2025-03-20",
+    "changes": [
+      {
+        "description": "Standardize input naming format for controller devices and virtual button actions. No functionality changes.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2025-04-06",
+    "changes": [
+      {
+        "description": "Fix double-click detection logic. (Thanks @danleongjy)",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2025-04-19",
+    "changes": [
+      {
+        "description": "Improve Last Controller Event Helper JSON Regex with more lenient matching.",
+        "breaking": false
+      }
+    ]
+  }
+]

--- a/blueprints/controllers/philips_324131092621/changelog.json
+++ b/blueprints/controllers/philips_324131092621/changelog.json
@@ -3,7 +3,7 @@
     "date": "2021-03-27",
     "changes": [
       {
-        "description": "First blueprint version :tada:",
+        "description": "First blueprint version 🎉",
         "breaking": false
       }
     ]
@@ -30,11 +30,11 @@
     "date": "2021-05-26",
     "changes": [
       {
-        "description": "Make helper_last_controller_event a mandatory input to simplify setup and enable future advanced features. When updating, provide a dedicated input_text entity for this input.",
+        "description": "Make `helper_last_controller_event` a mandatory input to simplify setup and enable future advanced features. When updating, provide a dedicated input_text entity for this input.",
         "breaking": true
       },
       {
-        "description": ":tada: Add Debouncing support to avoid duplicate action runs.",
+        "description": "🎉 Add Debouncing support to avoid duplicate action runs.",
         "breaking": false
       },
       {
@@ -82,7 +82,7 @@
     "date": "2022-08-08",
     "changes": [
       {
-        "description": "Optimize characters usage for the helper_last_controller_event text input.",
+        "description": "Optimize characters usage for the `helper_last_controller_event` text input.",
         "breaking": false
       }
     ]
@@ -91,7 +91,7 @@
     "date": "2025-02-13",
     "changes": [
       {
-        "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The controller_entity input is deprecated and controller_device is now mandatory. Remove controller_entity from your automation and configure controller_device with your controller device ID. (Thanks @yarafie)",
+        "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The `controller_entity` input is deprecated and `controller_device` is now mandatory. Remove `controller_entity` from your automation and configure `controller_device` with your controller device ID. (Thanks [@yarafie](https://github.com/yarafie))",
         "breaking": true
       }
     ]
@@ -109,7 +109,7 @@
     "date": "2025-04-06",
     "changes": [
       {
-        "description": "Fix double-click detection logic. (Thanks @danleongjy)",
+        "description": "Fix double-click detection logic. (Thanks [@danleongjy](https://github.com/danleongjy))",
         "breaking": false
       }
     ]

--- a/blueprints/controllers/philips_324131092621/changelog.json
+++ b/blueprints/controllers/philips_324131092621/changelog.json
@@ -1,0 +1,126 @@
+[
+  {
+    "date": "2021-03-27",
+    "changes": [
+      {
+        "description": "First blueprint version :tada:",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-04-19",
+    "changes": [
+      {
+        "description": "Fix double press events not being detected with deCONZ.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-04-23",
+    "changes": [
+      {
+        "description": "Fix deCONZ events not being recognized.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-05-26",
+    "changes": [
+      {
+        "description": "Make helper_last_controller_event a mandatory input to simplify setup and enable future advanced features. When updating, provide a dedicated input_text entity for this input.",
+        "breaking": true
+      },
+      {
+        "description": ":tada: Add Debouncing support to avoid duplicate action runs.",
+        "breaking": false
+      },
+      {
+        "description": "Prevent undesired endless loops by running loop actions a finite number of times, configurable through four new blueprint inputs.",
+        "breaking": false
+      },
+      {
+        "description": "Fix inputs wrongly marked as required.",
+        "breaking": false
+      },
+      {
+        "description": "Fix Zigbee2MQTT reporting null state changes.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-08-02",
+    "changes": [
+      {
+        "description": "Improve inputs documentation and organization.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-10-26",
+    "changes": [
+      {
+        "description": "Standardize blueprint structure and input naming across the collection. Improve blueprint documentation. No functionality change.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-11-19",
+    "changes": [
+      {
+        "description": "Fix controller events not being recognized when using ZHA.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2022-08-08",
+    "changes": [
+      {
+        "description": "Optimize characters usage for the helper_last_controller_event text input.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2025-02-13",
+    "changes": [
+      {
+        "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The controller_entity input is deprecated and controller_device is now mandatory. Remove controller_entity from your automation and configure controller_device with your controller device ID. (Thanks @yarafie)",
+        "breaking": true
+      }
+    ]
+  },
+  {
+    "date": "2025-03-20",
+    "changes": [
+      {
+        "description": "Standardize input naming format for controller devices and virtual button actions. No functionality changes.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2025-04-06",
+    "changes": [
+      {
+        "description": "Fix double-click detection logic. (Thanks @danleongjy)",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2025-04-19",
+    "changes": [
+      {
+        "description": "Improve Last Controller Event Helper JSON Regex with more lenient matching.",
+        "breaking": false
+      }
+    ]
+  }
+]

--- a/blueprints/controllers/philips_8718699693985/changelog.json
+++ b/blueprints/controllers/philips_8718699693985/changelog.json
@@ -3,7 +3,7 @@
     "date": "2021-07-14",
     "changes": [
       {
-        "description": "First blueprint version :tada:",
+        "description": "First blueprint version 🎉",
         "breaking": false
       }
     ]
@@ -30,7 +30,7 @@
     "date": "2022-08-08",
     "changes": [
       {
-        "description": "Optimize characters usage for the helper_last_controller_event text input.",
+        "description": "Optimize characters usage for the `helper_last_controller_event` text input.",
         "breaking": false
       }
     ]
@@ -39,7 +39,7 @@
     "date": "2025-01-05",
     "changes": [
       {
-        "description": "Add support for Zigbee2MQTT. (Thanks @alexdelprete)",
+        "description": "Add support for Zigbee2MQTT. (Thanks [@alexdelprete](https://github.com/alexdelprete))",
         "breaking": false
       },
       {
@@ -52,7 +52,7 @@
     "date": "2025-02-13",
     "changes": [
       {
-        "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The controller_entity input is deprecated and controller_device is now mandatory. Remove controller_entity from your automation and configure controller_device with your controller device ID. (Thanks @yarafie)",
+        "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The `controller_entity` input is deprecated and `controller_device` is now mandatory. Remove `controller_entity` from your automation and configure `controller_device` with your controller device ID. (Thanks [@yarafie](https://github.com/yarafie))",
         "breaking": true
       }
     ]
@@ -70,7 +70,7 @@
     "date": "2025-04-06",
     "changes": [
       {
-        "description": "Fix double-click detection logic. (Thanks @danleongjy)",
+        "description": "Fix double-click detection logic. (Thanks [@danleongjy](https://github.com/danleongjy))",
         "breaking": false
       }
     ]

--- a/blueprints/controllers/philips_8718699693985/changelog.json
+++ b/blueprints/controllers/philips_8718699693985/changelog.json
@@ -1,0 +1,87 @@
+[
+  {
+    "date": "2021-07-14",
+    "changes": [
+      {
+        "description": "First blueprint version :tada:",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-08-02",
+    "changes": [
+      {
+        "description": "Improve inputs documentation and organization.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-10-26",
+    "changes": [
+      {
+        "description": "Standardize blueprint structure and input naming across the collection. Improve blueprint documentation. No functionality change.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2022-08-08",
+    "changes": [
+      {
+        "description": "Optimize characters usage for the helper_last_controller_event text input.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2025-01-05",
+    "changes": [
+      {
+        "description": "Add support for Zigbee2MQTT. (Thanks @alexdelprete)",
+        "breaking": false
+      },
+      {
+        "description": "Fix regex for updated helper JSON serialization starting from Home Assistant 2023.5.0.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2025-02-13",
+    "changes": [
+      {
+        "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The controller_entity input is deprecated and controller_device is now mandatory. Remove controller_entity from your automation and configure controller_device with your controller device ID. (Thanks @yarafie)",
+        "breaking": true
+      }
+    ]
+  },
+  {
+    "date": "2025-03-20",
+    "changes": [
+      {
+        "description": "Standardize input naming format for controller devices and virtual button actions. No functionality changes.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2025-04-06",
+    "changes": [
+      {
+        "description": "Fix double-click detection logic. (Thanks @danleongjy)",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2025-04-19",
+    "changes": [
+      {
+        "description": "Improve Last Controller Event Helper JSON Regex with more lenient matching.",
+        "breaking": false
+      }
+    ]
+  }
+]

--- a/blueprints/controllers/philips_929002398602/changelog.json
+++ b/blueprints/controllers/philips_929002398602/changelog.json
@@ -1,0 +1,74 @@
+[
+  {
+    "date": "2021-11-21",
+    "changes": [
+      {
+        "description": "First blueprint version :tada:",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2022-07-22",
+    "changes": [
+      {
+        "description": "Fix short press actions not being triggered by quick button clicks.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2022-08-08",
+    "changes": [
+      {
+        "description": "Optimize characters usage for the helper_last_controller_event text input.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2025-02-13",
+    "changes": [
+      {
+        "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The controller_entity input is deprecated and controller_device is now mandatory. Remove controller_entity from your automation and configure controller_device with your controller device ID. (Thanks @yarafie)",
+        "breaking": true
+      }
+    ]
+  },
+  {
+    "date": "2025-03-20",
+    "changes": [
+      {
+        "description": "Standardize input naming format for controller devices and virtual button actions. No functionality changes.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2025-04-02",
+    "changes": [
+      {
+        "description": "Fix trigger_delta regex with optional whitespacing. (Thanks @TTvanWillegen)",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2025-04-06",
+    "changes": [
+      {
+        "description": "Fix double-click detection logic. (Thanks @danleongjy)",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2025-04-19",
+    "changes": [
+      {
+        "description": "Improve Last Controller Event Helper JSON Regex with more lenient matching.",
+        "breaking": false
+      }
+    ]
+  }
+]

--- a/blueprints/controllers/philips_929002398602/changelog.json
+++ b/blueprints/controllers/philips_929002398602/changelog.json
@@ -3,7 +3,7 @@
     "date": "2021-11-21",
     "changes": [
       {
-        "description": "First blueprint version :tada:",
+        "description": "First blueprint version 🎉",
         "breaking": false
       }
     ]
@@ -21,7 +21,7 @@
     "date": "2022-08-08",
     "changes": [
       {
-        "description": "Optimize characters usage for the helper_last_controller_event text input.",
+        "description": "Optimize characters usage for the `helper_last_controller_event` text input.",
         "breaking": false
       }
     ]
@@ -30,7 +30,7 @@
     "date": "2025-02-13",
     "changes": [
       {
-        "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The controller_entity input is deprecated and controller_device is now mandatory. Remove controller_entity from your automation and configure controller_device with your controller device ID. (Thanks @yarafie)",
+        "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The `controller_entity` input is deprecated and `controller_device` is now mandatory. Remove `controller_entity` from your automation and configure `controller_device` with your controller device ID. (Thanks [@yarafie](https://github.com/yarafie))",
         "breaking": true
       }
     ]
@@ -48,7 +48,7 @@
     "date": "2025-04-02",
     "changes": [
       {
-        "description": "Fix trigger_delta regex with optional whitespacing. (Thanks @TTvanWillegen)",
+        "description": "Fix trigger_delta regex with optional whitespacing. (Thanks [@TTvanWillegen](https://github.com/TTvanWillegen))",
         "breaking": false
       }
     ]
@@ -57,7 +57,7 @@
     "date": "2025-04-06",
     "changes": [
       {
-        "description": "Fix double-click detection logic. (Thanks @danleongjy)",
+        "description": "Fix double-click detection logic. (Thanks [@danleongjy](https://github.com/danleongjy))",
         "breaking": false
       }
     ]

--- a/blueprints/controllers/sonoff_snzb01/changelog.json
+++ b/blueprints/controllers/sonoff_snzb01/changelog.json
@@ -1,0 +1,38 @@
+[
+  {
+    "date": "2022-07-30",
+    "changes": [
+      {
+        "description": "First blueprint version :tada:",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2022-08-08",
+    "changes": [
+      {
+        "description": "Optimize characters usage for the helper_last_controller_event text input.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2025-02-13",
+    "changes": [
+      {
+        "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The controller_entity input is deprecated and controller_device is now mandatory. Remove controller_entity from your automation and configure controller_device with your controller device ID. (Thanks @yarafie)",
+        "breaking": true
+      }
+    ]
+  },
+  {
+    "date": "2025-04-19",
+    "changes": [
+      {
+        "description": "Improve Last Controller Event Helper JSON Regex with more lenient matching.",
+        "breaking": false
+      }
+    ]
+  }
+]

--- a/blueprints/controllers/sonoff_snzb01/changelog.json
+++ b/blueprints/controllers/sonoff_snzb01/changelog.json
@@ -3,7 +3,7 @@
     "date": "2022-07-30",
     "changes": [
       {
-        "description": "First blueprint version :tada:",
+        "description": "First blueprint version 🎉",
         "breaking": false
       }
     ]
@@ -12,7 +12,7 @@
     "date": "2022-08-08",
     "changes": [
       {
-        "description": "Optimize characters usage for the helper_last_controller_event text input.",
+        "description": "Optimize characters usage for the `helper_last_controller_event` text input.",
         "breaking": false
       }
     ]
@@ -21,7 +21,7 @@
     "date": "2025-02-13",
     "changes": [
       {
-        "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The controller_entity input is deprecated and controller_device is now mandatory. Remove controller_entity from your automation and configure controller_device with your controller device ID. (Thanks @yarafie)",
+        "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The `controller_entity` input is deprecated and `controller_device` is now mandatory. Remove `controller_entity` from your automation and configure `controller_device` with your controller device ID. (Thanks [@yarafie](https://github.com/yarafie))",
         "breaking": true
       }
     ]

--- a/blueprints/controllers/tuya_ERS-10TZBVK-AA/changelog.json
+++ b/blueprints/controllers/tuya_ERS-10TZBVK-AA/changelog.json
@@ -1,0 +1,11 @@
+[
+  {
+    "date": "2025-03-29",
+    "changes": [
+      {
+        "description": "Initial release. (Thanks @yarafie) :tada:",
+        "breaking": false
+      }
+    ]
+  }
+]

--- a/blueprints/controllers/tuya_ERS-10TZBVK-AA/changelog.json
+++ b/blueprints/controllers/tuya_ERS-10TZBVK-AA/changelog.json
@@ -3,7 +3,7 @@
     "date": "2025-03-29",
     "changes": [
       {
-        "description": "Initial release. (Thanks @yarafie) :tada:",
+        "description": "Initial release. (Thanks [@yarafie](https://github.com/yarafie)) 🎉",
         "breaking": false
       }
     ]

--- a/blueprints/controllers/xiaomi_wxcjkg11lm/changelog.json
+++ b/blueprints/controllers/xiaomi_wxcjkg11lm/changelog.json
@@ -3,7 +3,7 @@
     "date": "2021-12-03",
     "changes": [
       {
-        "description": "First blueprint version :tada:",
+        "description": "First blueprint version 🎉",
         "breaking": false
       }
     ]
@@ -12,7 +12,7 @@
     "date": "2022-08-08",
     "changes": [
       {
-        "description": "Optimize characters usage for the helper_last_controller_event text input.",
+        "description": "Optimize characters usage for the `helper_last_controller_event` text input.",
         "breaking": false
       }
     ]
@@ -21,7 +21,7 @@
     "date": "2025-02-13",
     "changes": [
       {
-        "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The controller_entity input is deprecated and controller_device is now mandatory. Remove controller_entity from your automation and configure controller_device with your controller device ID. (Thanks @yarafie)",
+        "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The `controller_entity` input is deprecated and `controller_device` is now mandatory. Remove `controller_entity` from your automation and configure `controller_device` with your controller device ID. (Thanks [@yarafie](https://github.com/yarafie))",
         "breaking": true
       }
     ]

--- a/blueprints/controllers/xiaomi_wxcjkg11lm/changelog.json
+++ b/blueprints/controllers/xiaomi_wxcjkg11lm/changelog.json
@@ -1,0 +1,47 @@
+[
+  {
+    "date": "2021-12-03",
+    "changes": [
+      {
+        "description": "First blueprint version :tada:",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2022-08-08",
+    "changes": [
+      {
+        "description": "Optimize characters usage for the helper_last_controller_event text input.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2025-02-13",
+    "changes": [
+      {
+        "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The controller_entity input is deprecated and controller_device is now mandatory. Remove controller_entity from your automation and configure controller_device with your controller device ID. (Thanks @yarafie)",
+        "breaking": true
+      }
+    ]
+  },
+  {
+    "date": "2025-03-20",
+    "changes": [
+      {
+        "description": "Standardize input naming format for controller devices and virtual button actions. No functionality changes.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2025-04-19",
+    "changes": [
+      {
+        "description": "Improve Last Controller Event Helper JSON Regex with more lenient matching.",
+        "breaking": false
+      }
+    ]
+  }
+]

--- a/blueprints/controllers/xiaomi_wxcjkg12lm/changelog.json
+++ b/blueprints/controllers/xiaomi_wxcjkg12lm/changelog.json
@@ -3,7 +3,7 @@
     "date": "2021-12-03",
     "changes": [
       {
-        "description": "First blueprint version :tada:",
+        "description": "First blueprint version 🎉",
         "breaking": false
       }
     ]
@@ -12,7 +12,7 @@
     "date": "2022-08-08",
     "changes": [
       {
-        "description": "Optimize characters usage for the helper_last_controller_event text input.",
+        "description": "Optimize characters usage for the `helper_last_controller_event` text input.",
         "breaking": false
       }
     ]
@@ -21,7 +21,7 @@
     "date": "2025-02-13",
     "changes": [
       {
-        "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The controller_entity input is deprecated and controller_device is now mandatory. Remove controller_entity from your automation and configure controller_device with your controller device ID. (Thanks @yarafie)",
+        "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The `controller_entity` input is deprecated and `controller_device` is now mandatory. Remove `controller_entity` from your automation and configure `controller_device` with your controller device ID. (Thanks [@yarafie](https://github.com/yarafie))",
         "breaking": true
       }
     ]

--- a/blueprints/controllers/xiaomi_wxcjkg12lm/changelog.json
+++ b/blueprints/controllers/xiaomi_wxcjkg12lm/changelog.json
@@ -1,0 +1,47 @@
+[
+  {
+    "date": "2021-12-03",
+    "changes": [
+      {
+        "description": "First blueprint version :tada:",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2022-08-08",
+    "changes": [
+      {
+        "description": "Optimize characters usage for the helper_last_controller_event text input.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2025-02-13",
+    "changes": [
+      {
+        "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The controller_entity input is deprecated and controller_device is now mandatory. Remove controller_entity from your automation and configure controller_device with your controller device ID. (Thanks @yarafie)",
+        "breaking": true
+      }
+    ]
+  },
+  {
+    "date": "2025-03-20",
+    "changes": [
+      {
+        "description": "Standardize input naming format for controller devices and virtual button actions. No functionality changes.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2025-04-19",
+    "changes": [
+      {
+        "description": "Improve Last Controller Event Helper JSON Regex with more lenient matching.",
+        "breaking": false
+      }
+    ]
+  }
+]

--- a/blueprints/controllers/xiaomi_wxcjkg13lm/changelog.json
+++ b/blueprints/controllers/xiaomi_wxcjkg13lm/changelog.json
@@ -3,7 +3,7 @@
     "date": "2021-12-03",
     "changes": [
       {
-        "description": "First blueprint version :tada:",
+        "description": "First blueprint version 🎉",
         "breaking": false
       }
     ]
@@ -12,7 +12,7 @@
     "date": "2022-08-08",
     "changes": [
       {
-        "description": "Optimize characters usage for the helper_last_controller_event text input.",
+        "description": "Optimize characters usage for the `helper_last_controller_event` text input.",
         "breaking": false
       }
     ]
@@ -21,7 +21,7 @@
     "date": "2025-02-13",
     "changes": [
       {
-        "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The controller_entity input is deprecated and controller_device is now mandatory. Remove controller_entity from your automation and configure controller_device with your controller device ID. (Thanks @yarafie)",
+        "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The `controller_entity` input is deprecated and `controller_device` is now mandatory. Remove `controller_entity` from your automation and configure `controller_device` with your controller device ID. (Thanks [@yarafie](https://github.com/yarafie))",
         "breaking": true
       }
     ]

--- a/blueprints/controllers/xiaomi_wxcjkg13lm/changelog.json
+++ b/blueprints/controllers/xiaomi_wxcjkg13lm/changelog.json
@@ -1,0 +1,47 @@
+[
+  {
+    "date": "2021-12-03",
+    "changes": [
+      {
+        "description": "First blueprint version :tada:",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2022-08-08",
+    "changes": [
+      {
+        "description": "Optimize characters usage for the helper_last_controller_event text input.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2025-02-13",
+    "changes": [
+      {
+        "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The controller_entity input is deprecated and controller_device is now mandatory. Remove controller_entity from your automation and configure controller_device with your controller device ID. (Thanks @yarafie)",
+        "breaking": true
+      }
+    ]
+  },
+  {
+    "date": "2025-03-20",
+    "changes": [
+      {
+        "description": "Standardize input naming format for controller devices and virtual button actions. No functionality changes.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2025-04-19",
+    "changes": [
+      {
+        "description": "Improve Last Controller Event Helper JSON Regex with more lenient matching.",
+        "breaking": false
+      }
+    ]
+  }
+]

--- a/blueprints/controllers/xiaomi_wxkg11lm/changelog.json
+++ b/blueprints/controllers/xiaomi_wxkg11lm/changelog.json
@@ -3,7 +3,7 @@
     "date": "2022-07-22",
     "changes": [
       {
-        "description": "First blueprint version :tada:",
+        "description": "First blueprint version 🎉",
         "breaking": false
       }
     ]
@@ -12,7 +12,7 @@
     "date": "2022-08-08",
     "changes": [
       {
-        "description": "Optimize characters usage for the helper_last_controller_event text input.",
+        "description": "Optimize characters usage for the `helper_last_controller_event` text input.",
         "breaking": false
       }
     ]
@@ -21,7 +21,7 @@
     "date": "2025-02-13",
     "changes": [
       {
-        "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The controller_entity input is deprecated and controller_device is now mandatory. Remove controller_entity from your automation and configure controller_device with your controller device ID. (Thanks @yarafie)",
+        "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The `controller_entity` input is deprecated and `controller_device` is now mandatory. Remove `controller_entity` from your automation and configure `controller_device` with your controller device ID. (Thanks [@yarafie](https://github.com/yarafie))",
         "breaking": true
       }
     ]
@@ -30,7 +30,7 @@
     "date": "2025-02-16",
     "changes": [
       {
-        "description": "Add support for Xiaomi WXKG01LM Mi Wireless Switch and rename Xiaomi WXKG11LM Aqara Wireless Switch Mini to Aqara WXKG11LM Wireless Mini Switch. (Thanks @yarafie)",
+        "description": "Add support for Xiaomi WXKG01LM Mi Wireless Switch and rename Xiaomi WXKG11LM Aqara Wireless Switch Mini to Aqara WXKG11LM Wireless Mini Switch. (Thanks [@yarafie](https://github.com/yarafie))",
         "breaking": false
       }
     ]

--- a/blueprints/controllers/xiaomi_wxkg11lm/changelog.json
+++ b/blueprints/controllers/xiaomi_wxkg11lm/changelog.json
@@ -1,0 +1,56 @@
+[
+  {
+    "date": "2022-07-22",
+    "changes": [
+      {
+        "description": "First blueprint version :tada:",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2022-08-08",
+    "changes": [
+      {
+        "description": "Optimize characters usage for the helper_last_controller_event text input.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2025-02-13",
+    "changes": [
+      {
+        "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The controller_entity input is deprecated and controller_device is now mandatory. Remove controller_entity from your automation and configure controller_device with your controller device ID. (Thanks @yarafie)",
+        "breaking": true
+      }
+    ]
+  },
+  {
+    "date": "2025-02-16",
+    "changes": [
+      {
+        "description": "Add support for Xiaomi WXKG01LM Mi Wireless Switch and rename Xiaomi WXKG11LM Aqara Wireless Switch Mini to Aqara WXKG11LM Wireless Mini Switch. (Thanks @yarafie)",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2025-03-20",
+    "changes": [
+      {
+        "description": "Standardize input naming format for controller devices and virtual button actions. No functionality changes.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2025-04-19",
+    "changes": [
+      {
+        "description": "Improve Last Controller Event Helper JSON Regex with more lenient matching.",
+        "breaking": false
+      }
+    ]
+  }
+]

--- a/blueprints/hooks/cover/changelog.json
+++ b/blueprints/hooks/cover/changelog.json
@@ -1,0 +1,131 @@
+[
+  {
+    "date": "2021-03-26",
+    "changes": [
+      {
+        "description": "First blueprint version :tada:",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-04-19",
+    "changes": [
+      {
+        "description": "Remove unused variable and fix warnings for undefined variables in Home Assistant Core >=2021.4.0.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-08-02",
+    "changes": [
+      {
+        "description": "Improve inputs documentation and organization.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-10-26",
+    "changes": [
+      {
+        "description": "Standardize blueprint structure and input naming across the collection.",
+        "breaking": false
+      },
+      {
+        "description": "Improve blueprint documentation.",
+        "breaking": false
+      },
+      {
+        "description": ":tada: Add support for alternate mappings.",
+        "breaking": false
+      },
+      {
+        "description": "Update controller names in the Controller Model input to match full controller names, prevent ambiguities and enable alternate mappings. After updating, reconfigure automations by selecting the correct controller name.",
+        "breaking": true
+      }
+    ]
+  },
+  {
+    "date": "2021-10-29",
+    "changes": [
+      {
+        "description": "Add support for IKEA E1766 TRÅDFRI Open/Close Remote.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-12-03",
+    "changes": [
+      {
+        "description": "Add support for Xiaomi WXCJKG11LM, WXCJKG12LM, and WXCJKG13LM.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2022-07-22",
+    "changes": [
+      {
+        "description": "Add support for Xiaomi WXKG11LM.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2022-07-30",
+    "changes": [
+      {
+        "description": "Add support for SONOFF SNZB-01.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2025-02-13",
+    "changes": [
+      {
+        "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The controller_entity input is deprecated and controller_device is now mandatory. Remove controller_entity from your automation and configure controller_device with your controller device ID. (Thanks @yarafie)",
+        "breaking": true
+      }
+    ]
+  },
+  {
+    "date": "2025-02-16",
+    "changes": [
+      {
+        "description": "Add support for Xiaomi WXKG01LM Mi Wireless Switch and rename Xiaomi WXKG11LM Aqara Wireless Switch Mini to Aqara WXKG11LM Wireless Mini Switch. Update the controller_model input accordingly if needed.",
+        "breaking": true
+      }
+    ]
+  },
+  {
+    "date": "2025-03-20",
+    "changes": [
+      {
+        "description": "Add support for IKEA E2201 RODRET Dimmer. (Thanks @yarafie)",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2025-03-26",
+    "changes": [
+      {
+        "description": "Add support for IKEA E2213 SOMRIG shortcut button. (Thanks @yarafie)",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2025-03-28",
+    "changes": [
+      {
+        "description": "Add support for IKEA E2123 SYMFONISK sound remote, gen 2. (Thanks @yarafie)",
+        "breaking": false
+      }
+    ]
+  }
+]

--- a/blueprints/hooks/cover/changelog.json
+++ b/blueprints/hooks/cover/changelog.json
@@ -3,7 +3,7 @@
     "date": "2021-03-26",
     "changes": [
       {
-        "description": "First blueprint version :tada:",
+        "description": "First blueprint version 🎉",
         "breaking": false
       }
     ]
@@ -38,7 +38,7 @@
         "breaking": false
       },
       {
-        "description": ":tada: Add support for alternate mappings.",
+        "description": "🎉 Add support for alternate mappings.",
         "breaking": false
       },
       {
@@ -87,7 +87,7 @@
     "date": "2025-02-13",
     "changes": [
       {
-        "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The controller_entity input is deprecated and controller_device is now mandatory. Remove controller_entity from your automation and configure controller_device with your controller device ID. (Thanks @yarafie)",
+        "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The `controller_entity` input is deprecated and `controller_device` is now mandatory. Remove `controller_entity` from your automation and configure `controller_device` with your controller device ID. (Thanks [@yarafie](https://github.com/yarafie))",
         "breaking": true
       }
     ]
@@ -96,7 +96,7 @@
     "date": "2025-02-16",
     "changes": [
       {
-        "description": "Add support for Xiaomi WXKG01LM Mi Wireless Switch and rename Xiaomi WXKG11LM Aqara Wireless Switch Mini to Aqara WXKG11LM Wireless Mini Switch. Update the controller_model input accordingly if needed.",
+        "description": "Add support for Xiaomi WXKG01LM Mi Wireless Switch and rename Xiaomi WXKG11LM Aqara Wireless Switch Mini to Aqara WXKG11LM Wireless Mini Switch. Update the `controller_model` input accordingly if needed.",
         "breaking": true
       }
     ]
@@ -105,7 +105,7 @@
     "date": "2025-03-20",
     "changes": [
       {
-        "description": "Add support for IKEA E2201 RODRET Dimmer. (Thanks @yarafie)",
+        "description": "Add support for IKEA E2201 RODRET Dimmer. (Thanks [@yarafie](https://github.com/yarafie))",
         "breaking": false
       }
     ]
@@ -114,7 +114,7 @@
     "date": "2025-03-26",
     "changes": [
       {
-        "description": "Add support for IKEA E2213 SOMRIG shortcut button. (Thanks @yarafie)",
+        "description": "Add support for IKEA E2213 SOMRIG shortcut button. (Thanks [@yarafie](https://github.com/yarafie))",
         "breaking": false
       }
     ]
@@ -123,7 +123,7 @@
     "date": "2025-03-28",
     "changes": [
       {
-        "description": "Add support for IKEA E2123 SYMFONISK sound remote, gen 2. (Thanks @yarafie)",
+        "description": "Add support for IKEA E2123 SYMFONISK sound remote, gen 2. (Thanks [@yarafie](https://github.com/yarafie))",
         "breaking": false
       }
     ]

--- a/blueprints/hooks/light/changelog.json
+++ b/blueprints/hooks/light/changelog.json
@@ -3,7 +3,7 @@
     "date": "2021-03-04",
     "changes": [
       {
-        "description": "First blueprint version :tada:",
+        "description": "First blueprint version 🎉",
         "breaking": false
       }
     ]
@@ -135,7 +135,7 @@
         "breaking": false
       },
       {
-        "description": ":tada: Add support for alternate mappings.",
+        "description": "🎉 Add support for alternate mappings.",
         "breaking": false
       },
       {
@@ -227,7 +227,7 @@
     "date": "2025-02-13",
     "changes": [
       {
-        "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The controller_entity input is deprecated and controller_device is now mandatory. Remove controller_entity from your automation and configure controller_device with your controller device ID. (Thanks @yarafie)",
+        "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The `controller_entity` input is deprecated and `controller_device` is now mandatory. Remove `controller_entity` from your automation and configure `controller_device` with your controller device ID. (Thanks [@yarafie](https://github.com/yarafie))",
         "breaking": true
       }
     ]
@@ -236,7 +236,7 @@
     "date": "2025-02-16",
     "changes": [
       {
-        "description": "Add support for Xiaomi WXKG01LM Mi Wireless Switch and rename Xiaomi WXKG11LM Aqara Wireless Switch Mini to Aqara WXKG11LM Wireless Mini Switch. Update the controller_model input accordingly if needed.",
+        "description": "Add support for Xiaomi WXKG01LM Mi Wireless Switch and rename Xiaomi WXKG11LM Aqara Wireless Switch Mini to Aqara WXKG11LM Wireless Mini Switch. Update the `controller_model` input accordingly if needed.",
         "breaking": true
       }
     ]
@@ -245,7 +245,7 @@
     "date": "2025-03-18",
     "changes": [
       {
-        "description": "Use min_brightness and max_brightness as conditions instead of \"while true\" loops. (Thanks @Nicolai-)",
+        "description": "Use min_brightness and max_brightness as conditions instead of \"while true\" loops. (Thanks [@Nicolai-](https://github.com/Nicolai-))",
         "breaking": false
       }
     ]
@@ -254,7 +254,7 @@
     "date": "2025-03-20",
     "changes": [
       {
-        "description": "Add support for IKEA E2201 RODRET Dimmer. (Thanks @yarafie)",
+        "description": "Add support for IKEA E2201 RODRET Dimmer. (Thanks [@yarafie](https://github.com/yarafie))",
         "breaking": false
       }
     ]
@@ -263,7 +263,7 @@
     "date": "2025-03-26",
     "changes": [
       {
-        "description": "Add support for IKEA E2213 SOMRIG shortcut button. (Thanks @yarafie)",
+        "description": "Add support for IKEA E2213 SOMRIG shortcut button. (Thanks [@yarafie](https://github.com/yarafie))",
         "breaking": false
       }
     ]
@@ -272,7 +272,7 @@
     "date": "2025-03-28",
     "changes": [
       {
-        "description": "Add support for IKEA E2123 SYMFONISK sound remote, gen 2. (Thanks @yarafie)",
+        "description": "Add support for IKEA E2123 SYMFONISK sound remote, gen 2. (Thanks [@yarafie](https://github.com/yarafie))",
         "breaking": false
       }
     ]
@@ -281,7 +281,7 @@
     "date": "2025-03-29",
     "changes": [
       {
-        "description": "Add support for Tuya ERS-10TZBVK-AA Smart knob. (Thanks @yarafie)",
+        "description": "Add support for Tuya ERS-10TZBVK-AA Smart knob. (Thanks [@yarafie](https://github.com/yarafie))",
         "breaking": false
       }
     ]

--- a/blueprints/hooks/light/changelog.json
+++ b/blueprints/hooks/light/changelog.json
@@ -1,0 +1,289 @@
+[
+  {
+    "date": "2021-03-04",
+    "changes": [
+      {
+        "description": "First blueprint version :tada:",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-03-07",
+    "changes": [
+      {
+        "description": "Add support for IKEA E1744 SYMFONISK Rotary Remote.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-03-14",
+    "changes": [
+      {
+        "description": "Add support for IKEA E1812 Shortcut button and fix IKEA E1743 naming.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-03-25",
+    "changes": [
+      {
+        "description": "Update action mapping for IKEA E1744. If you're using this Hook with an IKEA E1744, please update the corresponding Controller blueprint as well.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-03-26",
+    "changes": [
+      {
+        "description": "Set minimum and maximum light brightness.",
+        "breaking": false
+      },
+      {
+        "description": "Specify the number of steps from minimum to maximum brightness for both short and long actions when controlling the light.",
+        "breaking": false
+      },
+      {
+        "description": "Allow forcing brightness to a specific value when turning on the light.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-03-27",
+    "changes": [
+      {
+        "description": "Add support for Philips Hue Dimmer switch.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-04-06",
+    "changes": [
+      {
+        "description": "Fix light color modes preventing configuration of automations with color temperature control.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-04-15",
+    "changes": [
+      {
+        "description": "Add smooth power on/off features.",
+        "breaking": false
+      },
+      {
+        "description": "By default the light now turns off when a brightness down command is received at minimum brightness. Disable the smooth power off feature to keep the previous behaviour.",
+        "breaking": true
+      },
+      {
+        "description": "Fix optional field names.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-04-19",
+    "changes": [
+      {
+        "description": "Remove unused variable and fix warnings for undefined variables in Home Assistant Core >=2021.4.0.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-05-16",
+    "changes": [
+      {
+        "description": "Add support for OSRAM SMART+ Switch Mini.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-07-03",
+    "changes": [
+      {
+        "description": "Add support for Philips Hue Smart Button.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-08-02",
+    "changes": [
+      {
+        "description": "Improve inputs documentation and organization.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-10-26",
+    "changes": [
+      {
+        "description": "Standardize blueprint structure and input naming across the collection.",
+        "breaking": false
+      },
+      {
+        "description": "Improve blueprint documentation.",
+        "breaking": false
+      },
+      {
+        "description": ":tada: Add support for alternate mappings.",
+        "breaking": false
+      },
+      {
+        "description": "Update controller names in the Controller Model input to match full controller names, prevent ambiguities and enable alternate mappings. After updating, reconfigure automations by selecting the correct controller name.",
+        "breaking": true
+      },
+      {
+        "description": "Fix remembering brightness level when turning on lights if the previous state had brightness unavailable.",
+        "breaking": false
+      },
+      {
+        "description": "Add secondary mapping for IKEA E1743 TRÅDFRI On/Off Switch & Dimmer.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-10-29",
+    "changes": [
+      {
+        "description": "Add support for IKEA E1766 TRÅDFRI Open/Close Remote.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-11-07",
+    "changes": [
+      {
+        "description": "Add support for IKEA E2001/E2002 STYRBAR Remote control.",
+        "breaking": false
+      },
+      {
+        "description": "Fix color mode automatic detection not working properly with color temperature lights.",
+        "breaking": false
+      },
+      {
+        "description": "Add \"None\" color mode to disable color control features.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-11-21",
+    "changes": [
+      {
+        "description": "Add support for Philips 929002398602 Hue Dimmer switch v2.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-12-03",
+    "changes": [
+      {
+        "description": "Add support for Xiaomi WXCJKG11LM, WXCJKG12LM, and WXCJKG13LM.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-12-05",
+    "changes": [
+      {
+        "description": "Add secondary mapping for IKEA E2001/E2002.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2022-07-22",
+    "changes": [
+      {
+        "description": "Add support for Xiaomi WXKG11LM.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2022-07-30",
+    "changes": [
+      {
+        "description": "Add support for SONOFF SNZB-01.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2025-02-13",
+    "changes": [
+      {
+        "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The controller_entity input is deprecated and controller_device is now mandatory. Remove controller_entity from your automation and configure controller_device with your controller device ID. (Thanks @yarafie)",
+        "breaking": true
+      }
+    ]
+  },
+  {
+    "date": "2025-02-16",
+    "changes": [
+      {
+        "description": "Add support for Xiaomi WXKG01LM Mi Wireless Switch and rename Xiaomi WXKG11LM Aqara Wireless Switch Mini to Aqara WXKG11LM Wireless Mini Switch. Update the controller_model input accordingly if needed.",
+        "breaking": true
+      }
+    ]
+  },
+  {
+    "date": "2025-03-18",
+    "changes": [
+      {
+        "description": "Use min_brightness and max_brightness as conditions instead of \"while true\" loops. (Thanks @Nicolai-)",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2025-03-20",
+    "changes": [
+      {
+        "description": "Add support for IKEA E2201 RODRET Dimmer. (Thanks @yarafie)",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2025-03-26",
+    "changes": [
+      {
+        "description": "Add support for IKEA E2213 SOMRIG shortcut button. (Thanks @yarafie)",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2025-03-28",
+    "changes": [
+      {
+        "description": "Add support for IKEA E2123 SYMFONISK sound remote, gen 2. (Thanks @yarafie)",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2025-03-29",
+    "changes": [
+      {
+        "description": "Add support for Tuya ERS-10TZBVK-AA Smart knob. (Thanks @yarafie)",
+        "breaking": false
+      }
+    ]
+  }
+]

--- a/blueprints/hooks/media_player/changelog.json
+++ b/blueprints/hooks/media_player/changelog.json
@@ -3,7 +3,7 @@
     "date": "2021-03-04",
     "changes": [
       {
-        "description": "First blueprint version :tada:",
+        "description": "First blueprint version 🎉",
         "breaking": false
       }
     ]
@@ -101,7 +101,7 @@
         "breaking": false
       },
       {
-        "description": ":tada: Add support for alternate mappings.",
+        "description": "🎉 Add support for alternate mappings.",
         "breaking": false
       },
       {
@@ -172,7 +172,7 @@
     "date": "2025-02-13",
     "changes": [
       {
-        "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The controller_entity input is deprecated and controller_device is now mandatory. Remove controller_entity from your automation and configure controller_device with your controller device ID. (Thanks @yarafie)",
+        "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The `controller_entity` input is deprecated and `controller_device` is now mandatory. Remove `controller_entity` from your automation and configure `controller_device` with your controller device ID. (Thanks [@yarafie](https://github.com/yarafie))",
         "breaking": true
       }
     ]
@@ -181,7 +181,7 @@
     "date": "2025-02-16",
     "changes": [
       {
-        "description": "Add support for Xiaomi WXKG01LM Mi Wireless Switch and rename Xiaomi WXKG11LM Aqara Wireless Switch Mini to Aqara WXKG11LM Wireless Mini Switch. Update the controller_model input accordingly if needed.",
+        "description": "Add support for Xiaomi WXKG01LM Mi Wireless Switch and rename Xiaomi WXKG11LM Aqara Wireless Switch Mini to Aqara WXKG11LM Wireless Mini Switch. Update the `controller_model` input accordingly if needed.",
         "breaking": true
       }
     ]
@@ -190,7 +190,7 @@
     "date": "2025-03-20",
     "changes": [
       {
-        "description": "Add support for IKEA E2201 RODRET Dimmer. (Thanks @yarafie)",
+        "description": "Add support for IKEA E2201 RODRET Dimmer. (Thanks [@yarafie](https://github.com/yarafie))",
         "breaking": false
       }
     ]
@@ -199,7 +199,7 @@
     "date": "2025-03-26",
     "changes": [
       {
-        "description": "Add support for IKEA E2213 SOMRIG shortcut button. (Thanks @yarafie)",
+        "description": "Add support for IKEA E2213 SOMRIG shortcut button. (Thanks [@yarafie](https://github.com/yarafie))",
         "breaking": false
       }
     ]
@@ -208,7 +208,7 @@
     "date": "2025-03-28",
     "changes": [
       {
-        "description": "Add support for IKEA E2123 SYMFONISK sound remote, gen 2. (Thanks @yarafie)",
+        "description": "Add support for IKEA E2123 SYMFONISK sound remote, gen 2. (Thanks [@yarafie](https://github.com/yarafie))",
         "breaking": false
       }
     ]
@@ -217,7 +217,7 @@
     "date": "2025-03-29",
     "changes": [
       {
-        "description": "Add support for Tuya ERS-10TZBVK-AA Smart knob. (Thanks @yarafie)",
+        "description": "Add support for Tuya ERS-10TZBVK-AA Smart knob. (Thanks [@yarafie](https://github.com/yarafie))",
         "breaking": false
       }
     ]

--- a/blueprints/hooks/media_player/changelog.json
+++ b/blueprints/hooks/media_player/changelog.json
@@ -1,0 +1,225 @@
+[
+  {
+    "date": "2021-03-04",
+    "changes": [
+      {
+        "description": "First blueprint version :tada:",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-03-07",
+    "changes": [
+      {
+        "description": "Add support for IKEA E1744 SYMFONISK Rotary Remote.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-03-14",
+    "changes": [
+      {
+        "description": "Add support for IKEA E1812 Shortcut button and fix IKEA E1743 naming.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-03-25",
+    "changes": [
+      {
+        "description": "Update action mapping for IKEA E1744. If you're using this Hook with an IKEA E1744, please update the corresponding Controller blueprint as well.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-03-26",
+    "changes": [
+      {
+        "description": "Add the ability to specify the number of steps from minimum to maximum volume for both short and long actions when controlling the media player.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-03-27",
+    "changes": [
+      {
+        "description": "Add support for Philips Hue Dimmer switch.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-04-19",
+    "changes": [
+      {
+        "description": "Remove unused variable and fix warnings for undefined variables in Home Assistant Core >=2021.4.0.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-05-16",
+    "changes": [
+      {
+        "description": "Add support for OSRAM SMART+ Switch Mini.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-07-03",
+    "changes": [
+      {
+        "description": "Add support for Philips Hue Smart Button.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-08-02",
+    "changes": [
+      {
+        "description": "Improve inputs documentation and organization.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-10-26",
+    "changes": [
+      {
+        "description": "Standardize blueprint structure and input naming across the collection.",
+        "breaking": false
+      },
+      {
+        "description": "Improve blueprint documentation.",
+        "breaking": false
+      },
+      {
+        "description": ":tada: Add support for alternate mappings.",
+        "breaking": false
+      },
+      {
+        "description": "Update controller names in the Controller Model input to match full controller names, prevent ambiguities and enable alternate mappings. After updating, reconfigure automations by selecting the correct controller name.",
+        "breaking": true
+      },
+      {
+        "description": "Fix typo for IKEA E1524/E1810 center button long press action in mapping definition.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-10-29",
+    "changes": [
+      {
+        "description": "Add support for IKEA E1766 TRÅDFRI Open/Close Remote.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-11-07",
+    "changes": [
+      {
+        "description": "Add support for IKEA E2001/E2002 STYRBAR Remote control.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-11-21",
+    "changes": [
+      {
+        "description": "Add support for Philips 929002398602 Hue Dimmer switch v2.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2021-12-03",
+    "changes": [
+      {
+        "description": "Add support for Xiaomi WXCJKG11LM, WXCJKG12LM, and WXCJKG13LM.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2022-07-22",
+    "changes": [
+      {
+        "description": "Add support for Xiaomi WXKG11LM.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2022-07-30",
+    "changes": [
+      {
+        "description": "Add support for SONOFF SNZB-01.",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2025-02-13",
+    "changes": [
+      {
+        "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The controller_entity input is deprecated and controller_device is now mandatory. Remove controller_entity from your automation and configure controller_device with your controller device ID. (Thanks @yarafie)",
+        "breaking": true
+      }
+    ]
+  },
+  {
+    "date": "2025-02-16",
+    "changes": [
+      {
+        "description": "Add support for Xiaomi WXKG01LM Mi Wireless Switch and rename Xiaomi WXKG11LM Aqara Wireless Switch Mini to Aqara WXKG11LM Wireless Mini Switch. Update the controller_model input accordingly if needed.",
+        "breaking": true
+      }
+    ]
+  },
+  {
+    "date": "2025-03-20",
+    "changes": [
+      {
+        "description": "Add support for IKEA E2201 RODRET Dimmer. (Thanks @yarafie)",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2025-03-26",
+    "changes": [
+      {
+        "description": "Add support for IKEA E2213 SOMRIG shortcut button. (Thanks @yarafie)",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2025-03-28",
+    "changes": [
+      {
+        "description": "Add support for IKEA E2123 SYMFONISK sound remote, gen 2. (Thanks @yarafie)",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "date": "2025-03-29",
+    "changes": [
+      {
+        "description": "Add support for Tuya ERS-10TZBVK-AA Smart knob. (Thanks @yarafie)",
+        "breaking": false
+      }
+    ]
+  }
+]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       js-cookie:
         specifier: ^3.0.5
         version: 3.0.5
+      marked:
+        specifier: ^12.0.0
+        version: 12.0.2
       prism-react-renderer:
         specifier: ^2.3.0
         version: 2.4.1(react@19.0.0)
@@ -3746,6 +3749,11 @@ packages:
 
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
+  marked@12.0.2:
+    resolution: {integrity: sha512-qXUm7e/YKFoqFPYPa3Ukg9xlI5cyAtGmyEIzMfW//m6kXwCy2Ps9DYf5ioijFKQ8qyuscrHoY04iJGctu2Kg0Q==}
+    engines: {node: '>= 18'}
+    hasBin: true
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -10757,6 +10765,8 @@ snapshots:
       repeat-string: 1.6.1
 
   markdown-table@3.0.4: {}
+
+  marked@12.0.2: {}
 
   math-intrinsics@1.1.0: {}
 

--- a/website/docs/blueprints/automation/addon_update_notification.mdx
+++ b/website/docs/blueprints/automation/addon_update_notification.mdx
@@ -8,6 +8,7 @@ import {
   Inputs,
   Requirement,
   ImportCard,
+  Changelog,
 } from '/src/components/blueprints_docs'
 
 <ImportCard id='addon_update_notification' category='automation' />
@@ -78,5 +79,4 @@ Please be aware that if you use notification groups which include both iOS and A
 
 ## Changelog
 
-- **2021-04-25**: first blueprint version :tada:
-- **2021-10-26**: Standardize blueprints structure and inputs naming across the whole collection. Improve blueprint documentation. No functionality change.
+<Changelog category='automation' id='addon_update_notification' />

--- a/website/docs/blueprints/automation/on_off_schedule_state_persistence.mdx
+++ b/website/docs/blueprints/automation/on_off_schedule_state_persistence.mdx
@@ -8,6 +8,7 @@ import {
   Inputs,
   Requirement,
   ImportCard,
+  Changelog,
 } from '/src/components/blueprints_docs'
 
 <ImportCard id='on_off_schedule_state_persistence' category='automation' />
@@ -44,5 +45,4 @@ This automation only provides a simple On-Off schedule. More complex situations 
 
 ## Changelog
 
-- **2021-02-01**: first blueprint version :tada:
-- **2021-10-26**: Standardize blueprints structure and inputs naming across the whole collection. Improve blueprint documentation. Remove default value from required inputs. No functionality change.
+<Changelog category='automation' id='on_off_schedule_state_persistence' />

--- a/website/docs/blueprints/automation/persistent_notification_to_mobile.mdx
+++ b/website/docs/blueprints/automation/persistent_notification_to_mobile.mdx
@@ -8,6 +8,7 @@ import {
   Inputs,
   Requirement,
   ImportCard,
+  Changelog,
 } from '/src/components/blueprints_docs'
 
 <ImportCard id='persistent_notification_to_mobile' category='automation' />
@@ -67,5 +68,4 @@ Please be aware that if you use notification groups which include both iOS and A
 
 ## Changelog
 
-- **2021-02-01**: first blueprint version :tada:
-- **2021-10-26**: Standardize blueprints structure and inputs naming across the whole collection. Improve blueprint documentation. No functionality change.
+<Changelog category='automation' id='persistent_notification_to_mobile' />

--- a/website/docs/blueprints/automation/simple_safe_scheduler.mdx
+++ b/website/docs/blueprints/automation/simple_safe_scheduler.mdx
@@ -8,6 +8,7 @@ import {
   Inputs,
   Requirement,
   ImportCard,
+  Changelog,
 } from '/src/components/blueprints_docs'
 
 <ImportCard id='simple_safe_scheduler' category='automation' />
@@ -103,4 +104,4 @@ input_datetime:
 
 ## Changelog
 
-- **2021-10-22**: first blueprint version :tada:
+<Changelog category='automation' id='simple_safe_scheduler' />

--- a/website/docs/blueprints/controllers/ikea_e1524_e1810.mdx
+++ b/website/docs/blueprints/controllers/ikea_e1524_e1810.mdx
@@ -12,6 +12,7 @@ import {
   Inputs,
   Requirement,
   ImportCard,
+  Changelog,
 } from '/src/components/blueprints_docs'
 
 <ImportCard id='ikea_e1524_e1810' category='controllers' />
@@ -132,55 +133,4 @@ If you notice your controller is not behaving as expected please remove the batt
 
 ## Changelog
 
-- **2021-02-05**: first blueprint version :tada:
-- **2021-02-07**: fix an issue which prevented to create automations for ZHA or deCONZ.
-- **2021-02-08**: update example, fixed an issue which executed actions twice when the remote was connected via Zigbee2MQTT.
-- **2021-03-18**: added example for fully controlling a RGB light (thanks @kks36!)
-- **2021-02-21**:
-  - add support for virtual double press events
-  - block automation runs for empty and repeated messages
-  - reduce `input_text helper` writes
-- **2021-03-03**: move the blueprint in the Controllers-Hooks Ecosystem. See announcement [here](https://community.home-assistant.io/t/awesome-ha-blueprints-a-curated-list-of-blueprints-easily-create-controller-based-automations-remotes-switches-for-controlling-lights-media-players-and-more/256687/7). :tada:
-- **2021-03-25**: :warning: **Breaking Change**: standardize input names across all the Controller blueprints.
-  If you plan to update this blueprint, please update the inputs in your automations as follows:
-  - `remote` -> `controller_device`
-  - `zigbee2mqtt_remote` -> `controller_entity`
-  - `action_*` inputs -> `action_button_*`
-  - `helper_last_loop_event_input` -> `helper_last_controller_event`
-- **2021-03-26**: add support for the Cover Hook
-- **2021-03-30**: Fix event mappings for ZHA and deCONZ
-- **2021-04-19**: Fix double press events not being detected with deCONZ
-- **2021-04-23**: Fix deCONZ events not being recognized
-- **2021-05-26**:
-
-  :warning: **Breaking Change**:
-
-  `helper_last_controller_event` is now a mandatory input. It also simplifies the blueprint setup (reducing issues due to improper configuration missing the helper, which was required only in certain conditions as was stated in the docs), and provides support for advanced features which might be developed in the future.
-
-  If you plan to update this blueprint, please make sure to provide a valid `input_text` entity for the `helper_last_controller_event` input. You should create a separate `input_text` for each Controller blueprint you're configuring, since using the same for multiple automation could lead to inconsistencies and undefined behaviour.
-
-  **Other changes:**
-
-  - :tada: Add Debouncing support. Debouncing avoids duplicate action runs which might occur with certain controllers and integrations. The feature is disabled by default, check the documentation to find out how to enable it
-  - Prevent undesired endless loops, which might occur in rare cases when the corresponding stop event is not received, by running loop actions a finite number of times, customizable with four new blueprint inputs
-  - Fix inputs wrongly marked as required
-  - Fix for Zigbee2MQTT reporting null state changes
-
-- **2021-07-04**: Fix deCONZ button release events not being properly recognized
-- **2021-08-02**: Improve inputs documentation and organization
-- **2021-10-26**: Standardize blueprints structure and inputs naming across the whole collection. Improve blueprint documentation. No functionality change.
-- **2022-08-08**: Optimize characters usage for the `helper_last_controller_event` text input.
-- **2025-01-03**: Fixed double press events not triggered due to changes in Home Assistant 2023.5.x. ([@ZtormTheCat](https://github.com/ZtormTheCat))
-- **2025-02-13**:
-
-  :warning: **Breaking Change**:
-
-  Migrate to Zigbee2MQTT MQTT Device Triggers. ([@yarafie](https://github.com/yarafie))
-
-  The `controller_entity` input has been deprecated, and `controller_device` is now mandatory.
-  If you are a Zigbee2MQTT user and plan to update this blueprint, please make sure to remove the `controller_entity` input from your automation config and add the device ID of your controller to the `controller_device` input.
-  To obtain the device ID from your controller, configure the automation from the UI and use the device selector dropdown on the `controller_device` input to select your controller.
-
-- **2025-03-20**: Standardized input naming format for controller devices and virtual button actions. No functionality changes.
-- **2025-04-01**: Fix double-click detection logic. ([@danleongjy](https://github.com/danleongjy))
-- **2025-04-19**: Improve Last Controller Event Helper JSON Regex with more lenient matching.
+<Changelog category='controllers' id='ikea_e1524_e1810' />

--- a/website/docs/blueprints/controllers/ikea_e1743.mdx
+++ b/website/docs/blueprints/controllers/ikea_e1743.mdx
@@ -12,6 +12,7 @@ import {
   Inputs,
   Requirement,
   ImportCard,
+  Changelog,
 } from '/src/components/blueprints_docs'
 
 <ImportCard id='ikea_e1743' category='controllers' />
@@ -126,55 +127,4 @@ It's also important to note that the controller doesn't natively support double 
 
 ## Changelog
 
-- **2021-02-07**: first blueprint version :tada:
-- **2021-02-07**: fix an issue on Zigbee2MQTT triggering rules
-- **2021-02-07**: fix an issue which prevented to create automations for ZHA or deCONZ (thanks @kks36! :tada: ).
-- **2021-02-08**: update example, fix an issue which executed actions twice when the remote was connected via Zigbee2MQTT.
-- **2021-02-23**:
-  - add support for virtual double press events
-  - block automation runs for empty and repeated messages
-  - reduce `input_text helper` writes
-- **2021-03-03**: move the blueprint in the Controllers-Hooks Ecosystem. See announcement [here](https://community.home-assistant.io/t/awesome-ha-blueprints-a-curated-list-of-blueprints-easily-create-controller-based-automations-remotes-switches-for-controlling-lights-media-players-and-more/256687/7). :tada:
-- **2021-03-25**: :warning: **Breaking Change**: standardize input names across all the Controller blueprints.
-  If you plan to update this blueprint, please update the inputs in your automations as follows:
-  - `remote` -> `controller_device`
-  - `zigbee2mqtt_remote` -> `controller_entity`
-  - `action_*` inputs -> `action_button_*`
-  - `helper_last_loop_event_input` -> `helper_last_controller_event`
-- **2021-03-26**: add support for the Cover Hook
-- **2021-04-19**: Fix double press events not being detected with deCONZ
-- **2021-04-23**: Fix deCONZ events not being recognized
-- **2021-05-26**:
-
-  :warning: **Breaking Change**:
-
-  `helper_last_controller_event` is now a mandatory input. It also simplifies the blueprint setup (reducing issues due to improper configuration missing the helper, which was required only in certain conditions as was stated in the docs), and provides support for advanced features which might be developed in the future.
-
-  If you plan to update this blueprint, please make sure to provide a valid `input_text` entity for the `helper_last_controller_event` input. You should create a separate `input_text` for each Controller blueprint you're configuring, since using the same for multiple automation could lead to inconsistencies and undefined behaviour.
-
-  **Other changes:**
-
-  - :tada: Add Debouncing support. Debouncing avoids duplicate action runs which might occur with certain controllers and integrations. The feature is disabled by default, check the documentation to find out how to enable it
-  - Prevent undesired endless loops, which might occur in rare cases when the corresponding stop event is not received, by running loop actions a finite number of times, customizable with two new blueprint inputs
-  - Fix inputs wrongly marked as required
-  - Fix for Zigbee2MQTT reporting null state changes
-
-- **2021-07-04**: Fix deCONZ button release events not being properly recognized
-- **2021-08-02**: Improve inputs documentation and organization
-- **2021-10-26**: Standardize blueprints structure and inputs naming across the whole collection. Improve blueprint documentation. No functionality change.
-- **2022-08-08**: Optimize characters usage for the `helper_last_controller_event` text input.
-- **2025-01-02**: Remove spaces to match new helper format in Home Assistant 2023.5.x. ([@LordSushiPhoenix](https://github.com/LordSushiPhoenix))
-- **2025-01-23**:
-
-  :warning: **Breaking Change**:
-
-  Migrate to Zigbee2MQTT MQTT Device Triggers. ([@yarafie](https://github.com/yarafie))
-
-  The `controller_entity` input has been deprecated, and `controller_device` is now mandatory.
-  If you are a Zigbee2MQTT user and plan to update this blueprint, please make sure to remove the `controller_entity` input from your automation config and add the device ID of your controller to the `controller_device` input.
-  To obtain the device ID from your controller, configure the automation from the UI and use the device selector dropdown on the `controller_device` input to select your controller.
-
-- **2025-03-20**: Standardized input naming format for controller devices and virtual button actions. No functionality changes.
-- **2025-04-01**: Fix double-click detection logic. ([@danleongjy](https://github.com/danleongjy))
-- **2025-04-16**: Update ZHA long press and release actions ([@notherealmarco](https://github.com/notherealmarco))
-- **2025-04-19**: Improve Last Controller Event Helper JSON Regex with more lenient matching.
+<Changelog category='controllers' id='ikea_e1743' />

--- a/website/docs/blueprints/controllers/ikea_e1744.mdx
+++ b/website/docs/blueprints/controllers/ikea_e1744.mdx
@@ -12,6 +12,7 @@ import {
   Inputs,
   Requirement,
   ImportCard,
+  Changelog,
 } from '/src/components/blueprints_docs'
 
 <ImportCard id='ikea_e1744' category='controllers' />
@@ -94,50 +95,4 @@ The helper is used to determine stop rotation events when the controller is inte
 
 ## Changelog
 
-- **2021-03-07**: first blueprint version :tada:
-- **2021-03-25**:
-
-  :warning: **Breaking Change**:
-
-  Standardize input names across all the Controller blueprints.
-  If you plan to update this blueprint, please update the inputs in your automations as follows:
-
-  - `remote` -> `controller_device`
-  - `zigbee2mqtt_remote` -> `controller_entity`
-  - `action_click` -> `action_click_short`
-
-- **2021-04-19**: align action mapping format for deCONZ across all the Controller blueprints
-- **2021-04-23**: Fix deCONZ events not being recognized
-- **2021-05-14**:
-
-  :warning: **Breaking Change**:
-
-  `helper_last_controller_event` is now a mandatory input. It also simplifies the blueprint setup (reducing issues due to improper configuration missing the helper, which was required only in certain conditions as was stated in the docs), and provides support for advanced features which might be developed in the future.
-
-  If you plan to update this blueprint, please make sure to provide a valid `input_text` entity for the `helper_last_controller_event` input. You should create a separate `input_text` for each Controller blueprint you're configuring, since using the same for multiple automation could lead to inconsistencies and undefined behaviour.
-
-  **Other changes:**
-
-  - :tada: Add Debouncing support. Debouncing avoids duplicate action runs which might occur with certain controllers and integrations. The feature is disabled by default, check the documentation to find out how to enable it
-  - Prevent undesired endless loops, which might occur in rare cases when the corresponding stop event is not received, by running loop actions a finite number of times, customizable with two new blueprint inputs
-  - Use any RAW stop event (left/right) to identify the stop event corresponding to the current remote rotation
-  - Fix inputs wrongly marked as required
-
-- **2021-05-26**: Fix for Zigbee2MQTT reporting null state changes
-- **2021-07-04**: Fix deCONZ rotation stop events not being properly recognized
-- **2021-08-02**: Improve inputs documentation and organization
-- **2021-10-26**: Standardize blueprints structure and inputs naming across the whole collection. Improve blueprint documentation. No functionality change.
-- **2022-08-08**: Optimize characters usage for the `helper_last_controller_event` text input.
-- **2025-01-05**: Update ZHA event data to what ZHA provides in HA 2024.03.01 ([@ogajduse](https://github.com/ogajduse))
-- **2025-02-13**:
-
-  :warning: **Breaking Change**:
-
-  Migrate to Zigbee2MQTT MQTT Device Triggers. ([@yarafie](https://github.com/yarafie))
-
-  The `controller_entity` input has been deprecated, and `controller_device` is now mandatory.
-  If you are a Zigbee2MQTT user and plan to update this blueprint, please make sure to remove the `controller_entity` input from your automation config and add the device ID of your controller to the `controller_device` input.
-  To obtain the device ID from your controller, configure the automation from the UI and use the device selector dropdown on the `controller_device` input to select your controller.
-
-- **2025-03-20**: Standardized input naming format for controller devices and virtual button actions. No functionality changes.
-- **2025-04-19**: Improve Last Controller Event Helper JSON Regex with more lenient matching.
+<Changelog category='controllers' id='ikea_e1744' />

--- a/website/docs/blueprints/controllers/ikea_e1766.mdx
+++ b/website/docs/blueprints/controllers/ikea_e1766.mdx
@@ -12,6 +12,7 @@ import {
   Inputs,
   Requirement,
   ImportCard,
+  Changelog,
 } from '/src/components/blueprints_docs'
 
 <ImportCard id='ikea_e1766' category='controllers' />
@@ -118,18 +119,4 @@ Due to the controller not exposing long press events but only short and release 
 
 ## Changelog
 
-- **2021-10-29**: first blueprint version :tada:
-- **2022-08-08**: Optimize characters usage for the `helper_last_controller_event` text input.
-- **2025-02-13**:
-
-  :warning: **Breaking Change**:
-
-  Migrate to Zigbee2MQTT MQTT Device Triggers. ([@yarafie](https://github.com/yarafie))
-
-  The `controller_entity` input has been deprecated, and `controller_device` is now mandatory.
-  If you are a Zigbee2MQTT user and plan to update this blueprint, please make sure to remove the `controller_entity` input from your automation config and add the device ID of your controller to the `controller_device` input.
-  To obtain the device ID from your controller, configure the automation from the UI and use the device selector dropdown on the `controller_device` input to select your controller.
-
-- **2025-03-20**: Standardized input naming format for controller devices and virtual button actions. No functionality changes.
-- **2025-04-01**: Fix double-click detection logic. ([@danleongjy](https://github.com/danleongjy))
-- **2025-04-19**: Improve Last Controller Event Helper JSON Regex with more lenient matching.
+<Changelog category='controllers' id='ikea_e1766' />

--- a/website/docs/blueprints/controllers/ikea_e1812.mdx
+++ b/website/docs/blueprints/controllers/ikea_e1812.mdx
@@ -12,6 +12,7 @@ import {
   Inputs,
   Requirement,
   ImportCard,
+  Changelog,
 } from '/src/components/blueprints_docs'
 
 <ImportCard id='ikea_e1812' category='controllers' />
@@ -84,59 +85,4 @@ This Hook blueprint allows to build a controller-based automation to control a c
 
 ## Changelog
 
-- **2021-03-14**: first blueprint version :tada:
-- **2021-03-25**: :warning: **Breaking Change**: standardize input names across all the Controller blueprints.
-  If you plan to update this blueprint, please update the inputs in your automations as follows:
-  - `remote` -> `controller_device`
-  - `zigbee2mqtt_remote` -> `controller_entity`
-  - `helper_last_loop_event_input` -> `helper_last_controller_event`
-- **2021-03-26**: add support for the Cover Hook
-- **2021-04-19**: Fix double press events not being detected with deCONZ
-- **2021-04-23**: Fix deCONZ events not being recognized
-- **2021-05-15**:
-
-  :warning: **Breaking Change**:
-
-  `helper_last_controller_event` is now a mandatory input. It also simplifies the blueprint setup (reducing issues due to improper configuration missing the helper, which was required only in certain conditions as was stated in the docs), and provides support for advanced features which might be developed in the future.
-
-  If you plan to update this blueprint, please make sure to provide a valid `input_text` entity for the `helper_last_controller_event` input. You should create a separate `input_text` for each Controller blueprint you're configuring, since using the same for multiple automation could lead to inconsistencies and undefined behaviour.
-
-  **Other changes:**
-
-  - :tada: Add Debouncing support. Debouncing avoids duplicate action runs which might occur with certain controllers and integrations. The feature is disabled by default, check the documentation to find out how to enable it
-  - Prevent undesired endless loops, which might occur in rare cases when the corresponding stop event is not received, by running loop actions a finite number of times, customizable with a new blueprint input
-  - Fix inputs wrongly marked as required
-
-- **2021-05-26**: Fix for Zigbee2MQTT reporting null state changes
-- **2021-08-02**: Improve inputs documentation and organization
-- **2021-10-26**: Standardize blueprints structure and inputs naming across the whole collection. Improve blueprint documentation. No functionality change.
-- **2022-08-08**: Optimize characters usage for the `helper_last_controller_event` text input.
-- **2025-01-03**: Fixed double press events not triggered due to changes in Home Assistant 2023.5.x.
-- **2025-02-13**:
-
-  :warning: **Breaking Change**:
-
-  Migrate to Zigbee2MQTT MQTT Device Triggers. ([@yarafie](https://github.com/yarafie))
-
-  The `controller_entity` input has been deprecated, and `controller_device` is now mandatory.
-  If you are a Zigbee2MQTT user and plan to update this blueprint, please make sure to remove the `controller_entity` input from your automation config and add the device ID of your controller to the `controller_device` input.
-  To obtain the device ID from your controller, configure the automation from the UI and use the device selector dropdown on the `controller_device` input to select your controller.
-
-- **2025-03-20**: Standardized input naming format for controller devices and virtual button actions. No functionality changes.
-- **2025-04-06**: Fix double-click detection logic. ([@danleongjy](https://github.com/danleongjy))
-- **2025-04-12**:
-
-  :warning: **Breaking Change**:
-
-  Updated to add new double press to triggers and refactored blueprint to use triggers and trigger-id. ([@yarafie](https://github.com/yarafie))
-
-  The blueprint needs to be re-downloaded and automations using the blueprint needs to be set-up again.
-
-  This is due to the changes below:
-
-  - The need for selection of `integration` type has been removed from the inputs, the blueprint/automation will detect it automatically.
-  - The `helper_last_controller_event` text input is no longer needed and has been removed from the inputs.
-
-  **Other changes:**
-
-  Double press events are now natively supported.
+<Changelog category='controllers' id='ikea_e1812' />

--- a/website/docs/blueprints/controllers/ikea_e2001_e2002.mdx
+++ b/website/docs/blueprints/controllers/ikea_e2001_e2002.mdx
@@ -12,6 +12,7 @@ import {
   Inputs,
   Requirement,
   ImportCard,
+  Changelog,
 } from '/src/components/blueprints_docs'
 
 <ImportCard id='ikea_e2001_e2002' category='controllers' />
@@ -124,23 +125,4 @@ If you notice your controller is not behaving as expected please reset the devic
 
 ## Changelog
 
-- **2021-11-07**: first blueprint version :tada:
-- **2022-08-08**: Optimize characters usage for the `helper_last_controller_event` text input.
-- **2025-01-02**:
-  - (ZHA) Fixed a bug preventing long pressing actions to be triggered. ([@Ivarvdb](https://github.com/Ivarvdb))
-  - (Zigbee2MQTT) handle "unknown" state. ([@beardhatcode](https://github.com/beardhatcode))
-- **2025-01-03**: Remove spaces to match new helper format in Home Assistant 2023.5.x. ([@LordSushiPhoenix](https://github.com/LordSushiPhoenix))
-- **2025-02-13**:
-
-  :warning: **Breaking Change**:
-
-  Migrate to Zigbee2MQTT MQTT Device Triggers. ([@yarafie](https://github.com/yarafie))
-
-  The `controller_entity` input has been deprecated, and `controller_device` is now mandatory.
-  If you are a Zigbee2MQTT user and plan to update this blueprint, please make sure to remove the `controller_entity` input from your automation config and add the device ID of your controller to the `controller_device` input.
-  To obtain the device ID from your controller, configure the automation from the UI and use the device selector dropdown on the `controller_device` input to select your controller.
-
-- **2025-03-20**: Standardized input naming format for controller devices and virtual button actions. No functionality changes.
-- **2025-04-01**: Fix double-click detection logic. ([@danleongjy](https://github.com/danleongjy))
-- **2025-04-16**: Fix Long Press Down not releasing ([@kkthxbye-code](https://github.com/kkthxbye-code))
-- **2025-04-19**: Improve Last Controller Event Helper JSON Regex with more lenient matching.
+<Changelog category='controllers' id='ikea_e2001_e2002' />

--- a/website/docs/blueprints/controllers/ikea_e2123.mdx
+++ b/website/docs/blueprints/controllers/ikea_e2123.mdx
@@ -12,6 +12,7 @@ import {
   Inputs,
   Requirement,
   ImportCard,
+  Changelog,
 } from '/src/components/blueprints_docs'
 
 <ImportCard id='ikea_e2123' category='controllers' />
@@ -111,4 +112,4 @@ This blueprint is only compatible with firmwares 1.0.32 (20221219) and 1.0.35 (2
 
 ## Changelog
 
-- **2025-03-28**: Initial release. [Initial Release] ([@yarafie](https://github.com/yarafie)) :tada:
+<Changelog category='controllers' id='ikea_e2123' />

--- a/website/docs/blueprints/controllers/ikea_e2201.mdx
+++ b/website/docs/blueprints/controllers/ikea_e2201.mdx
@@ -12,6 +12,7 @@ import {
   Inputs,
   Requirement,
   ImportCard,
+  Changelog,
 } from '/src/components/blueprints_docs'
 
 <ImportCard id='ikea_e2201' category='controllers' />
@@ -112,6 +113,4 @@ It's important to note that the controller doesn't natively support double press
 
 ## Changelog
 
-- **2025-03-20**: Initial release. ([@yarafie](https://github.com/yarafie)) :tada:
-- **2025-03-20b**: Fix automation triggers. ([@yarafie](https://github.com/yarafie))
-- **2025-03-20c**: Standardized input naming format for controller devices and virtual button actions. No functionality changes.
+<Changelog category='controllers' id='ikea_e2201' />

--- a/website/docs/blueprints/controllers/ikea_e2213.mdx
+++ b/website/docs/blueprints/controllers/ikea_e2213.mdx
@@ -12,6 +12,7 @@ import {
   Inputs,
   Requirement,
   ImportCard,
+  Changelog,
 } from '/src/components/blueprints_docs'
 
 <ImportCard id='ikea_e2213' category='controllers' />
@@ -102,4 +103,4 @@ This Hook blueprint allows to build a controller-based automation to control a c
 
 ## Changelog
 
-- **2025-03-26**: Initial release. ([@yarafie](https://github.com/yarafie)) :tada:
+<Changelog category='controllers' id='ikea_e2213' />

--- a/website/docs/blueprints/controllers/ikea_ictc_g_1.mdx
+++ b/website/docs/blueprints/controllers/ikea_ictc_g_1.mdx
@@ -12,6 +12,7 @@ import {
   Inputs,
   Requirement,
   ImportCard,
+  Changelog,
 } from '/src/components/blueprints_docs'
 
 <ImportCard id='ikea_ictc_g_1' category='controllers' />
@@ -90,38 +91,4 @@ This blueprint provides beta support for controllers integrated with deCONZ, sin
 
 ## Changelog
 
-- **2021-03-26**: first blueprint version :tada:
-- **2021-04-19**: Fix stop rotation events not being detected with deCONZ
-- **2021-04-23**: Fix deCONZ events not being recognized
-- **2021-05-26**:
-
-  :warning: **Breaking Change**:
-
-  `helper_last_controller_event` is now a mandatory input. It also simplifies the blueprint setup (reducing issues due to improper configuration missing the helper, which was required only in certain conditions as was stated in the docs), and provides support for advanced features which might be developed in the future.
-
-  If you plan to update this blueprint, please make sure to provide a valid `input_text` entity for the `helper_last_controller_event` input. You should create a separate `input_text` for each Controller blueprint you're configuring, since using the same for multiple automation could lead to inconsistencies and undefined behaviour.
-
-  **Other changes:**
-
-  - :tada: Add Debouncing support. Debouncing avoids duplicate action runs which might occur with certain controllers and integrations. The feature is disabled by default, check the documentation to find out how to enable it
-  - Prevent undesired endless loops, which might occur in rare cases when the corresponding stop event is not received, by running loop actions a finite number of times, customizable with two new blueprint inputs
-  - Use any RAW stop event (left/right) to identify the stop event corresponding to the current remote rotation
-  - Fix inputs wrongly marked as required
-  - Fix for Zigbee2MQTT reporting null state changes
-
-- **2021-07-04**: Fix deCONZ rotation stop events not being properly recognized
-- **2021-08-02**: Improve inputs documentation and organization
-- **2021-10-26**: Standardize blueprints structure and inputs naming across the whole collection. Improve blueprint documentation. No functionality change.
-- **2022-08-08**: Optimize characters usage for the `helper_last_controller_event` text input.
-- **2025-02-13**:
-
-  :warning: **Breaking Change**:
-
-  Migrate to Zigbee2MQTT MQTT Device Triggers. ([@yarafie](https://github.com/yarafie))
-
-  The `controller_entity` input has been deprecated, and `controller_device` is now mandatory.
-  If you are a Zigbee2MQTT user and plan to update this blueprint, please make sure to remove the `controller_entity` input from your automation config and add the device ID of your controller to the `controller_device` input.
-  To obtain the device ID from your controller, configure the automation from the UI and use the device selector dropdown on the `controller_device` input to select your controller.
-
-- **2025-03-20**: Standardized input naming format for controller devices and virtual button actions. No functionality changes.
-- **2025-04-19**: Improve Last Controller Event Helper JSON Regex with more lenient matching.
+<Changelog category='controllers' id='ikea_ictc_g_1' />

--- a/website/docs/blueprints/controllers/osram_ac025xx00nj.mdx
+++ b/website/docs/blueprints/controllers/osram_ac025xx00nj.mdx
@@ -12,6 +12,7 @@ import {
   Inputs,
   Requirement,
   ImportCard,
+  Changelog,
 } from '/src/components/blueprints_docs'
 
 <ImportCard id='osram_ac025xx00nj' category='controllers' />
@@ -106,24 +107,4 @@ This blueprint supports any variant of the Osram SMART+ Switch Mini controller (
 
 ## Changelog
 
-- **2021-05-18**: first blueprint version :tada:
-- **2021-05-26**: Fix for Zigbee2MQTT reporting null state changes
-- **2021-08-02**: Improve inputs documentation and organization
-- **2021-10-26**: Standardize blueprints structure and inputs naming across the whole collection. Improve blueprint documentation. No functionality change.
-- **2022-08-08**: Optimize characters usage for the `helper_last_controller_event` text input.
-- **2025-01-05**:
-  - Updated Actions Mapping as per Z2M [docs](https://www.zigbee2mqtt.io/devices/AC0251100NJ_AC0251600NJ_AC0251700NJ.html#actions) for the device. ([@alexdelprete](https://github.com/alexdelprete))
-  - Fix regex for updated helper JSON serialization starting from Home Assistant 2023.5.0.
-- **2025-02-13**:
-
-  :warning: **Breaking Change**:
-
-  Migrate to Zigbee2MQTT MQTT Device Triggers. ([@yarafie](https://github.com/yarafie))
-
-  The `controller_entity` input has been deprecated, and `controller_device` is now mandatory.
-  If you are a Zigbee2MQTT user and plan to update this blueprint, please make sure to remove the `controller_entity` input from your automation config and add the device ID of your controller to the `controller_device` input.
-  To obtain the device ID from your controller, configure the automation from the UI and use the device selector dropdown on the `controller_device` input to select your controller.
-
-- **2025-03-20**: Standardized input naming format for controller devices and virtual button actions. No functionality changes.
-- **2025-04-06**: Fix double-click detection logic. ([@danleongjy](https://github.com/danleongjy))
-- **2025-04-19**: Improve Last Controller Event Helper JSON Regex with more lenient matching.
+<Changelog category='controllers' id='osram_ac025xx00nj' />

--- a/website/docs/blueprints/controllers/philips_324131092621.mdx
+++ b/website/docs/blueprints/controllers/philips_324131092621.mdx
@@ -12,6 +12,7 @@ import {
   Inputs,
   Requirement,
   ImportCard,
+  Changelog,
 } from '/src/components/blueprints_docs'
 
 <ImportCard id='philips_324131092621' category='controllers' />
@@ -105,38 +106,4 @@ It's also important to note that the controller doesn't natively support double 
 
 ## Changelog
 
-- **2021-03-27**: first blueprint version :tada:
-- **2021-04-19**: Fix double press events not being detected with deCONZ
-- **2021-04-23**: Fix deCONZ events not being recognized
-- **2021-05-26**:
-
-  :warning: **Breaking Change**:
-
-  `helper_last_controller_event` is now a mandatory input. It also simplifies the blueprint setup (reducing issues due to improper configuration missing the helper, which was required only in certain conditions as was stated in the docs), and provides support for advanced features which might be developed in the future.
-
-  If you plan to update this blueprint, please make sure to provide a valid `input_text` entity for the `helper_last_controller_event` input. You should create a separate `input_text` for each Controller blueprint you're configuring, since using the same for multiple automation could lead to inconsistencies and undefined behaviour.
-
-  **Other changes:**
-
-  - :tada: Add Debouncing support. Debouncing avoids duplicate action runs which might occur with certain controllers and integrations. The feature is disabled by default, check the documentation to find out how to enable it
-  - Prevent undesired endless loops, which might occur in rare cases when the corresponding stop event is not received, by running loop actions a finite number of times, customizable with four new blueprint inputs
-  - Fix inputs wrongly marked as required
-  - Fix for Zigbee2MQTT reporting null state changes
-
-- **2021-08-02**: Improve inputs documentation and organization
-- **2021-10-26**: Standardize blueprints structure and inputs naming across the whole collection. Improve blueprint documentation. No functionality change.
-- **2021-11-19**: Fix controller events not being recognized when using ZHA.
-- **2022-08-08**: Optimize characters usage for the `helper_last_controller_event` text input.
-- **2025-02-13**:
-
-  :warning: **Breaking Change**:
-
-  Migrate to Zigbee2MQTT MQTT Device Triggers. ([@yarafie](https://github.com/yarafie))
-
-  The `controller_entity` input has been deprecated, and `controller_device` is now mandatory.
-  If you are a Zigbee2MQTT user and plan to update this blueprint, please make sure to remove the `controller_entity` input from your automation config and add the device ID of your controller to the `controller_device` input.
-  To obtain the device ID from your controller, configure the automation from the UI and use the device selector dropdown on the `controller_device` input to select your controller.
-
-- **2025-03-20**: Standardized input naming format for controller devices and virtual button actions. No functionality changes.
-- **2025-04-06**: Fix double-click detection logic. ([@danleongjy](https://github.com/danleongjy))
-- **2025-04-19**: Improve Last Controller Event Helper JSON Regex with more lenient matching.
+<Changelog category='controllers' id='philips_324131092621' />

--- a/website/docs/blueprints/controllers/philips_8718699693985.mdx
+++ b/website/docs/blueprints/controllers/philips_8718699693985.mdx
@@ -12,6 +12,7 @@ import {
   Inputs,
   Requirement,
   ImportCard,
+  Changelog,
 } from '/src/components/blueprints_docs'
 
 <ImportCard id='philips_8718699693985' category='controllers' />
@@ -92,23 +93,4 @@ It's also important to note that the controller doesn't natively support double 
 
 ## Changelog
 
-- **2021-07-14**: first blueprint version :tada:
-- **2021-08-02**: Improve inputs documentation and organization
-- **2021-10-26**: Standardize blueprints structure and inputs naming across the whole collection. Improve blueprint documentation. No functionality change.
-- **2022-08-08**: Optimize characters usage for the `helper_last_controller_event` text input.
-- **2025-01-05**:
-  - Added support for Zigbee2MQTT. ([@alexdelprete](https://github.com/alexdelprete))
-  - Fix regex for updated helper JSON serialization starting from Home Assistant 2023.5.0.
-- **2025-02-13**:
-
-  :warning: **Breaking Change**:
-
-  Migrate to Zigbee2MQTT MQTT Device Triggers. ([@yarafie](https://github.com/yarafie))
-
-  The `controller_entity` input has been deprecated, and `controller_device` is now mandatory.
-  If you are a Zigbee2MQTT user and plan to update this blueprint, please make sure to remove the `controller_entity` input from your automation config and add the device ID of your controller to the `controller_device` input.
-  To obtain the device ID from your controller, configure the automation from the UI and use the device selector dropdown on the `controller_device` input to select your controller.
-
-- **2025-03-20**: Standardized input naming format for controller devices and virtual button actions. No functionality changes.
-- **2025-04-06**: Fix double-click detection logic. ([@danleongjy](https://github.com/danleongjy))
-- **2025-04-19**: Improve Last Controller Event Helper JSON Regex with more lenient matching.
+<Changelog category='controllers' id='philips_8718699693985' />

--- a/website/docs/blueprints/controllers/philips_929002398602.mdx
+++ b/website/docs/blueprints/controllers/philips_929002398602.mdx
@@ -12,6 +12,7 @@ import {
   Inputs,
   Requirement,
   ImportCard,
+  Changelog,
 } from '/src/components/blueprints_docs'
 
 <ImportCard id='philips_929002398602' category='controllers' />
@@ -104,20 +105,4 @@ It's also important to note that the controller doesn't natively support double 
 
 ## Changelog
 
-- **2021-11-21**: first blueprint version :tada:
-- **2022-07-22**: Fix short press actions not being triggered by quick button clicks.
-- **2022-08-08**: Optimize characters usage for the `helper_last_controller_event` text input.
-- **2025-02-13**:
-
-  :warning: **Breaking Change**:
-
-  Migrate to Zigbee2MQTT MQTT Device Triggers. ([@yarafie](https://github.com/yarafie))
-
-  The `controller_entity` input has been deprecated, and `controller_device` is now mandatory.
-  If you are a Zigbee2MQTT user and plan to update this blueprint, please make sure to remove the `controller_entity` input from your automation config and add the device ID of your controller to the `controller_device` input.
-  To obtain the device ID from your controller, configure the automation from the UI and use the device selector dropdown on the `controller_device` input to select your controller.
-
-- **2025-03-20**: Standardized input naming format for controller devices and virtual button actions. No functionality changes.
-- **2025-04-02**: Fix trigger_delta regex, with optional whitespacing. ([@TTvanWillegen](https://github.com/TTvanWillegen))
-- **2025-04-06**: Fix double-click detection logic. ([@danleongjy](https://github.com/danleongjy))
-- **2025-04-19**: Improve Last Controller Event Helper JSON Regex with more lenient matching.
+<Changelog category='controllers' id='philips_929002398602' />

--- a/website/docs/blueprints/controllers/sonoff_snzb01.mdx
+++ b/website/docs/blueprints/controllers/sonoff_snzb01.mdx
@@ -12,6 +12,7 @@ import {
   Inputs,
   Requirement,
   ImportCard,
+  Changelog,
 } from '/src/components/blueprints_docs'
 
 <ImportCard id='sonoff_snzb01' category='controllers' />
@@ -97,15 +98,4 @@ Please note that the long press action for this controller is triggered after th
 
 ## Changelog
 
-- **2022-07-30**: first blueprint version :tada:
-- **2022-08-08**: Optimize characters usage for the `helper_last_controller_event` text input.
-- **2025-02-13**:
-
-  :warning: **Breaking Change**:
-
-  Migrate to Zigbee2MQTT MQTT Device Triggers. ([@yarafie](https://github.com/yarafie))
-
-  The `controller_entity` input has been deprecated, and `controller_device` is now mandatory.
-  If you are a Zigbee2MQTT user and plan to update this blueprint, please make sure to remove the `controller_entity`
-
-- **2025-04-19**: Improve Last Controller Event Helper JSON Regex with more lenient matching.
+<Changelog category='controllers' id='sonoff_snzb01' />

--- a/website/docs/blueprints/controllers/tuya_ERS-10TZBVK-AA.mdx
+++ b/website/docs/blueprints/controllers/tuya_ERS-10TZBVK-AA.mdx
@@ -12,6 +12,7 @@ import {
   Inputs,
   Requirement,
   ImportCard,
+  Changelog,
 } from '/src/components/blueprints_docs'
 
 <ImportCard id='tuya_ERS-10TZBVK-AA' category='controllers' />
@@ -98,4 +99,4 @@ When in event mode, double presses are native.
 
 ## Changelog
 
-- **2025-03-29**: Initial release. ([@yarafie](https://github.com/yarafie)) :tada:
+<Changelog category='controllers' id='tuya_ERS-10TZBVK-AA' />

--- a/website/docs/blueprints/controllers/xiaomi_wxcjkg11lm.mdx
+++ b/website/docs/blueprints/controllers/xiaomi_wxcjkg11lm.mdx
@@ -12,6 +12,7 @@ import {
   Inputs,
   Requirement,
   ImportCard,
+  Changelog,
 } from '/src/components/blueprints_docs'
 
 <ImportCard id='xiaomi_wxcjkg11lm' category='controllers' />
@@ -104,17 +105,4 @@ The `helper_last_controller_event` (Helper - Last Controller Event) input serves
 
 ## Changelog
 
-- **2021-12-03**: first blueprint version :tada:
-- **2022-08-08**: Optimize characters usage for the `helper_last_controller_event` text input.
-- **2025-02-13**:
-
-  :warning: **Breaking Change**:
-
-  Migrate to Zigbee2MQTT MQTT Device Triggers. ([@yarafie](https://github.com/yarafie))
-
-  The `controller_entity` input has been deprecated, and `controller_device` is now mandatory.
-  If you are a Zigbee2MQTT user and plan to update this blueprint, please make sure to remove the `controller_entity` input from your automation config and add the device ID of your controller to the `controller_device` input.
-  To obtain the device ID from your controller, configure the automation from the UI and use the device selector dropdown on the `controller_device` input to select your controller.
-
-- **2025-03-20**: Standardized input naming format for controller devices and virtual button actions. No functionality changes.
-- **2025-04-19**: Improve Last Controller Event Helper JSON Regex with more lenient matching.
+<Changelog category='controllers' id='xiaomi_wxcjkg11lm' />

--- a/website/docs/blueprints/controllers/xiaomi_wxcjkg12lm.mdx
+++ b/website/docs/blueprints/controllers/xiaomi_wxcjkg12lm.mdx
@@ -12,6 +12,7 @@ import {
   Inputs,
   Requirement,
   ImportCard,
+  Changelog,
 } from '/src/components/blueprints_docs'
 
 <ImportCard id='xiaomi_wxcjkg12lm' category='controllers' />
@@ -130,17 +131,4 @@ The `helper_last_controller_event` (Helper - Last Controller Event) input serves
 
 ## Changelog
 
-- **2021-12-03**: first blueprint version :tada:
-- **2022-08-08**: Optimize characters usage for the `helper_last_controller_event` text input.
-- **2025-02-13**:
-
-  :warning: **Breaking Change**:
-
-  Migrate to Zigbee2MQTT MQTT Device Triggers. ([@yarafie](https://github.com/yarafie))
-
-  The `controller_entity` input has been deprecated, and `controller_device` is now mandatory.
-  If you are a Zigbee2MQTT user and plan to update this blueprint, please make sure to remove the `controller_entity` input from your automation config and add the device ID of your controller to the `controller_device` input.
-  To obtain the device ID from your controller, configure the automation from the UI and use the device selector dropdown on the `controller_device` input to select your controller.
-
-- **2025-03-20**: Standardized input naming format for controller devices and virtual button actions. No functionality changes.
-- **2025-04-19**: Improve Last Controller Event Helper JSON Regex with more lenient matching.
+<Changelog category='controllers' id='xiaomi_wxcjkg12lm' />

--- a/website/docs/blueprints/controllers/xiaomi_wxcjkg13lm.mdx
+++ b/website/docs/blueprints/controllers/xiaomi_wxcjkg13lm.mdx
@@ -12,6 +12,7 @@ import {
   Inputs,
   Requirement,
   ImportCard,
+  Changelog,
 } from '/src/components/blueprints_docs'
 
 <ImportCard id='xiaomi_wxcjkg13lm' category='controllers' />
@@ -156,17 +157,4 @@ The `helper_last_controller_event` (Helper - Last Controller Event) input serves
 
 ## Changelog
 
-- **2021-12-03**: first blueprint version :tada:
-- **2022-08-08**: Optimize characters usage for the `helper_last_controller_event` text input.
-- **2025-02-13**:
-
-  :warning: **Breaking Change**:
-
-  Migrate to Zigbee2MQTT MQTT Device Triggers. ([@yarafie](https://github.com/yarafie))
-
-  The `controller_entity` input has been deprecated, and `controller_device` is now mandatory.
-  If you are a Zigbee2MQTT user and plan to update this blueprint, please make sure to remove the `controller_entity` input from your automation config and add the device ID of your controller to the `controller_device` input.
-  To obtain the device ID from your controller, configure the automation from the UI and use the device selector dropdown on the `controller_device` input to select your controller.
-
-- **2025-03-20**: Standardized input naming format for controller devices and virtual button actions. No functionality changes.
-- **2025-04-19**: Improve Last Controller Event Helper JSON Regex with more lenient matching.
+<Changelog category='controllers' id='xiaomi_wxcjkg13lm' />

--- a/website/docs/blueprints/controllers/xiaomi_wxkg11lm.mdx
+++ b/website/docs/blueprints/controllers/xiaomi_wxkg11lm.mdx
@@ -13,6 +13,7 @@ import {
   Inputs,
   Requirement,
   ImportCard,
+  Changelog,
 } from '/src/components/blueprints_docs'
 
 <ImportCard id='xiaomi_wxkg11lm' category='controllers' />
@@ -100,18 +101,4 @@ Please note that this blueprint provides deCONZ support for the 2018 version of 
 
 ## Changelog
 
-- **2022-07-22**: first blueprint version :tada:
-- **2022-08-08**: Optimize characters usage for the `helper_last_controller_event` text input.
-- **2025-02-13**:
-
-  :warning: **Breaking Change**:
-
-  Migrate to Zigbee2MQTT MQTT Device Triggers. ([@yarafie](https://github.com/yarafie))
-
-  The `controller_entity` input has been deprecated, and `controller_device` is now mandatory.
-  If you are a Zigbee2MQTT user and plan to update this blueprint, please make sure to remove the `controller_entity` input from your automation config and add the device ID of your controller to the `controller_device` input.
-  To obtain the device ID from your controller, configure the automation from the UI and use the device selector dropdown on the `controller_device` input to select your controller.
-
-- **2025-02-16**: Add support for Xiaomi WXKG01LM Mi Wireless Switch, rename Xiaomi WXKG11LM Aqara Wireless Switch Mini to Aqara WXKG11LM Wireless Mini Switch. ([@yarafie](https://github.com/yarafie))
-- **2025-03-20**: Standardized input naming format for controller devices and virtual button actions. No functionality changes.
-- **2025-04-19**: Improve Last Controller Event Helper JSON Regex with more lenient matching.
+<Changelog category='controllers' id='xiaomi_wxkg11lm' />

--- a/website/docs/blueprints/hooks/cover.mdx
+++ b/website/docs/blueprints/hooks/cover.mdx
@@ -8,6 +8,7 @@ import {
   Inputs,
   Requirement,
   ImportCard,
+  Changelog,
 } from '/src/components/blueprints_docs'
 
 <ImportCard id='cover' category='hooks' />
@@ -64,37 +65,4 @@ If you want to link multiple covers to the same controller you can either use [C
 
 ## Changelog
 
-- **2021-03-26**: first blueprint version :tada:
-- **2021-04-19**: remove unused variable, fix warnings for undefined variables in Home Assistant Core >=2021.4.0
-- **2021-08-02**: Improve inputs documentation and organization
-- **2021-10-26**:
-  - Standardize blueprints structure and inputs naming across the whole collection.
-  - Improve blueprint documentation.
-  - :tada: Add support for alternate mappings. Additional mappings for currently supported controllers will be added from now on. Refer to the documentation of your controller for more details.
-  - :warning: **Breaking Change**: update controller names in the `Controller Model` input, to match the full name of controllers, prevent ambiguities and enable support for alternate mappings. After updating this blueprint, please reconfigure your automations by selecting again the value for the `Controller Model` input, matching the full name of the controller you're using with this hook.
-- **2021-10-29**: Add support for IKEA E1766 TRÅDFRI Open/Close Remote.
-- **2021-12-03**: Add support for Xiaomi WXCJKG11LM, WXCJKG12LM, WXCJKG13LM.
-- **2022-07-22**: Add support for Xiaomi WXKG11LM.
-- **2022-07-30**: Add support for SONOFF SNZB-01.
-- **2025-02-13**:
-
-  :warning: **Breaking Change**:
-
-  Migrate to Zigbee2MQTT MQTT Device Triggers. ([@yarafie](https://github.com/yarafie))
-
-  The `controller_entity` input has been deprecated, and `controller_device` is now mandatory.
-  If you are a Zigbee2MQTT user and plan to update this blueprint, please make sure to remove the `controller_entity` input from your automation config and add the device ID of your controller to the `controller_device` input.
-  To obtain the device ID from your controller, configure the automation from the UI and use the device selector dropdown on the `controller_device` input to select your controller.
-
-- **2025-02-16**:
-
-  :warning: **Breaking Change**:
-
-  Add support for Xiaomi WXKG01LM Mi Wireless Switch, rename Xiaomi WXKG11LM Aqara Wireless Switch Mini to Aqara WXKG11LM Wireless Mini Switch
-
-  If you had configured the `controller_model` input to `Xiaomi WXKG11LM Aqara Wireless Switch Mini`, please change it to `Aqara WXKG11LM Wireless Mini Switch`.
-  The change has been implemented to match the controller with the correct manufacturer name (Aqara).
-
-- **2025-03-20**: Added support for IKEA E2201 RODRET Dimmer. ([@yarafie](https://github.com/yarafie))
-- **2025-03-26**: Added support for IKEA E2213 SOMRIG shortcut button. ([@yarafie](https://github.com/yarafie))
-- **2025-03-28**: Added support for IKEA E2123 SYMFONISK sound remote, gen 2. ([@yarafie](https://github.com/yarafie))
+<Changelog category='hooks' id='cover' />

--- a/website/docs/blueprints/hooks/light.mdx
+++ b/website/docs/blueprints/hooks/light.mdx
@@ -8,6 +8,7 @@ import {
   Inputs,
   Requirement,
   ImportCard,
+  Changelog,
 } from '/src/components/blueprints_docs'
 
 <ImportCard id='light' category='hooks' />
@@ -72,62 +73,4 @@ If you want to link multiple lights to the same controller you can either use [L
 
 ## Changelog
 
-- **2021-03-04**: first blueprint version :tada:
-- **2021-03-07**: add support for IKEA E1744 SYMFONISK rotary remote
-- **2021-03-14**: add support for IKEA E1812 Shortcut button, fix E1743 naming
-- **2021-03-25**: update action mapping for IKEA E1744. If you're using this Hook with an IKEA E1744, please update also the corresponding Controller blueprint
-- **2021-03-26**:
-  - set minimum and maximum light brightness
-  - specify number of steps from min to max brightness, both for short and long actions, when controlling the light
-  - allow to force brightness to a specific value when turning on the light
-- **2021-03-27**: add support for Philips Hue dimmer switch
-- **2021-04-06**: fix light color modes not allowing to configure an automation with color temperature control.
-- **2021-04-15**:
-  - add smooth power on/off features
-  - **breaking change**: by default the light now turns off when a brightness down command is received and light is at minimum brightness. To disable this behaviour, turn off the smooth power off feature.
-  - fix some optional fields name.
-- **2021-04-19**: remove unused variable, fix warnings for undefined variables in Home Assistant Core >=2021.4.0
-- **2021-05-16**: Add support for Osram SMART+ Switch Mini
-- **2021-07-03**: Add support for Philips Hue Smart Button
-- **2021-08-02**: Improve inputs documentation and organization
-- **2021-10-26**:
-  - Standardize blueprints structure and inputs naming across the whole collection.
-  - Improve blueprint documentation.
-  - :tada: Add support for alternate mappings. Additional mappings for currently supported controllers will be added from now on. Refer to the documentation of your controller for more details.
-  - :warning: **Breaking Change**: update controller names in the `Controller Model` input, to match the full name of controllers, prevent ambiguities and enable support for alternate mappings. After updating this blueprint, please reconfigure your automations by selecting again the value for the `Controller Model` input, matching the full name of the controller you're using with this hook.
-  - Fix for remembering brightness level when turning on, where brightness level unavailable when light off.
-  - Added secondary mapping for IKEA E1743 TRÅDFRI On/Off Switch & Dimmer
-- **2021-10-29**: Add support for IKEA E1766 TRÅDFRI Open/Close Remote.
-- **2021-11-07**:
-  - Add support for IKEA E2001/E2002 STYRBAR Remote control.
-  - Fix color mode automatic detection not working properly with color temperature lights.
-  - Add "None" color mode to completely disable color control features.
-- **2021-11-21**: Add support for Philips 929002398602 Hue Dimmer switch v2.
-- **2021-12-03**: Add support for Xiaomi WXCJKG11LM, WXCJKG12LM, WXCJKG13LM.
-- **2021-12-05**: Added secondary mapping for IKEA E2001/E2002
-- **2022-07-22**: Add support for Xiaomi WXKG11LM.
-- **2022-07-30**: Add support for SONOFF SNZB-01.
-- **2025-02-13**:
-
-  :warning: **Breaking Change**:
-
-  Migrate to Zigbee2MQTT MQTT Device Triggers. ([@yarafie](https://github.com/yarafie))
-
-  The `controller_entity` input has been deprecated, and `controller_device` is now mandatory.
-  If you are a Zigbee2MQTT user and plan to update this blueprint, please make sure to remove the `controller_entity` input from your automation config and add the device ID of your controller to the `controller_device` input.
-  To obtain the device ID from your controller, configure the automation from the UI and use the device selector dropdown on the `controller_device` input to select your controller.
-
-- **2025-02-16**:
-
-  :warning: **Breaking Change**:
-
-  Add support for Xiaomi WXKG01LM Mi Wireless Switch, rename Xiaomi WXKG11LM Aqara Wireless Switch Mini to Aqara WXKG11LM Wireless Mini Switch
-
-  If you had configured the `controller_model` input to `Xiaomi WXKG11LM Aqara Wireless Switch Mini`, please change it to `Aqara WXKG11LM Wireless Mini Switch`.
-  The change has been implemented to match the controller with the correct manufacturer name (Aqara).
-
-- **2025-03-18**: use min_brightness and max_brightness as conditions instead of "while true" loops [@Nicolai-](https://github.com/Nicolai-).
-- **2025-03-20**: Added support for IKEA E2201 RODRET Dimmer. ([@yarafie](https://github.com/yarafie))
-- **2025-03-26**: Added support for IKEA E2213 SOMRIG shortcut button. ([@yarafie](https://github.com/yarafie))
-- **2025-03-28**: Added support for IKEA E2123 SYMFONISK sound remote, gen 2. ([@yarafie](https://github.com/yarafie))
-- **2025-03-29**: Added support for Tuya ERS-10TZBVK-AA Smart knob. ([@yarafie](https://github.com/yarafie))
+<Changelog category='hooks' id='light' />

--- a/website/docs/blueprints/hooks/media_player.mdx
+++ b/website/docs/blueprints/hooks/media_player.mdx
@@ -8,6 +8,7 @@ import {
   Inputs,
   Requirement,
   ImportCard,
+  Changelog,
 } from '/src/components/blueprints_docs'
 
 <ImportCard id='media_player' category='hooks' />
@@ -72,48 +73,4 @@ Not all media players support the customization of the number of steps for volum
 
 ## Changelog
 
-- **2021-03-04**: first blueprint version :tada:
-- **2021-03-07**: add support for IKEA E1744 SYMFONISK rotary remote
-- **2021-03-14**: add support for IKEA E1812 Shortcut button, fix E1743 naming
-- **2021-03-25**: update action mapping for IKEA E1744. If you're using this Hook with an IKEA E1744, please update also the corresponding Controller blueprint
-- **2021-03-26**: add the ability to specify number of steps from min to max volume, both for short and long actions, when controlling the media player
-- **2021-03-27**: Add support for Philips Hue dimmer switch
-- **2021-04-19**: remove unused variable, fix warnings for undefined variables in Home Assistant Core >=2021.4.0
-- **2021-05-16**: Add support for Osram SMART+ Switch Mini
-- **2021-07-03**: Add support for Philips Hue Smart Button
-- **2021-08-02**: Improve inputs documentation and organization
-- **2021-10-26**:
-  - Standardize blueprints structure and inputs naming across the whole collection.
-  - Improve blueprint documentation.
-  - :tada: Add support for alternate mappings. Additional mappings for currently supported controllers will be added from now on. Refer to the documentation of your controller for more details.
-  - :warning: **Breaking Change**: update controller names in the `Controller Model` input, to match the full name of controllers, prevent ambiguities and enable support for alternate mappings. After updating this blueprint, please reconfigure your automations by selecting again the value for the `Controller Model` input, matching the full name of the controller you're using with this hook.
-  - Fix typo for IKEA E1524/E1810 center button long press action in mapping definition.
-- **2021-10-29**: Add support for IKEA E1766 TRÅDFRI Open/Close Remote.
-- **2021-11-07**: Add support for IKEA E2001/E2002 STYRBAR Remote control.
-- **2021-11-21**: Add support for Philips 929002398602 Hue Dimmer switch v2.
-- **2021-12-03**: Add support for Xiaomi WXCJKG11LM, WXCJKG12LM, WXCJKG13LM.
-- **2022-07-22**: Add support for Xiaomi WXKG11LM.
-- **2022-07-30**: Add support for SONOFF SNZB-01.
-- **2025-02-13**:
-
-  :warning: **Breaking Change**:
-
-  Migrate to Zigbee2MQTT MQTT Device Triggers. ([@yarafie](https://github.com/yarafie))
-
-  The `controller_entity` input has been deprecated, and `controller_device` is now mandatory.
-  If you are a Zigbee2MQTT user and plan to update this blueprint, please make sure to remove the `controller_entity` input from your automation config and add the device ID of your controller to the `controller_device` input.
-  To obtain the device ID from your controller, configure the automation from the UI and use the device selector dropdown on the `controller_device` input to select your controller.
-
-- **2025-02-16**:
-
-  :warning: **Breaking Change**:
-
-  Add support for Xiaomi WXKG01LM Mi Wireless Switch, rename Xiaomi WXKG11LM Aqara Wireless Switch Mini to Aqara WXKG11LM Wireless Mini Switch
-
-  If you had configured the `controller_model` input to `Xiaomi WXKG11LM Aqara Wireless Switch Mini`, please change it to `Aqara WXKG11LM Wireless Mini Switch`.
-  The change has been implemented to match the controller with the correct manufacturer name (Aqara).
-
-- **2025-03-20**: Added support for IKEA E2201 RODRET Dimmer. ([@yarafie](https://github.com/yarafie))
-- **2025-03-26**: Added support for IKEA E2213 SOMRIG shortcut button. ([@yarafie](https://github.com/yarafie))
-- **2025-03-28**: Added support for IKEA E2123 SYMFONISK sound remote, gen 2. ([@yarafie](https://github.com/yarafie))
-- **2025-03-29**: Added support for Tuya ERS-10TZBVK-AA Smart knob. ([@yarafie](https://github.com/yarafie))
+<Changelog category='hooks' id='media_player' />

--- a/website/package.json
+++ b/website/package.json
@@ -29,7 +29,8 @@
     "react-cookie-consent": "^9.0.0",
     "react-dom": "^19.0.0",
     "react-ga4": "^2.1.0",
-    "react-json-view-lite": "^2.3.0"
+    "react-json-view-lite": "^2.3.0",
+    "marked": "^12.0.0"
   },
   "browserslist": {
     "production": [

--- a/website/src/components/blueprints_docs/Changelog.tsx
+++ b/website/src/components/blueprints_docs/Changelog.tsx
@@ -60,7 +60,12 @@ marked.setOptions({
 })
 
 const markdownToHtml = (markdown: string): string => {
-  return marked.parse(markdown) as string
+  // Use parse() to handle line breaks properly, then strip <p> wrapper tags
+  // to avoid extra spacing in inline contexts
+  let html = marked.parse(markdown) as string
+  // Remove leading/trailing <p> tags and their content wrappers
+  html = html.replace(/^<p>/, '').replace(/<\/p>\s*$/, '')
+  return html.trim()
 }
 
 const renderDescription = (description: string): React.ReactNode => (

--- a/website/src/components/blueprints_docs/Changelog.tsx
+++ b/website/src/components/blueprints_docs/Changelog.tsx
@@ -1,0 +1,169 @@
+import React, { useEffect, useState } from 'react'
+import { marked } from 'marked'
+import { changelogsContext } from '../../utils'
+
+interface ChangelogChange {
+  description: string
+  breaking: boolean
+}
+
+interface ChangelogEntry {
+  date: string
+  changes: ChangelogChange[]
+}
+
+interface ChangelogProps {
+  category: string
+  id: string
+}
+
+type ChangelogState =
+  | { status: 'loading' }
+  | { status: 'error'; message: string }
+  | { status: 'empty' }
+  | { status: 'ready'; entries: ChangelogEntry[] }
+
+const styles = {
+  list: {
+    listStyleType: 'disc',
+    marginLeft: '1.5rem',
+  },
+  entry: {
+    marginBottom: '0.5rem',
+  },
+  nestedList: {
+    listStyleType: 'disc',
+    marginTop: '0.5rem',
+    marginLeft: '1.5rem',
+  },
+  inlineMessage: {
+    margin: 0,
+    color: 'var(--ifm-color-emphasis-600)',
+  },
+  warning: {
+    fontWeight: 600,
+  },
+}
+
+// Configure marked for inline markdown parsing
+// Customize link renderer to open links in new tab
+const renderer = new marked.Renderer()
+renderer.link = (href, title, text) => {
+  const titleAttr = title ? ` title="${title}"` : ''
+  return `<a href="${href}" target="_blank" rel="noopener noreferrer"${titleAttr}>${text}</a>`
+}
+
+marked.setOptions({
+  breaks: true, // Convert line breaks to <br>
+  gfm: true, // GitHub Flavored Markdown
+  renderer,
+})
+
+const markdownToHtml = (markdown: string): string => {
+  return marked.parse(markdown) as string
+}
+
+const renderDescription = (description: string): React.ReactNode => (
+  <span dangerouslySetInnerHTML={{ __html: markdownToHtml(description) }} />
+)
+
+const Changelog: React.FC<ChangelogProps> = ({ category, id }) => {
+  const [state, setState] = useState<ChangelogState>({ status: 'loading' })
+
+  useEffect(() => {
+    let isMounted = true
+
+    const loadChangelog = () => {
+      try {
+        const path = `./${category}/${id}/changelog.json`
+        const parsed = changelogsContext(path) as unknown as ChangelogEntry[]
+
+        if (!isMounted) return
+
+        if (!parsed || parsed.length === 0) {
+          setState({ status: 'empty' })
+          return
+        }
+
+        setState({ status: 'ready', entries: parsed })
+      } catch (error) {
+        if (!isMounted) return
+
+        // If the file is not found by the context, consider it empty
+        const message =
+          error instanceof Error ? error.message : 'Unable to load changelog.'
+
+        if (
+          /^\.\/.+changelog\.json$/.test(message) ||
+          /not found/i.test(message)
+        ) {
+          setState({ status: 'empty' })
+        } else {
+          setState({ status: 'error', message })
+        }
+      }
+    }
+
+    loadChangelog()
+
+    return () => {
+      isMounted = false
+    }
+  }, [category, id])
+
+  if (state.status === 'loading') {
+    return <p style={styles.inlineMessage}>Loading changelog…</p>
+  }
+
+  if (state.status === 'error') {
+    return (
+      <p style={styles.inlineMessage}>
+        Unable to load changelog. {state.message}
+      </p>
+    )
+  }
+
+  if (state.status === 'empty') {
+    return (
+      <p style={styles.inlineMessage}>No changelog entries available yet.</p>
+    )
+  }
+
+  return (
+    <>
+      <ul style={styles.list}>
+        {state.entries.map((entry) => {
+          const hasMultipleChanges = entry.changes.length > 1
+          const hasBreakingChanges = entry.changes.some(
+            (change) => change.breaking,
+          )
+
+          return (
+            <li key={`${entry.date}`} style={styles.entry}>
+              <strong>{entry.date}</strong>
+              {hasMultipleChanges || hasBreakingChanges ? (
+                <ul style={styles.nestedList}>
+                  {entry.changes.map((change, index) => (
+                    <li key={`${entry.date}-${index}`}>
+                      {change.breaking && (
+                        <span style={styles.warning}>
+                          <strong>🚨 Breaking Change</strong> :
+                        </span>
+                      )}
+                      {change.breaking && ' '}
+                      {renderDescription(change.description)}
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <>: {renderDescription(entry.changes[0]?.description ?? '')}</>
+              )}
+            </li>
+          )
+        })}
+      </ul>
+    </>
+  )
+}
+
+export default Changelog

--- a/website/src/components/blueprints_docs/index.tsx
+++ b/website/src/components/blueprints_docs/index.tsx
@@ -4,6 +4,7 @@ import Requirement from './Requirement'
 import ImportCard from './BlueprintImportCard'
 import BlueprintsList from './BlueprintsList'
 import ControllersList from './ControllersList'
+import Changelog from './Changelog'
 
 export {
   Input,
@@ -12,4 +13,5 @@ export {
   ImportCard,
   BlueprintsList,
   ControllersList,
+  Changelog,
 }

--- a/website/src/utils.ts
+++ b/website/src/utils.ts
@@ -7,6 +7,15 @@ export const blueprintsContext = require.context(
   /\.ya?ml$/,
 )
 
+/**
+ * Context for accessing blueprint changelog JSON files
+ */
+export const changelogsContext = require.context(
+  '@blueprints',
+  true,
+  /changelog\.json$/,
+)
+
 interface DocusaurusFrontMatter {
   title: string
   description: string


### PR DESCRIPTION
Thank you for taking the time to work on a Pull Request. Your contribution is really appreciated! :tada:
**Please don't delete any part of the template**, since keeping the provided structure will help maintainers to review your work more rapidly.

Sections marked as \* are required and need to be filled in.

## Proposed change\*

This PR refactors the way Blueprint Changelogs are written. Instead of being input in the `mdx` doc file for the blueprint, structured `json` changelogs are placed aside the blueprint `yaml` file. 
Then, a React component in the docs website fetches the changelog file for each blueprint, and renders the Changelog in the blueprint page.

This PR includes no functionality change.

## Checklist\*

- [X] I followed sections of the [Contribution Guidelines](https://github.com/EPMatt/awesome-ha-blueprints/blob/main/CONTRIBUTING.md) relevant to changes I'm proposing.
- [X] I properly tested proposed changes on my system and confirm that they are working as expected.
- [X] I formatted files with Prettier using the command `npm run format` before submitting my Pull Request.
