### PR TITLE
feat(docs): add blueprint version and author information, update blueprint import UI

### DIFF
--- a/blueprints/automation/addon_update_notification/addon_update_notification.yaml
+++ b/blueprints/automation/addon_update_notification/addon_update_notification.yaml
@@ -147,7 +147,7 @@ blueprint:
 # Automation schema
 variables:
   ahb_version: 2025.11.04
-  ahb_author: EPMatt
+  ahb_maintainers: [EPMatt]
   # convert blueprint inputs to variables to be used in templates
   notification_title: !input notification_title
   notification_message: !input notification_message

--- a/blueprints/automation/addon_update_notification/addon_update_notification.yaml
+++ b/blueprints/automation/addon_update_notification/addon_update_notification.yaml
@@ -146,6 +146,8 @@ blueprint:
           multiline: true
 # Automation schema
 variables:
+  ahb_version: 2025.11.04
+  ahb_author: EPMatt
   # convert blueprint inputs to variables to be used in templates
   notification_title: !input notification_title
   notification_message: !input notification_message

--- a/blueprints/automation/addon_update_notification/changelog.json
+++ b/blueprints/automation/addon_update_notification/changelog.json
@@ -1,6 +1,6 @@
 [
   {
-    "date": "2021-04-25",
+    "date": "2021.04.25",
     "changes": [
       {
         "description": "First blueprint version 🎉",
@@ -9,7 +9,7 @@
     ]
   },
   {
-    "date": "2021-10-26",
+    "date": "2021.10.26",
     "changes": [
       {
         "description": "Standardize blueprint structure and input naming across the collection. Improve blueprint documentation. No functionality change.",

--- a/blueprints/automation/example/example.yaml
+++ b/blueprints/automation/example/example.yaml
@@ -34,7 +34,7 @@ blueprint:
 # Automation schema
 variables:
   ahb_version: 2025.11.04
-  ahb_author: EPMatt
+  ahb_maintainers: [EPMatt]
 mode: restart
 
 trigger:

--- a/blueprints/automation/example/example.yaml
+++ b/blueprints/automation/example/example.yaml
@@ -32,6 +32,9 @@ blueprint:
         device:
 
 # Automation schema
+variables:
+  ahb_version: 2025.11.04
+  ahb_author: EPMatt
 mode: restart
 
 trigger:

--- a/blueprints/automation/on_off_schedule_state_persistence/changelog.json
+++ b/blueprints/automation/on_off_schedule_state_persistence/changelog.json
@@ -1,6 +1,6 @@
 [
   {
-    "date": "2021-02-01",
+    "date": "2021.02.01",
     "changes": [
       {
         "description": "First blueprint version 🎉",
@@ -9,7 +9,7 @@
     ]
   },
   {
-    "date": "2021-10-26",
+    "date": "2021.10.26",
     "changes": [
       {
         "description": "Standardize blueprint structure and input naming across the collection. Improve blueprint documentation. Remove default values from required inputs. No functionality change.",

--- a/blueprints/automation/on_off_schedule_state_persistence/on_off_schedule_state_persistence.yaml
+++ b/blueprints/automation/on_off_schedule_state_persistence/on_off_schedule_state_persistence.yaml
@@ -43,6 +43,8 @@ blueprint:
         boolean:
 # Automation schema
 variables:
+  ahb_version: 2025.11.04
+  ahb_author: EPMatt
   # convert input tags to variables, to be used in templates
   off_time: !input off_time
   on_time: !input on_time

--- a/blueprints/automation/on_off_schedule_state_persistence/on_off_schedule_state_persistence.yaml
+++ b/blueprints/automation/on_off_schedule_state_persistence/on_off_schedule_state_persistence.yaml
@@ -44,7 +44,7 @@ blueprint:
 # Automation schema
 variables:
   ahb_version: 2025.11.04
-  ahb_author: EPMatt
+  ahb_maintainers: [EPMatt]
   # convert input tags to variables, to be used in templates
   off_time: !input off_time
   on_time: !input on_time

--- a/blueprints/automation/persistent_notification_to_mobile/changelog.json
+++ b/blueprints/automation/persistent_notification_to_mobile/changelog.json
@@ -1,6 +1,6 @@
 [
   {
-    "date": "2021-02-01",
+    "date": "2021.02.01",
     "changes": [
       {
         "description": "First blueprint version 🎉",
@@ -9,7 +9,7 @@
     ]
   },
   {
-    "date": "2021-10-26",
+    "date": "2021.10.26",
     "changes": [
       {
         "description": "Standardize blueprint structure and input naming across the collection. Improve blueprint documentation. No functionality change.",

--- a/blueprints/automation/persistent_notification_to_mobile/persistent_notification_to_mobile.yaml
+++ b/blueprints/automation/persistent_notification_to_mobile/persistent_notification_to_mobile.yaml
@@ -53,6 +53,8 @@ blueprint:
         text:
 # Automation schema
 variables:
+  ahb_version: 2025.11.04
+  ahb_author: EPMatt
   # convert input tags to variables, to be used in templates
   notification_id: !input notification_id
   replace_notifications: !input replace_notifications

--- a/blueprints/automation/persistent_notification_to_mobile/persistent_notification_to_mobile.yaml
+++ b/blueprints/automation/persistent_notification_to_mobile/persistent_notification_to_mobile.yaml
@@ -54,7 +54,7 @@ blueprint:
 # Automation schema
 variables:
   ahb_version: 2025.11.04
-  ahb_author: EPMatt
+  ahb_maintainers: [EPMatt]
   # convert input tags to variables, to be used in templates
   notification_id: !input notification_id
   replace_notifications: !input replace_notifications

--- a/blueprints/automation/simple_safe_scheduler/changelog.json
+++ b/blueprints/automation/simple_safe_scheduler/changelog.json
@@ -1,6 +1,6 @@
 [
   {
-    "date": "2021-10-22",
+    "date": "2021.10.22",
     "changes": [
       {
         "description": "First blueprint version 🎉",

--- a/blueprints/automation/simple_safe_scheduler/simple_safe_scheduler.yaml
+++ b/blueprints/automation/simple_safe_scheduler/simple_safe_scheduler.yaml
@@ -136,6 +136,8 @@ blueprint:
           mode: slider
 # Automation schema
 variables:
+  ahb_version: 2025.11.04
+  ahb_author: EPMatt
   # convert input tags to variables, to be used in templates
   day_monday: !input day_monday
   day_tuesday: !input day_tuesday

--- a/blueprints/automation/simple_safe_scheduler/simple_safe_scheduler.yaml
+++ b/blueprints/automation/simple_safe_scheduler/simple_safe_scheduler.yaml
@@ -137,7 +137,7 @@ blueprint:
 # Automation schema
 variables:
   ahb_version: 2025.11.04
-  ahb_author: EPMatt
+  ahb_maintainers: [EPMatt]
   # convert input tags to variables, to be used in templates
   day_monday: !input day_monday
   day_tuesday: !input day_tuesday

--- a/blueprints/controllers/ikea_e1524_e1810/changelog.json
+++ b/blueprints/controllers/ikea_e1524_e1810/changelog.json
@@ -1,6 +1,6 @@
 [
   {
-    "date": "2021-02-05",
+    "date": "2021.02.05",
     "changes": [
       {
         "description": "First blueprint version 🎉",
@@ -9,7 +9,7 @@
     ]
   },
   {
-    "date": "2021-02-07",
+    "date": "2021.02.07",
     "changes": [
       {
         "description": "Fix an issue which prevented creating automations for ZHA or deCONZ.",
@@ -18,7 +18,7 @@
     ]
   },
   {
-    "date": "2021-02-08",
+    "date": "2021.02.08",
     "changes": [
       {
         "description": "Update example and fix an issue which executed actions twice when the remote was connected via Zigbee2MQTT.",
@@ -27,7 +27,7 @@
     ]
   },
   {
-    "date": "2021-02-21",
+    "date": "2021.02.21",
     "changes": [
       {
         "description": "Add support for virtual double press events.",
@@ -44,7 +44,7 @@
     ]
   },
   {
-    "date": "2021-03-03",
+    "date": "2021.03.03",
     "changes": [
       {
         "description": "Move the blueprint into the Controllers-Hooks Ecosystem.",
@@ -53,7 +53,7 @@
     ]
   },
   {
-    "date": "2021-03-18",
+    "date": "2021.03.18",
     "changes": [
       {
         "description": "Add example for fully controlling an RGB light (Thanks [@kks36](https://github.com/kks36)!).",
@@ -62,7 +62,7 @@
     ]
   },
   {
-    "date": "2021-03-25",
+    "date": "2021.03.25",
     "changes": [
       {
         "description": "Standardize input names across all the Controller blueprints. If you plan to update this blueprint, please update the inputs in your automations as follows:\n- `remote` -> `controller_device`\n- `zigbee2mqtt_remote` -> `controller_entity`\n- `action_* inputs` -> `action_button_*`\n- `helper_last_loop_event_input` -> `helper_last_controller_event`",
@@ -71,7 +71,7 @@
     ]
   },
   {
-    "date": "2021-03-26",
+    "date": "2021.03.26",
     "changes": [
       {
         "description": "Add support for the Cover Hook.",
@@ -80,7 +80,7 @@
     ]
   },
   {
-    "date": "2021-03-30",
+    "date": "2021.03.30",
     "changes": [
       {
         "description": "Fix event mappings for ZHA and deCONZ.",
@@ -89,7 +89,7 @@
     ]
   },
   {
-    "date": "2021-04-19",
+    "date": "2021.04.19",
     "changes": [
       {
         "description": "Fix double press events not being detected with deCONZ.",
@@ -98,7 +98,7 @@
     ]
   },
   {
-    "date": "2021-04-23",
+    "date": "2021.04.23",
     "changes": [
       {
         "description": "Fix deCONZ events not being recognized.",
@@ -107,7 +107,7 @@
     ]
   },
   {
-    "date": "2021-05-26",
+    "date": "2021.05.26",
     "changes": [
       {
         "description": "Make `helper_last_controller_event` a mandatory input to simplify setup and enable future advanced features. When updating, ensure to provide a dedicated input_text entity for this input.",
@@ -132,7 +132,7 @@
     ]
   },
   {
-    "date": "2021-07-04",
+    "date": "2021.07.04",
     "changes": [
       {
         "description": "Fix deCONZ button release events not being properly recognized.",
@@ -141,7 +141,7 @@
     ]
   },
   {
-    "date": "2021-08-02",
+    "date": "2021.08.02",
     "changes": [
       {
         "description": "Improve inputs documentation and organization.",
@@ -150,7 +150,7 @@
     ]
   },
   {
-    "date": "2021-10-26",
+    "date": "2021.10.26",
     "changes": [
       {
         "description": "Standardize blueprints structure and inputs naming across the collection. Improve blueprint documentation.",
@@ -159,7 +159,7 @@
     ]
   },
   {
-    "date": "2022-08-08",
+    "date": "2022.08.08",
     "changes": [
       {
         "description": "Optimize characters usage for the `helper_last_controller_event` text input.",
@@ -168,7 +168,7 @@
     ]
   },
   {
-    "date": "2025-01-03",
+    "date": "2025.01.03",
     "changes": [
       {
         "description": "Fix double press events not triggered due to changes in Home Assistant 2023.5.x. (Thanks [@ZtormTheCat](https://github.com/ZtormTheCat))",
@@ -177,7 +177,7 @@
     ]
   },
   {
-    "date": "2025-02-13",
+    "date": "2025.02.13",
     "changes": [
       {
         "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The `controller_entity` input is deprecated and `controller_device` is now mandatory. Remove `controller_entity` from your automation and configure the `controller_device` input with your controller device ID. (Thanks [@yarafie](https://github.com/yarafie))",
@@ -186,7 +186,7 @@
     ]
   },
   {
-    "date": "2025-03-20",
+    "date": "2025.03.20",
     "changes": [
       {
         "description": "Standardize input naming format for controller devices and virtual button actions. No functionality changes.",
@@ -195,7 +195,7 @@
     ]
   },
   {
-    "date": "2025-04-01",
+    "date": "2025.04.01",
     "changes": [
       {
         "description": "Fix double-click detection logic. (Thanks [@danleongjy](https://github.com/danleongjy))",
@@ -204,7 +204,7 @@
     ]
   },
   {
-    "date": "2025-04-19",
+    "date": "2025.04.19",
     "changes": [
       {
         "description": "Improve Last Controller Event Helper JSON Regex with more lenient matching.",

--- a/blueprints/controllers/ikea_e1524_e1810/ikea_e1524_e1810.yaml
+++ b/blueprints/controllers/ikea_e1524_e1810/ikea_e1524_e1810.yaml
@@ -309,6 +309,8 @@ blueprint:
           step: 10
 # Automation schema
 variables:
+  ahb_version: 2025.11.04
+  ahb_author: EPMatt
   # convert input tags to variables, to be used in templates
   integration: !input integration
   button_left_long_loop: !input button_left_long_loop

--- a/blueprints/controllers/ikea_e1524_e1810/ikea_e1524_e1810.yaml
+++ b/blueprints/controllers/ikea_e1524_e1810/ikea_e1524_e1810.yaml
@@ -310,7 +310,7 @@ blueprint:
 # Automation schema
 variables:
   ahb_version: 2025.11.04
-  ahb_author: EPMatt
+  ahb_maintainers: [EPMatt]
   # convert input tags to variables, to be used in templates
   integration: !input integration
   button_left_long_loop: !input button_left_long_loop

--- a/blueprints/controllers/ikea_e1743/changelog.json
+++ b/blueprints/controllers/ikea_e1743/changelog.json
@@ -1,6 +1,6 @@
 [
   {
-    "date": "2021-02-07",
+    "date": "2021.02.07",
     "changes": [
       {
         "description": "First blueprint version 🎉",
@@ -9,7 +9,7 @@
     ]
   },
   {
-    "date": "2021-02-07",
+    "date": "2021.02.07",
     "changes": [
       {
         "description": "Fix an issue on Zigbee2MQTT triggering rules.",
@@ -18,7 +18,7 @@
     ]
   },
   {
-    "date": "2021-02-07",
+    "date": "2021.02.07",
     "changes": [
       {
         "description": "Fix an issue which prevented creating automations for ZHA or deCONZ. (Thanks [@kks36](https://github.com/kks36))! 🎉)",
@@ -27,7 +27,7 @@
     ]
   },
   {
-    "date": "2021-02-08",
+    "date": "2021.02.08",
     "changes": [
       {
         "description": "Update example and fix an issue which executed actions twice when the remote was connected via Zigbee2MQTT.",
@@ -36,7 +36,7 @@
     ]
   },
   {
-    "date": "2021-02-23",
+    "date": "2021.02.23",
     "changes": [
       {
         "description": "Add support for virtual double press events.",
@@ -53,7 +53,7 @@
     ]
   },
   {
-    "date": "2021-03-03",
+    "date": "2021.03.03",
     "changes": [
       {
         "description": "Move the blueprint into the Controllers-Hooks Ecosystem.",
@@ -62,7 +62,7 @@
     ]
   },
   {
-    "date": "2021-03-25",
+    "date": "2021.03.25",
     "changes": [
       {
         "description": "Standardize input names across all the Controller blueprints. If you plan to update this blueprint, please update the inputs in your automations as follows:\n- `remote` -> `controller_device`\n- `zigbee2mqtt_remote` -> `controller_entity`\n- `action_* inputs` -> `action_button_*`\n- `helper_last_loop_event_input` -> `helper_last_controller_event`",
@@ -71,7 +71,7 @@
     ]
   },
   {
-    "date": "2021-03-26",
+    "date": "2021.03.26",
     "changes": [
       {
         "description": "Add support for the Cover Hook.",
@@ -80,7 +80,7 @@
     ]
   },
   {
-    "date": "2021-04-19",
+    "date": "2021.04.19",
     "changes": [
       {
         "description": "Fix double press events not being detected with deCONZ.",
@@ -89,7 +89,7 @@
     ]
   },
   {
-    "date": "2021-04-23",
+    "date": "2021.04.23",
     "changes": [
       {
         "description": "Fix deCONZ events not being recognized.",
@@ -98,7 +98,7 @@
     ]
   },
   {
-    "date": "2021-05-26",
+    "date": "2021.05.26",
     "changes": [
       {
         "description": "Make `helper_last_controller_event` a mandatory input to simplify setup and enable future advanced features. When updating, provide a dedicated input_text entity for this input.",
@@ -123,7 +123,7 @@
     ]
   },
   {
-    "date": "2021-07-04",
+    "date": "2021.07.04",
     "changes": [
       {
         "description": "Fix deCONZ button release events not being properly recognized.",
@@ -132,7 +132,7 @@
     ]
   },
   {
-    "date": "2021-08-02",
+    "date": "2021.08.02",
     "changes": [
       {
         "description": "Improve inputs documentation and organization.",
@@ -141,7 +141,7 @@
     ]
   },
   {
-    "date": "2021-10-26",
+    "date": "2021.10.26",
     "changes": [
       {
         "description": "Standardize blueprint structure and input naming across the collection. Improve blueprint documentation. No functionality change.",
@@ -150,7 +150,7 @@
     ]
   },
   {
-    "date": "2022-08-08",
+    "date": "2022.08.08",
     "changes": [
       {
         "description": "Optimize characters usage for the `helper_last_controller_event` text input.",
@@ -159,7 +159,7 @@
     ]
   },
   {
-    "date": "2025-01-02",
+    "date": "2025.01.02",
     "changes": [
       {
         "description": "Remove spaces to match the new helper format in Home Assistant 2023.5.x. (Thanks [@LordSushiPhoenix](https://github.com/LordSushiPhoenix))",
@@ -168,7 +168,7 @@
     ]
   },
   {
-    "date": "2025-01-23",
+    "date": "2025.01.23",
     "changes": [
       {
         "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The `controller_entity` input is deprecated and `controller_device` is now mandatory. Remove `controller_entity` from your automation and configure `controller_device` with your controller device ID. (Thanks [@yarafie](https://github.com/yarafie))",
@@ -177,7 +177,7 @@
     ]
   },
   {
-    "date": "2025-03-20",
+    "date": "2025.03.20",
     "changes": [
       {
         "description": "Standardize input naming format for controller devices and virtual button actions. No functionality changes.",
@@ -186,7 +186,7 @@
     ]
   },
   {
-    "date": "2025-04-01",
+    "date": "2025.04.01",
     "changes": [
       {
         "description": "Fix double-click detection logic. (Thanks [@danleongjy](https://github.com/danleongjy))",
@@ -195,7 +195,7 @@
     ]
   },
   {
-    "date": "2025-04-16",
+    "date": "2025.04.16",
     "changes": [
       {
         "description": "Update ZHA long press and release actions. (Thanks [@notherealmarco](https://github.com/notherealmarco))",
@@ -204,7 +204,7 @@
     ]
   },
   {
-    "date": "2025-04-19",
+    "date": "2025.04.19",
     "changes": [
       {
         "description": "Improve Last Controller Event Helper JSON Regex with more lenient matching.",

--- a/blueprints/controllers/ikea_e1743/ikea_e1743.yaml
+++ b/blueprints/controllers/ikea_e1743/ikea_e1743.yaml
@@ -190,6 +190,8 @@ blueprint:
           step: 10
 # Automation schema
 variables:
+  ahb_version: 2025.11.04
+  ahb_author: EPMatt
   # convert input tags to variables, to be used in templates
   integration: !input integration
   button_up_long_loop: !input button_up_long_loop

--- a/blueprints/controllers/ikea_e1743/ikea_e1743.yaml
+++ b/blueprints/controllers/ikea_e1743/ikea_e1743.yaml
@@ -191,7 +191,7 @@ blueprint:
 # Automation schema
 variables:
   ahb_version: 2025.11.04
-  ahb_author: EPMatt
+  ahb_maintainers: [EPMatt]
   # convert input tags to variables, to be used in templates
   integration: !input integration
   button_up_long_loop: !input button_up_long_loop

--- a/blueprints/controllers/ikea_e1744/changelog.json
+++ b/blueprints/controllers/ikea_e1744/changelog.json
@@ -1,6 +1,6 @@
 [
   {
-    "date": "2021-03-07",
+    "date": "2021.03.07",
     "changes": [
       {
         "description": "First blueprint version 🎉",
@@ -9,7 +9,7 @@
     ]
   },
   {
-    "date": "2021-03-25",
+    "date": "2021.03.25",
     "changes": [
       {
         "description": "Standardize input names across all the Controller blueprints. Update your automation inputs as follows:\n- `remote` -> `controller_device`\n- `zigbee2mqtt_remote` -> `controller_entity`\n- `action_click` -> `action_click_short`",
@@ -18,7 +18,7 @@
     ]
   },
   {
-    "date": "2021-04-19",
+    "date": "2021.04.19",
     "changes": [
       {
         "description": "Align action mapping format for deCONZ across all the Controller blueprints.",
@@ -27,7 +27,7 @@
     ]
   },
   {
-    "date": "2021-04-23",
+    "date": "2021.04.23",
     "changes": [
       {
         "description": "Fix deCONZ events not being recognized.",
@@ -36,7 +36,7 @@
     ]
   },
   {
-    "date": "2021-05-14",
+    "date": "2021.05.14",
     "changes": [
       {
         "description": "Make `helper_last_controller_event` a mandatory input to simplify setup and enable future advanced features. When updating, provide a dedicated input_text entity for this input.",
@@ -61,7 +61,7 @@
     ]
   },
   {
-    "date": "2021-05-26",
+    "date": "2021.05.26",
     "changes": [
       {
         "description": "Fix Zigbee2MQTT reporting null state changes.",
@@ -70,7 +70,7 @@
     ]
   },
   {
-    "date": "2021-07-04",
+    "date": "2021.07.04",
     "changes": [
       {
         "description": "Fix deCONZ rotation stop events not being properly recognized.",
@@ -79,7 +79,7 @@
     ]
   },
   {
-    "date": "2021-08-02",
+    "date": "2021.08.02",
     "changes": [
       {
         "description": "Improve inputs documentation and organization.",
@@ -88,7 +88,7 @@
     ]
   },
   {
-    "date": "2021-10-26",
+    "date": "2021.10.26",
     "changes": [
       {
         "description": "Standardize blueprint structure and input naming across the collection. Improve blueprint documentation. No functionality change.",
@@ -97,7 +97,7 @@
     ]
   },
   {
-    "date": "2022-08-08",
+    "date": "2022.08.08",
     "changes": [
       {
         "description": "Optimize characters usage for the `helper_last_controller_event` text input.",
@@ -106,7 +106,7 @@
     ]
   },
   {
-    "date": "2025-01-05",
+    "date": "2025.01.05",
     "changes": [
       {
         "description": "Update ZHA event data to match what ZHA provides in Home Assistant 2024.03.01. (Thanks [@ogajduse](https://github.com/ogajduse))",
@@ -115,7 +115,7 @@
     ]
   },
   {
-    "date": "2025-02-13",
+    "date": "2025.02.13",
     "changes": [
       {
         "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The `controller_entity` input is deprecated and `controller_device` is now mandatory. Remove `controller_entity` from your automation and configure `controller_device` with your controller device ID. (Thanks [@yarafie](https://github.com/yarafie))",
@@ -124,7 +124,7 @@
     ]
   },
   {
-    "date": "2025-03-20",
+    "date": "2025.03.20",
     "changes": [
       {
         "description": "Standardize input naming format for controller devices and virtual button actions. No functionality changes.",
@@ -133,7 +133,7 @@
     ]
   },
   {
-    "date": "2025-04-19",
+    "date": "2025.04.19",
     "changes": [
       {
         "description": "Improve Last Controller Event Helper JSON Regex with more lenient matching.",

--- a/blueprints/controllers/ikea_e1744/ikea_e1744.yaml
+++ b/blueprints/controllers/ikea_e1744/ikea_e1744.yaml
@@ -159,6 +159,8 @@ blueprint:
           step: 10
 # Automation schema
 variables:
+  ahb_version: 2025.11.04
+  ahb_author: EPMatt
   # convert input tags to variables, to be used in templates
   integration: !input integration
   rotate_left_loop: !input rotate_left_loop

--- a/blueprints/controllers/ikea_e1744/ikea_e1744.yaml
+++ b/blueprints/controllers/ikea_e1744/ikea_e1744.yaml
@@ -160,7 +160,7 @@ blueprint:
 # Automation schema
 variables:
   ahb_version: 2025.11.04
-  ahb_author: EPMatt
+  ahb_maintainers: [EPMatt]
   # convert input tags to variables, to be used in templates
   integration: !input integration
   rotate_left_loop: !input rotate_left_loop

--- a/blueprints/controllers/ikea_e1766/changelog.json
+++ b/blueprints/controllers/ikea_e1766/changelog.json
@@ -1,6 +1,6 @@
 [
   {
-    "date": "2021-10-29",
+    "date": "2021.10.29",
     "changes": [
       {
         "description": "First blueprint version 🎉",
@@ -9,7 +9,7 @@
     ]
   },
   {
-    "date": "2022-08-08",
+    "date": "2022.08.08",
     "changes": [
       {
         "description": "Optimize characters usage for the `helper_last_controller_event` text input.",
@@ -18,7 +18,7 @@
     ]
   },
   {
-    "date": "2025-02-13",
+    "date": "2025.02.13",
     "changes": [
       {
         "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The `controller_entity` input is deprecated and `controller_device` is now mandatory. Remove `controller_entity` from your automation and configure `controller_device` with your controller device ID. (Thanks [@yarafie](https://github.com/yarafie))",
@@ -27,7 +27,7 @@
     ]
   },
   {
-    "date": "2025-03-20",
+    "date": "2025.03.20",
     "changes": [
       {
         "description": "Standardize input naming format for controller devices and virtual button actions. No functionality changes.",
@@ -36,7 +36,7 @@
     ]
   },
   {
-    "date": "2025-04-01",
+    "date": "2025.04.01",
     "changes": [
       {
         "description": "Fix double-click detection logic. (Thanks [@danleongjy](https://github.com/danleongjy))",
@@ -45,7 +45,7 @@
     ]
   },
   {
-    "date": "2025-04-19",
+    "date": "2025.04.19",
     "changes": [
       {
         "description": "Improve Last Controller Event Helper JSON Regex with more lenient matching.",

--- a/blueprints/controllers/ikea_e1766/ikea_e1766.yaml
+++ b/blueprints/controllers/ikea_e1766/ikea_e1766.yaml
@@ -141,7 +141,7 @@ blueprint:
 # Automation schema
 variables:
   ahb_version: 2025.11.04
-  ahb_author: EPMatt
+  ahb_maintainers: [EPMatt]
   # convert input tags to variables, to be used in templates
   integration: !input integration
   button_up_double_press: !input button_up_double_press

--- a/blueprints/controllers/ikea_e1766/ikea_e1766.yaml
+++ b/blueprints/controllers/ikea_e1766/ikea_e1766.yaml
@@ -140,6 +140,8 @@ blueprint:
           step: 10
 # Automation schema
 variables:
+  ahb_version: 2025.11.04
+  ahb_author: EPMatt
   # convert input tags to variables, to be used in templates
   integration: !input integration
   button_up_double_press: !input button_up_double_press

--- a/blueprints/controllers/ikea_e1812/changelog.json
+++ b/blueprints/controllers/ikea_e1812/changelog.json
@@ -1,6 +1,6 @@
 [
   {
-    "date": "2021-03-14",
+    "date": "2021.03.14",
     "changes": [
       {
         "description": "First blueprint version 🎉",
@@ -9,7 +9,7 @@
     ]
   },
   {
-    "date": "2021-03-25",
+    "date": "2021.03.25",
     "changes": [
       {
         "description": "Standardize input names across all the Controller blueprints. If you plan to update this blueprint, please update the inputs in your automations as follows:\n- `remote` -> `controller_device`\n- `zigbee2mqtt_remote` -> `controller_entity`\n- `helper_last_loop_event_input` -> `helper_last_controller_event`",
@@ -18,7 +18,7 @@
     ]
   },
   {
-    "date": "2021-03-26",
+    "date": "2021.03.26",
     "changes": [
       {
         "description": "Add support for the Cover Hook.",
@@ -27,7 +27,7 @@
     ]
   },
   {
-    "date": "2021-04-19",
+    "date": "2021.04.19",
     "changes": [
       {
         "description": "Fix double press events not being detected with deCONZ.",
@@ -36,7 +36,7 @@
     ]
   },
   {
-    "date": "2021-04-23",
+    "date": "2021.04.23",
     "changes": [
       {
         "description": "Fix deCONZ events not being recognized.",
@@ -45,7 +45,7 @@
     ]
   },
   {
-    "date": "2021-05-15",
+    "date": "2021.05.15",
     "changes": [
       {
         "description": "Make `helper_last_controller_event` a mandatory input to simplify setup and enable future advanced features. Provide a dedicated input_text entity for this input when updating.",
@@ -66,7 +66,7 @@
     ]
   },
   {
-    "date": "2021-05-26",
+    "date": "2021.05.26",
     "changes": [
       {
         "description": "Fix Zigbee2MQTT reporting null state changes.",
@@ -75,7 +75,7 @@
     ]
   },
   {
-    "date": "2021-08-02",
+    "date": "2021.08.02",
     "changes": [
       {
         "description": "Improve inputs documentation and organization.",
@@ -84,7 +84,7 @@
     ]
   },
   {
-    "date": "2021-10-26",
+    "date": "2021.10.26",
     "changes": [
       {
         "description": "Standardize blueprint structure and input naming across the collection. Improve blueprint documentation. No functionality change.",
@@ -93,7 +93,7 @@
     ]
   },
   {
-    "date": "2022-08-08",
+    "date": "2022.08.08",
     "changes": [
       {
         "description": "Optimize characters usage for the `helper_last_controller_event` text input.",
@@ -102,7 +102,7 @@
     ]
   },
   {
-    "date": "2025-01-03",
+    "date": "2025.01.03",
     "changes": [
       {
         "description": "Fix double press events not triggered due to changes in Home Assistant 2023.5.x.",
@@ -111,7 +111,7 @@
     ]
   },
   {
-    "date": "2025-02-13",
+    "date": "2025.02.13",
     "changes": [
       {
         "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The `controller_entity` input is deprecated and `controller_device` is now mandatory. Remove `controller_entity` from your automation and configure `controller_device` with your controller device ID. (Thanks [@yarafie](https://github.com/yarafie))",
@@ -120,7 +120,7 @@
     ]
   },
   {
-    "date": "2025-03-20",
+    "date": "2025.03.20",
     "changes": [
       {
         "description": "Standardize input naming format for controller devices and virtual button actions. No functionality changes.",
@@ -129,7 +129,7 @@
     ]
   },
   {
-    "date": "2025-04-06",
+    "date": "2025.04.06",
     "changes": [
       {
         "description": "Fix double-click detection logic. (Thanks [@danleongjy](https://github.com/danleongjy))",
@@ -138,7 +138,7 @@
     ]
   },
   {
-    "date": "2025-04-12",
+    "date": "2025.04.12",
     "changes": [
       {
         "description": "Add native double press triggers and refactor the blueprint to use triggers and trigger IDs. The integration selector input is removed, and `helper_last_controller_event` is no longer required. Re-download the blueprint and reconfigure existing automations to apply the changes. (Thanks [@yarafie](https://github.com/yarafie))",

--- a/blueprints/controllers/ikea_e1812/ikea_e1812.yaml
+++ b/blueprints/controllers/ikea_e1812/ikea_e1812.yaml
@@ -115,7 +115,7 @@ blueprint:
 # Automation schema
 variables:
   ahb_version: 2025.11.04
-  ahb_author: EPMatt
+  ahb_maintainers: [EPMatt]
   # Controller ID
   controller_id: !input controller_device
   # integration id used to select items in the action mapping

--- a/blueprints/controllers/ikea_e1812/ikea_e1812.yaml
+++ b/blueprints/controllers/ikea_e1812/ikea_e1812.yaml
@@ -114,6 +114,8 @@ blueprint:
 #
 # Automation schema
 variables:
+  ahb_version: 2025.11.04
+  ahb_author: EPMatt
   # Controller ID
   controller_id: !input controller_device
   # integration id used to select items in the action mapping

--- a/blueprints/controllers/ikea_e2001_e2002/changelog.json
+++ b/blueprints/controllers/ikea_e2001_e2002/changelog.json
@@ -1,6 +1,6 @@
 [
   {
-    "date": "2021-11-07",
+    "date": "2021.11.07",
     "changes": [
       {
         "description": "First blueprint version 🎉",
@@ -9,7 +9,7 @@
     ]
   },
   {
-    "date": "2022-08-08",
+    "date": "2022.08.08",
     "changes": [
       {
         "description": "Optimize characters usage for the `helper_last_controller_event` text input.",
@@ -18,7 +18,7 @@
     ]
   },
   {
-    "date": "2025-01-02",
+    "date": "2025.01.02",
     "changes": [
       {
         "description": "(ZHA) Fix a bug preventing long press actions from being triggered. (Thanks [@Ivarvdb](https://github.com/Ivarvdb))",
@@ -31,7 +31,7 @@
     ]
   },
   {
-    "date": "2025-01-03",
+    "date": "2025.01.03",
     "changes": [
       {
         "description": "Remove spaces to match the new helper format in Home Assistant 2023.5.x. (Thanks [@LordSushiPhoenix](https://github.com/LordSushiPhoenix))",
@@ -40,7 +40,7 @@
     ]
   },
   {
-    "date": "2025-02-13",
+    "date": "2025.02.13",
     "changes": [
       {
         "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The `controller_entity` input is deprecated and `controller_device` is now mandatory. Remove `controller_entity` from your automation and configure `controller_device` with your controller device ID. (Thanks [@yarafie](https://github.com/yarafie))",
@@ -49,7 +49,7 @@
     ]
   },
   {
-    "date": "2025-03-20",
+    "date": "2025.03.20",
     "changes": [
       {
         "description": "Standardize input naming format for controller devices and virtual button actions. No functionality changes.",
@@ -58,7 +58,7 @@
     ]
   },
   {
-    "date": "2025-04-01",
+    "date": "2025.04.01",
     "changes": [
       {
         "description": "Fix double-click detection logic. (Thanks [@danleongjy](https://github.com/danleongjy))",
@@ -67,7 +67,7 @@
     ]
   },
   {
-    "date": "2025-04-16",
+    "date": "2025.04.16",
     "changes": [
       {
         "description": "Fix long press down not releasing. (Thanks [@kkthxbye-code](https://github.com/kkthxbye-code))",
@@ -76,7 +76,7 @@
     ]
   },
   {
-    "date": "2025-04-19",
+    "date": "2025.04.19",
     "changes": [
       {
         "description": "Improve Last Controller Event Helper JSON Regex with more lenient matching.",

--- a/blueprints/controllers/ikea_e2001_e2002/ikea_e2001_e2002.yaml
+++ b/blueprints/controllers/ikea_e2001_e2002/ikea_e2001_e2002.yaml
@@ -285,6 +285,8 @@ blueprint:
           step: 10
 # Automation schema
 variables:
+  ahb_version: 2025.11.04
+  ahb_author: EPMatt
   # convert input tags to variables, to be used in templates
   integration: !input integration
   button_left_long_loop: !input button_left_long_loop

--- a/blueprints/controllers/ikea_e2001_e2002/ikea_e2001_e2002.yaml
+++ b/blueprints/controllers/ikea_e2001_e2002/ikea_e2001_e2002.yaml
@@ -286,7 +286,7 @@ blueprint:
 # Automation schema
 variables:
   ahb_version: 2025.11.04
-  ahb_author: EPMatt
+  ahb_maintainers: [EPMatt]
   # convert input tags to variables, to be used in templates
   integration: !input integration
   button_left_long_loop: !input button_left_long_loop

--- a/blueprints/controllers/ikea_e2123/changelog.json
+++ b/blueprints/controllers/ikea_e2123/changelog.json
@@ -1,6 +1,6 @@
 [
   {
-    "date": "2025-03-28",
+    "date": "2025.03.28",
     "changes": [
       {
         "description": "Initial release. (Thanks [@yarafie](https://github.com/yarafie)) 🎉",

--- a/blueprints/controllers/ikea_e2123/ikea_e2123.yaml
+++ b/blueprints/controllers/ikea_e2123/ikea_e2123.yaml
@@ -313,6 +313,8 @@ blueprint:
 #
 # Automation schema
 variables:
+  ahb_version: 2025.11.04
+  ahb_author: EPMatt
   # Controller ID
   controller_id: !input controller_device
   # integration id used to select items in the action mapping

--- a/blueprints/controllers/ikea_e2123/ikea_e2123.yaml
+++ b/blueprints/controllers/ikea_e2123/ikea_e2123.yaml
@@ -314,7 +314,7 @@ blueprint:
 # Automation schema
 variables:
   ahb_version: 2025.11.04
-  ahb_author: EPMatt
+  ahb_maintainers: [EPMatt]
   # Controller ID
   controller_id: !input controller_device
   # integration id used to select items in the action mapping

--- a/blueprints/controllers/ikea_e2201/changelog.json
+++ b/blueprints/controllers/ikea_e2201/changelog.json
@@ -1,6 +1,6 @@
 [
   {
-    "date": "2025-03-20",
+    "date": "2025.03.20",
     "changes": [
       {
         "description": "Initial release. (Thanks [@yarafie](https://github.com/yarafie)) 🎉",

--- a/blueprints/controllers/ikea_e2201/ikea_e2201.yaml
+++ b/blueprints/controllers/ikea_e2201/ikea_e2201.yaml
@@ -176,7 +176,7 @@ blueprint:
 # Automation schema
 variables:
   ahb_version: 2025.11.04
-  ahb_author: EPMatt
+  ahb_maintainers: [EPMatt]
   # Controller ID
   controller_id: !input controller_device
   # integration id used to select items in the action mapping

--- a/blueprints/controllers/ikea_e2201/ikea_e2201.yaml
+++ b/blueprints/controllers/ikea_e2201/ikea_e2201.yaml
@@ -175,6 +175,8 @@ blueprint:
 #
 # Automation schema
 variables:
+  ahb_version: 2025.11.04
+  ahb_author: EPMatt
   # Controller ID
   controller_id: !input controller_device
   # integration id used to select items in the action mapping

--- a/blueprints/controllers/ikea_e2213/changelog.json
+++ b/blueprints/controllers/ikea_e2213/changelog.json
@@ -1,6 +1,6 @@
 [
   {
-    "date": "2025-03-26",
+    "date": "2025.03.26",
     "changes": [
       {
         "description": "Initial release. (Thanks [@yarafie](https://github.com/yarafie)) 🎉",

--- a/blueprints/controllers/ikea_e2213/ikea_e2213.yaml
+++ b/blueprints/controllers/ikea_e2213/ikea_e2213.yaml
@@ -159,6 +159,8 @@ blueprint:
 #
 # Automation schema
 variables:
+  ahb_version: 2025.11.04
+  ahb_author: EPMatt
   # Controller ID
   controller_id: !input controller_device
   # integration id used to select items in the action mapping

--- a/blueprints/controllers/ikea_e2213/ikea_e2213.yaml
+++ b/blueprints/controllers/ikea_e2213/ikea_e2213.yaml
@@ -160,7 +160,7 @@ blueprint:
 # Automation schema
 variables:
   ahb_version: 2025.11.04
-  ahb_author: EPMatt
+  ahb_maintainers: [EPMatt]
   # Controller ID
   controller_id: !input controller_device
   # integration id used to select items in the action mapping

--- a/blueprints/controllers/ikea_ictc_g_1/changelog.json
+++ b/blueprints/controllers/ikea_ictc_g_1/changelog.json
@@ -1,6 +1,6 @@
 [
   {
-    "date": "2021-03-26",
+    "date": "2021.03.26",
     "changes": [
       {
         "description": "First blueprint version 🎉",
@@ -9,7 +9,7 @@
     ]
   },
   {
-    "date": "2021-04-19",
+    "date": "2021.04.19",
     "changes": [
       {
         "description": "Fix stop rotation events not being detected with deCONZ.",
@@ -18,7 +18,7 @@
     ]
   },
   {
-    "date": "2021-04-23",
+    "date": "2021.04.23",
     "changes": [
       {
         "description": "Fix deCONZ events not being recognized.",
@@ -27,7 +27,7 @@
     ]
   },
   {
-    "date": "2021-05-26",
+    "date": "2021.05.26",
     "changes": [
       {
         "description": "Make `helper_last_controller_event` a mandatory input to simplify setup and enable future advanced features. When updating, provide a dedicated input_text entity for this input.",
@@ -56,7 +56,7 @@
     ]
   },
   {
-    "date": "2021-07-04",
+    "date": "2021.07.04",
     "changes": [
       {
         "description": "Fix deCONZ rotation stop events not being properly recognized.",
@@ -65,7 +65,7 @@
     ]
   },
   {
-    "date": "2021-08-02",
+    "date": "2021.08.02",
     "changes": [
       {
         "description": "Improve inputs documentation and organization.",
@@ -74,7 +74,7 @@
     ]
   },
   {
-    "date": "2021-10-26",
+    "date": "2021.10.26",
     "changes": [
       {
         "description": "Standardize blueprint structure and input naming across the collection. Improve blueprint documentation. No functionality change.",
@@ -83,7 +83,7 @@
     ]
   },
   {
-    "date": "2022-08-08",
+    "date": "2022.08.08",
     "changes": [
       {
         "description": "Optimize characters usage for the `helper_last_controller_event` text input.",
@@ -92,7 +92,7 @@
     ]
   },
   {
-    "date": "2025-02-13",
+    "date": "2025.02.13",
     "changes": [
       {
         "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The `controller_entity` input is deprecated and `controller_device` is now mandatory. Remove `controller_entity` from your automation and configure `controller_device` with your controller device ID. (Thanks [@yarafie](https://github.com/yarafie))",
@@ -101,7 +101,7 @@
     ]
   },
   {
-    "date": "2025-03-20",
+    "date": "2025.03.20",
     "changes": [
       {
         "description": "Standardize input naming format for controller devices and virtual button actions. No functionality changes.",
@@ -110,7 +110,7 @@
     ]
   },
   {
-    "date": "2025-04-19",
+    "date": "2025.04.19",
     "changes": [
       {
         "description": "Improve Last Controller Event Helper JSON Regex with more lenient matching.",

--- a/blueprints/controllers/ikea_ictc_g_1/ikea_ictc_g_1.yaml
+++ b/blueprints/controllers/ikea_ictc_g_1/ikea_ictc_g_1.yaml
@@ -140,6 +140,8 @@ blueprint:
           step: 10
 # Automation schema
 variables:
+  ahb_version: 2025.11.04
+  ahb_author: EPMatt
   # convert input tags to variables, to be used in templates
   integration: !input integration
   rotate_left_loop: !input rotate_left_loop

--- a/blueprints/controllers/ikea_ictc_g_1/ikea_ictc_g_1.yaml
+++ b/blueprints/controllers/ikea_ictc_g_1/ikea_ictc_g_1.yaml
@@ -141,7 +141,7 @@ blueprint:
 # Automation schema
 variables:
   ahb_version: 2025.11.04
-  ahb_author: EPMatt
+  ahb_maintainers: [EPMatt]
   # convert input tags to variables, to be used in templates
   integration: !input integration
   rotate_left_loop: !input rotate_left_loop

--- a/blueprints/controllers/osram_ac025xx00nj/changelog.json
+++ b/blueprints/controllers/osram_ac025xx00nj/changelog.json
@@ -1,6 +1,6 @@
 [
   {
-    "date": "2021-05-18",
+    "date": "2021.05.18",
     "changes": [
       {
         "description": "First blueprint version 🎉",
@@ -9,7 +9,7 @@
     ]
   },
   {
-    "date": "2021-05-26",
+    "date": "2021.05.26",
     "changes": [
       {
         "description": "Fix Zigbee2MQTT reporting null state changes.",
@@ -18,7 +18,7 @@
     ]
   },
   {
-    "date": "2021-08-02",
+    "date": "2021.08.02",
     "changes": [
       {
         "description": "Improve inputs documentation and organization.",
@@ -27,7 +27,7 @@
     ]
   },
   {
-    "date": "2021-10-26",
+    "date": "2021.10.26",
     "changes": [
       {
         "description": "Standardize blueprint structure and input naming across the collection. Improve blueprint documentation. No functionality change.",
@@ -36,7 +36,7 @@
     ]
   },
   {
-    "date": "2022-08-08",
+    "date": "2022.08.08",
     "changes": [
       {
         "description": "Optimize characters usage for the `helper_last_controller_event` text input.",
@@ -45,7 +45,7 @@
     ]
   },
   {
-    "date": "2025-01-05",
+    "date": "2025.01.05",
     "changes": [
       {
         "description": "Update actions mapping to align with the latest Zigbee2MQTT documentation for the device. (Thanks [@alexdelprete](https://github.com/alexdelprete))",
@@ -58,7 +58,7 @@
     ]
   },
   {
-    "date": "2025-02-13",
+    "date": "2025.02.13",
     "changes": [
       {
         "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The `controller_entity` input is deprecated and `controller_device` is now mandatory. Remove `controller_entity` from your automation and configure `controller_device` with your controller device ID. (Thanks [@yarafie](https://github.com/yarafie))",
@@ -67,7 +67,7 @@
     ]
   },
   {
-    "date": "2025-03-20",
+    "date": "2025.03.20",
     "changes": [
       {
         "description": "Standardize input naming format for controller devices and virtual button actions. No functionality changes.",
@@ -76,7 +76,7 @@
     ]
   },
   {
-    "date": "2025-04-06",
+    "date": "2025.04.06",
     "changes": [
       {
         "description": "Fix double-click detection logic. (Thanks [@danleongjy](https://github.com/danleongjy))",
@@ -85,7 +85,7 @@
     ]
   },
   {
-    "date": "2025-04-19",
+    "date": "2025.04.19",
     "changes": [
       {
         "description": "Improve Last Controller Event Helper JSON Regex with more lenient matching.",

--- a/blueprints/controllers/osram_ac025xx00nj/osram_ac025xx00nj.yaml
+++ b/blueprints/controllers/osram_ac025xx00nj/osram_ac025xx00nj.yaml
@@ -237,6 +237,8 @@ blueprint:
           step: 10
 # Automation schema
 variables:
+  ahb_version: 2025.11.04
+  ahb_author: EPMatt
   # convert input tags to variables, to be used in templates
   integration: !input integration
   button_up_long_loop: !input button_up_long_loop

--- a/blueprints/controllers/osram_ac025xx00nj/osram_ac025xx00nj.yaml
+++ b/blueprints/controllers/osram_ac025xx00nj/osram_ac025xx00nj.yaml
@@ -238,7 +238,7 @@ blueprint:
 # Automation schema
 variables:
   ahb_version: 2025.11.04
-  ahb_author: EPMatt
+  ahb_maintainers: [EPMatt]
   # convert input tags to variables, to be used in templates
   integration: !input integration
   button_up_long_loop: !input button_up_long_loop

--- a/blueprints/controllers/philips_324131092621/changelog.json
+++ b/blueprints/controllers/philips_324131092621/changelog.json
@@ -1,6 +1,6 @@
 [
   {
-    "date": "2021-03-27",
+    "date": "2021.03.27",
     "changes": [
       {
         "description": "First blueprint version 🎉",
@@ -9,7 +9,7 @@
     ]
   },
   {
-    "date": "2021-04-19",
+    "date": "2021.04.19",
     "changes": [
       {
         "description": "Fix double press events not being detected with deCONZ.",
@@ -18,7 +18,7 @@
     ]
   },
   {
-    "date": "2021-04-23",
+    "date": "2021.04.23",
     "changes": [
       {
         "description": "Fix deCONZ events not being recognized.",
@@ -27,7 +27,7 @@
     ]
   },
   {
-    "date": "2021-05-26",
+    "date": "2021.05.26",
     "changes": [
       {
         "description": "Make `helper_last_controller_event` a mandatory input to simplify setup and enable future advanced features. When updating, provide a dedicated input_text entity for this input.",
@@ -52,7 +52,7 @@
     ]
   },
   {
-    "date": "2021-08-02",
+    "date": "2021.08.02",
     "changes": [
       {
         "description": "Improve inputs documentation and organization.",
@@ -61,7 +61,7 @@
     ]
   },
   {
-    "date": "2021-10-26",
+    "date": "2021.10.26",
     "changes": [
       {
         "description": "Standardize blueprint structure and input naming across the collection. Improve blueprint documentation. No functionality change.",
@@ -70,7 +70,7 @@
     ]
   },
   {
-    "date": "2021-11-19",
+    "date": "2021.11.19",
     "changes": [
       {
         "description": "Fix controller events not being recognized when using ZHA.",
@@ -79,7 +79,7 @@
     ]
   },
   {
-    "date": "2022-08-08",
+    "date": "2022.08.08",
     "changes": [
       {
         "description": "Optimize characters usage for the `helper_last_controller_event` text input.",
@@ -88,7 +88,7 @@
     ]
   },
   {
-    "date": "2025-02-13",
+    "date": "2025.02.13",
     "changes": [
       {
         "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The `controller_entity` input is deprecated and `controller_device` is now mandatory. Remove `controller_entity` from your automation and configure `controller_device` with your controller device ID. (Thanks [@yarafie](https://github.com/yarafie))",
@@ -97,7 +97,7 @@
     ]
   },
   {
-    "date": "2025-03-20",
+    "date": "2025.03.20",
     "changes": [
       {
         "description": "Standardize input naming format for controller devices and virtual button actions. No functionality changes.",
@@ -106,7 +106,7 @@
     ]
   },
   {
-    "date": "2025-04-06",
+    "date": "2025.04.06",
     "changes": [
       {
         "description": "Fix double-click detection logic. (Thanks [@danleongjy](https://github.com/danleongjy))",
@@ -115,7 +115,7 @@
     ]
   },
   {
-    "date": "2025-04-19",
+    "date": "2025.04.19",
     "changes": [
       {
         "description": "Improve Last Controller Event Helper JSON Regex with more lenient matching.",

--- a/blueprints/controllers/philips_324131092621/philips_324131092621.yaml
+++ b/blueprints/controllers/philips_324131092621/philips_324131092621.yaml
@@ -286,7 +286,7 @@ blueprint:
 # Automation schema
 variables:
   ahb_version: 2025.11.04
-  ahb_author: EPMatt
+  ahb_maintainers: [EPMatt]
   # convert input tags to variables, to be used in templates
   integration: !input integration
   button_on_long_loop: !input button_on_long_loop

--- a/blueprints/controllers/philips_324131092621/philips_324131092621.yaml
+++ b/blueprints/controllers/philips_324131092621/philips_324131092621.yaml
@@ -285,6 +285,8 @@ blueprint:
           step: 10
 # Automation schema
 variables:
+  ahb_version: 2025.11.04
+  ahb_author: EPMatt
   # convert input tags to variables, to be used in templates
   integration: !input integration
   button_on_long_loop: !input button_on_long_loop

--- a/blueprints/controllers/philips_8718699693985/changelog.json
+++ b/blueprints/controllers/philips_8718699693985/changelog.json
@@ -1,6 +1,6 @@
 [
   {
-    "date": "2021-07-14",
+    "date": "2021.07.14",
     "changes": [
       {
         "description": "First blueprint version 🎉",
@@ -9,7 +9,7 @@
     ]
   },
   {
-    "date": "2021-08-02",
+    "date": "2021.08.02",
     "changes": [
       {
         "description": "Improve inputs documentation and organization.",
@@ -18,7 +18,7 @@
     ]
   },
   {
-    "date": "2021-10-26",
+    "date": "2021.10.26",
     "changes": [
       {
         "description": "Standardize blueprint structure and input naming across the collection. Improve blueprint documentation. No functionality change.",
@@ -27,7 +27,7 @@
     ]
   },
   {
-    "date": "2022-08-08",
+    "date": "2022.08.08",
     "changes": [
       {
         "description": "Optimize characters usage for the `helper_last_controller_event` text input.",
@@ -36,7 +36,7 @@
     ]
   },
   {
-    "date": "2025-01-05",
+    "date": "2025.01.05",
     "changes": [
       {
         "description": "Add support for Zigbee2MQTT. (Thanks [@alexdelprete](https://github.com/alexdelprete))",
@@ -49,7 +49,7 @@
     ]
   },
   {
-    "date": "2025-02-13",
+    "date": "2025.02.13",
     "changes": [
       {
         "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The `controller_entity` input is deprecated and `controller_device` is now mandatory. Remove `controller_entity` from your automation and configure `controller_device` with your controller device ID. (Thanks [@yarafie](https://github.com/yarafie))",
@@ -58,7 +58,7 @@
     ]
   },
   {
-    "date": "2025-03-20",
+    "date": "2025.03.20",
     "changes": [
       {
         "description": "Standardize input naming format for controller devices and virtual button actions. No functionality changes.",
@@ -67,7 +67,7 @@
     ]
   },
   {
-    "date": "2025-04-06",
+    "date": "2025.04.06",
     "changes": [
       {
         "description": "Fix double-click detection logic. (Thanks [@danleongjy](https://github.com/danleongjy))",
@@ -76,7 +76,7 @@
     ]
   },
   {
-    "date": "2025-04-19",
+    "date": "2025.04.19",
     "changes": [
       {
         "description": "Improve Last Controller Event Helper JSON Regex with more lenient matching.",

--- a/blueprints/controllers/philips_8718699693985/philips_8718699693985.yaml
+++ b/blueprints/controllers/philips_8718699693985/philips_8718699693985.yaml
@@ -142,7 +142,7 @@ blueprint:
 # Automation schema
 variables:
   ahb_version: 2025.11.04
-  ahb_author: EPMatt
+  ahb_maintainers: [EPMatt]
   # convert input tags to variables, to be used in templates
   integration: !input integration
   button_long_loop: !input button_long_loop

--- a/blueprints/controllers/philips_8718699693985/philips_8718699693985.yaml
+++ b/blueprints/controllers/philips_8718699693985/philips_8718699693985.yaml
@@ -141,6 +141,8 @@ blueprint:
           step: 10
 # Automation schema
 variables:
+  ahb_version: 2025.11.04
+  ahb_author: EPMatt
   # convert input tags to variables, to be used in templates
   integration: !input integration
   button_long_loop: !input button_long_loop

--- a/blueprints/controllers/philips_929002398602/changelog.json
+++ b/blueprints/controllers/philips_929002398602/changelog.json
@@ -1,6 +1,6 @@
 [
   {
-    "date": "2021-11-21",
+    "date": "2021.11.21",
     "changes": [
       {
         "description": "First blueprint version 🎉",
@@ -9,7 +9,7 @@
     ]
   },
   {
-    "date": "2022-07-22",
+    "date": "2022.07.22",
     "changes": [
       {
         "description": "Fix short press actions not being triggered by quick button clicks.",
@@ -18,7 +18,7 @@
     ]
   },
   {
-    "date": "2022-08-08",
+    "date": "2022.08.08",
     "changes": [
       {
         "description": "Optimize characters usage for the `helper_last_controller_event` text input.",
@@ -27,7 +27,7 @@
     ]
   },
   {
-    "date": "2025-02-13",
+    "date": "2025.02.13",
     "changes": [
       {
         "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The `controller_entity` input is deprecated and `controller_device` is now mandatory. Remove `controller_entity` from your automation and configure `controller_device` with your controller device ID. (Thanks [@yarafie](https://github.com/yarafie))",
@@ -36,7 +36,7 @@
     ]
   },
   {
-    "date": "2025-03-20",
+    "date": "2025.03.20",
     "changes": [
       {
         "description": "Standardize input naming format for controller devices and virtual button actions. No functionality changes.",
@@ -45,7 +45,7 @@
     ]
   },
   {
-    "date": "2025-04-02",
+    "date": "2025.04.02",
     "changes": [
       {
         "description": "Fix trigger_delta regex with optional whitespacing. (Thanks [@TTvanWillegen](https://github.com/TTvanWillegen))",
@@ -54,7 +54,7 @@
     ]
   },
   {
-    "date": "2025-04-06",
+    "date": "2025.04.06",
     "changes": [
       {
         "description": "Fix double-click detection logic. (Thanks [@danleongjy](https://github.com/danleongjy))",
@@ -63,7 +63,7 @@
     ]
   },
   {
-    "date": "2025-04-19",
+    "date": "2025.04.19",
     "changes": [
       {
         "description": "Improve Last Controller Event Helper JSON Regex with more lenient matching.",

--- a/blueprints/controllers/philips_929002398602/philips_929002398602.yaml
+++ b/blueprints/controllers/philips_929002398602/philips_929002398602.yaml
@@ -285,7 +285,7 @@ blueprint:
 # Automation schema
 variables:
   ahb_version: 2025.11.04
-  ahb_author: EPMatt
+  ahb_maintainers: [EPMatt]
   # convert input tags to variables, to be used in templates
   integration: !input integration
   button_on_long_loop: !input button_on_long_loop

--- a/blueprints/controllers/philips_929002398602/philips_929002398602.yaml
+++ b/blueprints/controllers/philips_929002398602/philips_929002398602.yaml
@@ -284,6 +284,8 @@ blueprint:
           step: 10
 # Automation schema
 variables:
+  ahb_version: 2025.11.04
+  ahb_author: EPMatt
   # convert input tags to variables, to be used in templates
   integration: !input integration
   button_on_long_loop: !input button_on_long_loop

--- a/blueprints/controllers/sonoff_snzb01/changelog.json
+++ b/blueprints/controllers/sonoff_snzb01/changelog.json
@@ -1,6 +1,6 @@
 [
   {
-    "date": "2022-07-30",
+    "date": "2022.07.30",
     "changes": [
       {
         "description": "First blueprint version 🎉",
@@ -9,7 +9,7 @@
     ]
   },
   {
-    "date": "2022-08-08",
+    "date": "2022.08.08",
     "changes": [
       {
         "description": "Optimize characters usage for the `helper_last_controller_event` text input.",
@@ -18,7 +18,7 @@
     ]
   },
   {
-    "date": "2025-02-13",
+    "date": "2025.02.13",
     "changes": [
       {
         "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The `controller_entity` input is deprecated and `controller_device` is now mandatory. Remove `controller_entity` from your automation and configure `controller_device` with your controller device ID. (Thanks [@yarafie](https://github.com/yarafie))",
@@ -27,7 +27,7 @@
     ]
   },
   {
-    "date": "2025-04-19",
+    "date": "2025.04.19",
     "changes": [
       {
         "description": "Improve Last Controller Event Helper JSON Regex with more lenient matching.",

--- a/blueprints/controllers/sonoff_snzb01/sonoff_snzb01.yaml
+++ b/blueprints/controllers/sonoff_snzb01/sonoff_snzb01.yaml
@@ -98,6 +98,8 @@ blueprint:
           step: 10
 # Automation schema
 variables:
+  ahb_version: 2025.11.04
+  ahb_author: EPMatt
   # convert input tags to variables, to be used in templates
   integration: !input integration
   helper_last_controller_event: !input helper_last_controller_event

--- a/blueprints/controllers/sonoff_snzb01/sonoff_snzb01.yaml
+++ b/blueprints/controllers/sonoff_snzb01/sonoff_snzb01.yaml
@@ -99,7 +99,7 @@ blueprint:
 # Automation schema
 variables:
   ahb_version: 2025.11.04
-  ahb_author: EPMatt
+  ahb_maintainers: [EPMatt]
   # convert input tags to variables, to be used in templates
   integration: !input integration
   helper_last_controller_event: !input helper_last_controller_event

--- a/blueprints/controllers/tuya_ERS-10TZBVK-AA/changelog.json
+++ b/blueprints/controllers/tuya_ERS-10TZBVK-AA/changelog.json
@@ -1,6 +1,6 @@
 [
   {
-    "date": "2025-03-29",
+    "date": "2025.03.29",
     "changes": [
       {
         "description": "Initial release. (Thanks [@yarafie](https://github.com/yarafie)) 🎉",

--- a/blueprints/controllers/tuya_ERS-10TZBVK-AA/tuya_ERS-10TZBVK-AA.yaml
+++ b/blueprints/controllers/tuya_ERS-10TZBVK-AA/tuya_ERS-10TZBVK-AA.yaml
@@ -234,7 +234,7 @@ blueprint:
 # Automation schema
 variables:
   ahb_version: 2025.11.04
-  ahb_author: EPMatt
+  ahb_maintainers: [EPMatt]
   # Controller ID
   controller_id: !input controller_device
   # integration id used to select items in the action mapping

--- a/blueprints/controllers/tuya_ERS-10TZBVK-AA/tuya_ERS-10TZBVK-AA.yaml
+++ b/blueprints/controllers/tuya_ERS-10TZBVK-AA/tuya_ERS-10TZBVK-AA.yaml
@@ -233,6 +233,8 @@ blueprint:
 #
 # Automation schema
 variables:
+  ahb_version: 2025.11.04
+  ahb_author: EPMatt
   # Controller ID
   controller_id: !input controller_device
   # integration id used to select items in the action mapping

--- a/blueprints/controllers/xiaomi_wxcjkg11lm/changelog.json
+++ b/blueprints/controllers/xiaomi_wxcjkg11lm/changelog.json
@@ -1,6 +1,6 @@
 [
   {
-    "date": "2021-12-03",
+    "date": "2021.12.03",
     "changes": [
       {
         "description": "First blueprint version 🎉",
@@ -9,7 +9,7 @@
     ]
   },
   {
-    "date": "2022-08-08",
+    "date": "2022.08.08",
     "changes": [
       {
         "description": "Optimize characters usage for the `helper_last_controller_event` text input.",
@@ -18,7 +18,7 @@
     ]
   },
   {
-    "date": "2025-02-13",
+    "date": "2025.02.13",
     "changes": [
       {
         "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The `controller_entity` input is deprecated and `controller_device` is now mandatory. Remove `controller_entity` from your automation and configure `controller_device` with your controller device ID. (Thanks [@yarafie](https://github.com/yarafie))",
@@ -27,7 +27,7 @@
     ]
   },
   {
-    "date": "2025-03-20",
+    "date": "2025.03.20",
     "changes": [
       {
         "description": "Standardize input naming format for controller devices and virtual button actions. No functionality changes.",
@@ -36,7 +36,7 @@
     ]
   },
   {
-    "date": "2025-04-19",
+    "date": "2025.04.19",
     "changes": [
       {
         "description": "Improve Last Controller Event Helper JSON Regex with more lenient matching.",

--- a/blueprints/controllers/xiaomi_wxcjkg11lm/xiaomi_wxcjkg11lm.yaml
+++ b/blueprints/controllers/xiaomi_wxcjkg11lm/xiaomi_wxcjkg11lm.yaml
@@ -178,7 +178,7 @@ blueprint:
 # Automation schema
 variables:
   ahb_version: 2025.11.04
-  ahb_author: EPMatt
+  ahb_maintainers: [EPMatt]
   # convert input tags to variables, to be used in templates
   integration: !input integration
   button_1_long_loop: !input button_1_long_loop

--- a/blueprints/controllers/xiaomi_wxcjkg11lm/xiaomi_wxcjkg11lm.yaml
+++ b/blueprints/controllers/xiaomi_wxcjkg11lm/xiaomi_wxcjkg11lm.yaml
@@ -177,6 +177,8 @@ blueprint:
           step: 10
 # Automation schema
 variables:
+  ahb_version: 2025.11.04
+  ahb_author: EPMatt
   # convert input tags to variables, to be used in templates
   integration: !input integration
   button_1_long_loop: !input button_1_long_loop

--- a/blueprints/controllers/xiaomi_wxcjkg12lm/changelog.json
+++ b/blueprints/controllers/xiaomi_wxcjkg12lm/changelog.json
@@ -1,6 +1,6 @@
 [
   {
-    "date": "2021-12-03",
+    "date": "2021.12.03",
     "changes": [
       {
         "description": "First blueprint version 🎉",
@@ -9,7 +9,7 @@
     ]
   },
   {
-    "date": "2022-08-08",
+    "date": "2022.08.08",
     "changes": [
       {
         "description": "Optimize characters usage for the `helper_last_controller_event` text input.",
@@ -18,7 +18,7 @@
     ]
   },
   {
-    "date": "2025-02-13",
+    "date": "2025.02.13",
     "changes": [
       {
         "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The `controller_entity` input is deprecated and `controller_device` is now mandatory. Remove `controller_entity` from your automation and configure `controller_device` with your controller device ID. (Thanks [@yarafie](https://github.com/yarafie))",
@@ -27,7 +27,7 @@
     ]
   },
   {
-    "date": "2025-03-20",
+    "date": "2025.03.20",
     "changes": [
       {
         "description": "Standardize input naming format for controller devices and virtual button actions. No functionality changes.",
@@ -36,7 +36,7 @@
     ]
   },
   {
-    "date": "2025-04-19",
+    "date": "2025.04.19",
     "changes": [
       {
         "description": "Improve Last Controller Event Helper JSON Regex with more lenient matching.",

--- a/blueprints/controllers/xiaomi_wxcjkg12lm/xiaomi_wxcjkg12lm.yaml
+++ b/blueprints/controllers/xiaomi_wxcjkg12lm/xiaomi_wxcjkg12lm.yaml
@@ -273,6 +273,8 @@ blueprint:
           step: 10
 # Automation schema
 variables:
+  ahb_version: 2025.11.04
+  ahb_author: EPMatt
   # convert input tags to variables, to be used in templates
   integration: !input integration
   button_1_long_loop: !input button_1_long_loop

--- a/blueprints/controllers/xiaomi_wxcjkg12lm/xiaomi_wxcjkg12lm.yaml
+++ b/blueprints/controllers/xiaomi_wxcjkg12lm/xiaomi_wxcjkg12lm.yaml
@@ -274,7 +274,7 @@ blueprint:
 # Automation schema
 variables:
   ahb_version: 2025.11.04
-  ahb_author: EPMatt
+  ahb_maintainers: [EPMatt]
   # convert input tags to variables, to be used in templates
   integration: !input integration
   button_1_long_loop: !input button_1_long_loop

--- a/blueprints/controllers/xiaomi_wxcjkg13lm/changelog.json
+++ b/blueprints/controllers/xiaomi_wxcjkg13lm/changelog.json
@@ -1,6 +1,6 @@
 [
   {
-    "date": "2021-12-03",
+    "date": "2021.12.03",
     "changes": [
       {
         "description": "First blueprint version 🎉",
@@ -9,7 +9,7 @@
     ]
   },
   {
-    "date": "2022-08-08",
+    "date": "2022.08.08",
     "changes": [
       {
         "description": "Optimize characters usage for the `helper_last_controller_event` text input.",
@@ -18,7 +18,7 @@
     ]
   },
   {
-    "date": "2025-02-13",
+    "date": "2025.02.13",
     "changes": [
       {
         "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The `controller_entity` input is deprecated and `controller_device` is now mandatory. Remove `controller_entity` from your automation and configure `controller_device` with your controller device ID. (Thanks [@yarafie](https://github.com/yarafie))",
@@ -27,7 +27,7 @@
     ]
   },
   {
-    "date": "2025-03-20",
+    "date": "2025.03.20",
     "changes": [
       {
         "description": "Standardize input naming format for controller devices and virtual button actions. No functionality changes.",
@@ -36,7 +36,7 @@
     ]
   },
   {
-    "date": "2025-04-19",
+    "date": "2025.04.19",
     "changes": [
       {
         "description": "Improve Last Controller Event Helper JSON Regex with more lenient matching.",

--- a/blueprints/controllers/xiaomi_wxcjkg13lm/xiaomi_wxcjkg13lm.yaml
+++ b/blueprints/controllers/xiaomi_wxcjkg13lm/xiaomi_wxcjkg13lm.yaml
@@ -370,7 +370,7 @@ blueprint:
 # Automation schema
 variables:
   ahb_version: 2025.11.04
-  ahb_author: EPMatt
+  ahb_maintainers: [EPMatt]
   # convert input tags to variables, to be used in templates
   integration: !input integration
   button_1_long_loop: !input button_1_long_loop

--- a/blueprints/controllers/xiaomi_wxcjkg13lm/xiaomi_wxcjkg13lm.yaml
+++ b/blueprints/controllers/xiaomi_wxcjkg13lm/xiaomi_wxcjkg13lm.yaml
@@ -369,6 +369,8 @@ blueprint:
           step: 10
 # Automation schema
 variables:
+  ahb_version: 2025.11.04
+  ahb_author: EPMatt
   # convert input tags to variables, to be used in templates
   integration: !input integration
   button_1_long_loop: !input button_1_long_loop

--- a/blueprints/controllers/xiaomi_wxkg11lm/changelog.json
+++ b/blueprints/controllers/xiaomi_wxkg11lm/changelog.json
@@ -1,6 +1,6 @@
 [
   {
-    "date": "2022-07-22",
+    "date": "2022.07.22",
     "changes": [
       {
         "description": "First blueprint version 🎉",
@@ -9,7 +9,7 @@
     ]
   },
   {
-    "date": "2022-08-08",
+    "date": "2022.08.08",
     "changes": [
       {
         "description": "Optimize characters usage for the `helper_last_controller_event` text input.",
@@ -18,7 +18,7 @@
     ]
   },
   {
-    "date": "2025-02-13",
+    "date": "2025.02.13",
     "changes": [
       {
         "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The `controller_entity` input is deprecated and `controller_device` is now mandatory. Remove `controller_entity` from your automation and configure `controller_device` with your controller device ID. (Thanks [@yarafie](https://github.com/yarafie))",
@@ -27,7 +27,7 @@
     ]
   },
   {
-    "date": "2025-02-16",
+    "date": "2025.02.16",
     "changes": [
       {
         "description": "Add support for Xiaomi WXKG01LM Mi Wireless Switch and rename Xiaomi WXKG11LM Aqara Wireless Switch Mini to Aqara WXKG11LM Wireless Mini Switch. (Thanks [@yarafie](https://github.com/yarafie))",
@@ -36,7 +36,7 @@
     ]
   },
   {
-    "date": "2025-03-20",
+    "date": "2025.03.20",
     "changes": [
       {
         "description": "Standardize input naming format for controller devices and virtual button actions. No functionality changes.",
@@ -45,7 +45,7 @@
     ]
   },
   {
-    "date": "2025-04-19",
+    "date": "2025.04.19",
     "changes": [
       {
         "description": "Improve Last Controller Event Helper JSON Regex with more lenient matching.",

--- a/blueprints/controllers/xiaomi_wxkg11lm/xiaomi_wxkg11lm.yaml
+++ b/blueprints/controllers/xiaomi_wxkg11lm/xiaomi_wxkg11lm.yaml
@@ -134,7 +134,7 @@ blueprint:
 # Automation schema
 variables:
   ahb_version: 2025.11.04
-  ahb_author: EPMatt
+  ahb_maintainers: [EPMatt]
   # convert input tags to variables, to be used in templates
   integration: !input integration
   button_long_loop: !input button_long_loop

--- a/blueprints/controllers/xiaomi_wxkg11lm/xiaomi_wxkg11lm.yaml
+++ b/blueprints/controllers/xiaomi_wxkg11lm/xiaomi_wxkg11lm.yaml
@@ -133,6 +133,8 @@ blueprint:
           step: 10
 # Automation schema
 variables:
+  ahb_version: 2025.11.04
+  ahb_author: EPMatt
   # convert input tags to variables, to be used in templates
   integration: !input integration
   button_long_loop: !input button_long_loop

--- a/blueprints/hooks/cover/changelog.json
+++ b/blueprints/hooks/cover/changelog.json
@@ -1,6 +1,6 @@
 [
   {
-    "date": "2021-03-26",
+    "date": "2021.03.26",
     "changes": [
       {
         "description": "First blueprint version 🎉",
@@ -9,7 +9,7 @@
     ]
   },
   {
-    "date": "2021-04-19",
+    "date": "2021.04.19",
     "changes": [
       {
         "description": "Remove unused variable and fix warnings for undefined variables in Home Assistant Core >=2021.4.0.",
@@ -18,7 +18,7 @@
     ]
   },
   {
-    "date": "2021-08-02",
+    "date": "2021.08.02",
     "changes": [
       {
         "description": "Improve inputs documentation and organization.",
@@ -27,7 +27,7 @@
     ]
   },
   {
-    "date": "2021-10-26",
+    "date": "2021.10.26",
     "changes": [
       {
         "description": "Standardize blueprint structure and input naming across the collection.",
@@ -48,7 +48,7 @@
     ]
   },
   {
-    "date": "2021-10-29",
+    "date": "2021.10.29",
     "changes": [
       {
         "description": "Add support for IKEA E1766 TRÅDFRI Open/Close Remote.",
@@ -57,7 +57,7 @@
     ]
   },
   {
-    "date": "2021-12-03",
+    "date": "2021.12.03",
     "changes": [
       {
         "description": "Add support for Xiaomi WXCJKG11LM, WXCJKG12LM, and WXCJKG13LM.",
@@ -66,7 +66,7 @@
     ]
   },
   {
-    "date": "2022-07-22",
+    "date": "2022.07.22",
     "changes": [
       {
         "description": "Add support for Xiaomi WXKG11LM.",
@@ -75,7 +75,7 @@
     ]
   },
   {
-    "date": "2022-07-30",
+    "date": "2022.07.30",
     "changes": [
       {
         "description": "Add support for SONOFF SNZB-01.",
@@ -84,7 +84,7 @@
     ]
   },
   {
-    "date": "2025-02-13",
+    "date": "2025.02.13",
     "changes": [
       {
         "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The `controller_entity` input is deprecated and `controller_device` is now mandatory. Remove `controller_entity` from your automation and configure `controller_device` with your controller device ID. (Thanks [@yarafie](https://github.com/yarafie))",
@@ -93,7 +93,7 @@
     ]
   },
   {
-    "date": "2025-02-16",
+    "date": "2025.02.16",
     "changes": [
       {
         "description": "Add support for Xiaomi WXKG01LM Mi Wireless Switch and rename Xiaomi WXKG11LM Aqara Wireless Switch Mini to Aqara WXKG11LM Wireless Mini Switch. Update the `controller_model` input accordingly if needed.",
@@ -102,7 +102,7 @@
     ]
   },
   {
-    "date": "2025-03-20",
+    "date": "2025.03.20",
     "changes": [
       {
         "description": "Add support for IKEA E2201 RODRET Dimmer. (Thanks [@yarafie](https://github.com/yarafie))",
@@ -111,7 +111,7 @@
     ]
   },
   {
-    "date": "2025-03-26",
+    "date": "2025.03.26",
     "changes": [
       {
         "description": "Add support for IKEA E2213 SOMRIG shortcut button. (Thanks [@yarafie](https://github.com/yarafie))",
@@ -120,7 +120,7 @@
     ]
   },
   {
-    "date": "2025-03-28",
+    "date": "2025.03.28",
     "changes": [
       {
         "description": "Add support for IKEA E2123 SYMFONISK sound remote, gen 2. (Thanks [@yarafie](https://github.com/yarafie))",

--- a/blueprints/hooks/cover/cover.yaml
+++ b/blueprints/hooks/cover/cover.yaml
@@ -60,7 +60,7 @@ blueprint:
 # Automation schema
 variables:
   ahb_version: 2025.11.04
-  ahb_author: EPMatt
+  ahb_maintainers: [EPMatt]
   # convert blueprint inputs into variables to be used in templates
   controller_model: !input controller_model
   # supported controllers and mappings

--- a/blueprints/hooks/cover/cover.yaml
+++ b/blueprints/hooks/cover/cover.yaml
@@ -59,6 +59,8 @@ blueprint:
           domain: cover
 # Automation schema
 variables:
+  ahb_version: 2025.11.04
+  ahb_author: EPMatt
   # convert blueprint inputs into variables to be used in templates
   controller_model: !input controller_model
   # supported controllers and mappings

--- a/blueprints/hooks/light/changelog.json
+++ b/blueprints/hooks/light/changelog.json
@@ -1,6 +1,6 @@
 [
   {
-    "date": "2021-03-04",
+    "date": "2021.03.04",
     "changes": [
       {
         "description": "First blueprint version 🎉",
@@ -9,7 +9,7 @@
     ]
   },
   {
-    "date": "2021-03-07",
+    "date": "2021.03.07",
     "changes": [
       {
         "description": "Add support for IKEA E1744 SYMFONISK Rotary Remote.",
@@ -18,7 +18,7 @@
     ]
   },
   {
-    "date": "2021-03-14",
+    "date": "2021.03.14",
     "changes": [
       {
         "description": "Add support for IKEA E1812 Shortcut button and fix IKEA E1743 naming.",
@@ -27,7 +27,7 @@
     ]
   },
   {
-    "date": "2021-03-25",
+    "date": "2021.03.25",
     "changes": [
       {
         "description": "Update action mapping for IKEA E1744. If you're using this Hook with an IKEA E1744, please update the corresponding Controller blueprint as well.",
@@ -36,7 +36,7 @@
     ]
   },
   {
-    "date": "2021-03-26",
+    "date": "2021.03.26",
     "changes": [
       {
         "description": "Set minimum and maximum light brightness.",
@@ -53,7 +53,7 @@
     ]
   },
   {
-    "date": "2021-03-27",
+    "date": "2021.03.27",
     "changes": [
       {
         "description": "Add support for Philips Hue Dimmer switch.",
@@ -62,7 +62,7 @@
     ]
   },
   {
-    "date": "2021-04-06",
+    "date": "2021.04.06",
     "changes": [
       {
         "description": "Fix light color modes preventing configuration of automations with color temperature control.",
@@ -71,7 +71,7 @@
     ]
   },
   {
-    "date": "2021-04-15",
+    "date": "2021.04.15",
     "changes": [
       {
         "description": "Add smooth power on/off features.",
@@ -88,7 +88,7 @@
     ]
   },
   {
-    "date": "2021-04-19",
+    "date": "2021.04.19",
     "changes": [
       {
         "description": "Remove unused variable and fix warnings for undefined variables in Home Assistant Core >=2021.4.0.",
@@ -97,7 +97,7 @@
     ]
   },
   {
-    "date": "2021-05-16",
+    "date": "2021.05.16",
     "changes": [
       {
         "description": "Add support for OSRAM SMART+ Switch Mini.",
@@ -106,7 +106,7 @@
     ]
   },
   {
-    "date": "2021-07-03",
+    "date": "2021.07.03",
     "changes": [
       {
         "description": "Add support for Philips Hue Smart Button.",
@@ -115,7 +115,7 @@
     ]
   },
   {
-    "date": "2021-08-02",
+    "date": "2021.08.02",
     "changes": [
       {
         "description": "Improve inputs documentation and organization.",
@@ -124,7 +124,7 @@
     ]
   },
   {
-    "date": "2021-10-26",
+    "date": "2021.10.26",
     "changes": [
       {
         "description": "Standardize blueprint structure and input naming across the collection.",
@@ -153,7 +153,7 @@
     ]
   },
   {
-    "date": "2021-10-29",
+    "date": "2021.10.29",
     "changes": [
       {
         "description": "Add support for IKEA E1766 TRÅDFRI Open/Close Remote.",
@@ -162,7 +162,7 @@
     ]
   },
   {
-    "date": "2021-11-07",
+    "date": "2021.11.07",
     "changes": [
       {
         "description": "Add support for IKEA E2001/E2002 STYRBAR Remote control.",
@@ -179,7 +179,7 @@
     ]
   },
   {
-    "date": "2021-11-21",
+    "date": "2021.11.21",
     "changes": [
       {
         "description": "Add support for Philips 929002398602 Hue Dimmer switch v2.",
@@ -188,7 +188,7 @@
     ]
   },
   {
-    "date": "2021-12-03",
+    "date": "2021.12.03",
     "changes": [
       {
         "description": "Add support for Xiaomi WXCJKG11LM, WXCJKG12LM, and WXCJKG13LM.",
@@ -197,7 +197,7 @@
     ]
   },
   {
-    "date": "2021-12-05",
+    "date": "2021.12.05",
     "changes": [
       {
         "description": "Add secondary mapping for IKEA E2001/E2002.",
@@ -206,7 +206,7 @@
     ]
   },
   {
-    "date": "2022-07-22",
+    "date": "2022.07.22",
     "changes": [
       {
         "description": "Add support for Xiaomi WXKG11LM.",
@@ -215,7 +215,7 @@
     ]
   },
   {
-    "date": "2022-07-30",
+    "date": "2022.07.30",
     "changes": [
       {
         "description": "Add support for SONOFF SNZB-01.",
@@ -224,7 +224,7 @@
     ]
   },
   {
-    "date": "2025-02-13",
+    "date": "2025.02.13",
     "changes": [
       {
         "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The `controller_entity` input is deprecated and `controller_device` is now mandatory. Remove `controller_entity` from your automation and configure `controller_device` with your controller device ID. (Thanks [@yarafie](https://github.com/yarafie))",
@@ -233,7 +233,7 @@
     ]
   },
   {
-    "date": "2025-02-16",
+    "date": "2025.02.16",
     "changes": [
       {
         "description": "Add support for Xiaomi WXKG01LM Mi Wireless Switch and rename Xiaomi WXKG11LM Aqara Wireless Switch Mini to Aqara WXKG11LM Wireless Mini Switch. Update the `controller_model` input accordingly if needed.",
@@ -242,7 +242,7 @@
     ]
   },
   {
-    "date": "2025-03-18",
+    "date": "2025.03.18",
     "changes": [
       {
         "description": "Use min_brightness and max_brightness as conditions instead of \"while true\" loops. (Thanks [@Nicolai-](https://github.com/Nicolai-))",
@@ -251,7 +251,7 @@
     ]
   },
   {
-    "date": "2025-03-20",
+    "date": "2025.03.20",
     "changes": [
       {
         "description": "Add support for IKEA E2201 RODRET Dimmer. (Thanks [@yarafie](https://github.com/yarafie))",
@@ -260,7 +260,7 @@
     ]
   },
   {
-    "date": "2025-03-26",
+    "date": "2025.03.26",
     "changes": [
       {
         "description": "Add support for IKEA E2213 SOMRIG shortcut button. (Thanks [@yarafie](https://github.com/yarafie))",
@@ -269,7 +269,7 @@
     ]
   },
   {
-    "date": "2025-03-28",
+    "date": "2025.03.28",
     "changes": [
       {
         "description": "Add support for IKEA E2123 SYMFONISK sound remote, gen 2. (Thanks [@yarafie](https://github.com/yarafie))",
@@ -278,7 +278,7 @@
     ]
   },
   {
-    "date": "2025-03-29",
+    "date": "2025.03.29",
     "changes": [
       {
         "description": "Add support for Tuya ERS-10TZBVK-AA Smart knob. (Thanks [@yarafie](https://github.com/yarafie))",

--- a/blueprints/hooks/light/light.yaml
+++ b/blueprints/hooks/light/light.yaml
@@ -168,7 +168,7 @@ blueprint:
 # Automation schema
 variables:
   ahb_version: 2025.11.04
-  ahb_author: EPMatt
+  ahb_maintainers: [EPMatt]
   # convert blueprint inputs into variables to be used in templates
   controller_model: !input controller_model
   # supported controllers and mappings

--- a/blueprints/hooks/light/light.yaml
+++ b/blueprints/hooks/light/light.yaml
@@ -167,6 +167,8 @@ blueprint:
         boolean:
 # Automation schema
 variables:
+  ahb_version: 2025.11.04
+  ahb_author: EPMatt
   # convert blueprint inputs into variables to be used in templates
   controller_model: !input controller_model
   # supported controllers and mappings

--- a/blueprints/hooks/media_player/changelog.json
+++ b/blueprints/hooks/media_player/changelog.json
@@ -1,6 +1,6 @@
 [
   {
-    "date": "2021-03-04",
+    "date": "2021.03.04",
     "changes": [
       {
         "description": "First blueprint version 🎉",
@@ -9,7 +9,7 @@
     ]
   },
   {
-    "date": "2021-03-07",
+    "date": "2021.03.07",
     "changes": [
       {
         "description": "Add support for IKEA E1744 SYMFONISK Rotary Remote.",
@@ -18,7 +18,7 @@
     ]
   },
   {
-    "date": "2021-03-14",
+    "date": "2021.03.14",
     "changes": [
       {
         "description": "Add support for IKEA E1812 Shortcut button and fix IKEA E1743 naming.",
@@ -27,7 +27,7 @@
     ]
   },
   {
-    "date": "2021-03-25",
+    "date": "2021.03.25",
     "changes": [
       {
         "description": "Update action mapping for IKEA E1744. If you're using this Hook with an IKEA E1744, please update the corresponding Controller blueprint as well.",
@@ -36,7 +36,7 @@
     ]
   },
   {
-    "date": "2021-03-26",
+    "date": "2021.03.26",
     "changes": [
       {
         "description": "Add the ability to specify the number of steps from minimum to maximum volume for both short and long actions when controlling the media player.",
@@ -45,7 +45,7 @@
     ]
   },
   {
-    "date": "2021-03-27",
+    "date": "2021.03.27",
     "changes": [
       {
         "description": "Add support for Philips Hue Dimmer switch.",
@@ -54,7 +54,7 @@
     ]
   },
   {
-    "date": "2021-04-19",
+    "date": "2021.04.19",
     "changes": [
       {
         "description": "Remove unused variable and fix warnings for undefined variables in Home Assistant Core >=2021.4.0.",
@@ -63,7 +63,7 @@
     ]
   },
   {
-    "date": "2021-05-16",
+    "date": "2021.05.16",
     "changes": [
       {
         "description": "Add support for OSRAM SMART+ Switch Mini.",
@@ -72,7 +72,7 @@
     ]
   },
   {
-    "date": "2021-07-03",
+    "date": "2021.07.03",
     "changes": [
       {
         "description": "Add support for Philips Hue Smart Button.",
@@ -81,7 +81,7 @@
     ]
   },
   {
-    "date": "2021-08-02",
+    "date": "2021.08.02",
     "changes": [
       {
         "description": "Improve inputs documentation and organization.",
@@ -90,7 +90,7 @@
     ]
   },
   {
-    "date": "2021-10-26",
+    "date": "2021.10.26",
     "changes": [
       {
         "description": "Standardize blueprint structure and input naming across the collection.",
@@ -115,7 +115,7 @@
     ]
   },
   {
-    "date": "2021-10-29",
+    "date": "2021.10.29",
     "changes": [
       {
         "description": "Add support for IKEA E1766 TRÅDFRI Open/Close Remote.",
@@ -124,7 +124,7 @@
     ]
   },
   {
-    "date": "2021-11-07",
+    "date": "2021.11.07",
     "changes": [
       {
         "description": "Add support for IKEA E2001/E2002 STYRBAR Remote control.",
@@ -133,7 +133,7 @@
     ]
   },
   {
-    "date": "2021-11-21",
+    "date": "2021.11.21",
     "changes": [
       {
         "description": "Add support for Philips 929002398602 Hue Dimmer switch v2.",
@@ -142,7 +142,7 @@
     ]
   },
   {
-    "date": "2021-12-03",
+    "date": "2021.12.03",
     "changes": [
       {
         "description": "Add support for Xiaomi WXCJKG11LM, WXCJKG12LM, and WXCJKG13LM.",
@@ -151,7 +151,7 @@
     ]
   },
   {
-    "date": "2022-07-22",
+    "date": "2022.07.22",
     "changes": [
       {
         "description": "Add support for Xiaomi WXKG11LM.",
@@ -160,7 +160,7 @@
     ]
   },
   {
-    "date": "2022-07-30",
+    "date": "2022.07.30",
     "changes": [
       {
         "description": "Add support for SONOFF SNZB-01.",
@@ -169,7 +169,7 @@
     ]
   },
   {
-    "date": "2025-02-13",
+    "date": "2025.02.13",
     "changes": [
       {
         "description": "Migrate to Zigbee2MQTT MQTT Device Triggers. The `controller_entity` input is deprecated and `controller_device` is now mandatory. Remove `controller_entity` from your automation and configure `controller_device` with your controller device ID. (Thanks [@yarafie](https://github.com/yarafie))",
@@ -178,7 +178,7 @@
     ]
   },
   {
-    "date": "2025-02-16",
+    "date": "2025.02.16",
     "changes": [
       {
         "description": "Add support for Xiaomi WXKG01LM Mi Wireless Switch and rename Xiaomi WXKG11LM Aqara Wireless Switch Mini to Aqara WXKG11LM Wireless Mini Switch. Update the `controller_model` input accordingly if needed.",
@@ -187,7 +187,7 @@
     ]
   },
   {
-    "date": "2025-03-20",
+    "date": "2025.03.20",
     "changes": [
       {
         "description": "Add support for IKEA E2201 RODRET Dimmer. (Thanks [@yarafie](https://github.com/yarafie))",
@@ -196,7 +196,7 @@
     ]
   },
   {
-    "date": "2025-03-26",
+    "date": "2025.03.26",
     "changes": [
       {
         "description": "Add support for IKEA E2213 SOMRIG shortcut button. (Thanks [@yarafie](https://github.com/yarafie))",
@@ -205,7 +205,7 @@
     ]
   },
   {
-    "date": "2025-03-28",
+    "date": "2025.03.28",
     "changes": [
       {
         "description": "Add support for IKEA E2123 SYMFONISK sound remote, gen 2. (Thanks [@yarafie](https://github.com/yarafie))",
@@ -214,7 +214,7 @@
     ]
   },
   {
-    "date": "2025-03-29",
+    "date": "2025.03.29",
     "changes": [
       {
         "description": "Add support for Tuya ERS-10TZBVK-AA Smart knob. (Thanks [@yarafie](https://github.com/yarafie))",

--- a/blueprints/hooks/media_player/media_player.yaml
+++ b/blueprints/hooks/media_player/media_player.yaml
@@ -89,6 +89,8 @@ blueprint:
           mode: box
 # Automation schema
 variables:
+  ahb_version: 2025.11.04
+  ahb_author: EPMatt
   # convert blueprint inputs into variables to be used in templates
   controller_model: !input controller_model
   # supported controllers and mappings

--- a/blueprints/hooks/media_player/media_player.yaml
+++ b/blueprints/hooks/media_player/media_player.yaml
@@ -90,7 +90,7 @@ blueprint:
 # Automation schema
 variables:
   ahb_version: 2025.11.04
-  ahb_author: EPMatt
+  ahb_maintainers: [EPMatt]
   # convert blueprint inputs into variables to be used in templates
   controller_model: !input controller_model
   # supported controllers and mappings

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       react-json-view-lite:
         specifier: ^2.3.0
         version: 2.4.1(react@19.0.0)
+      react-select:
+        specifier: ^5.8.0
+        version: 5.10.2(@types/react@19.0.12)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
     devDependencies:
       '@docusaurus/module-type-aliases':
         specifier: ^3.7.0
@@ -1209,6 +1212,47 @@ packages:
     resolution: {integrity: sha512-e7zcB6TPnVzyUaHMJyLSArKa2AG3h9+4CfvKXKKWNx6hRs+p0a+u7HHTJBgo6KW2m+vqDnuIHK4X+bhmoghAFA==}
     engines: {node: '>=18.0'}
 
+  '@emotion/babel-plugin@11.13.5':
+    resolution: {integrity: sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==}
+
+  '@emotion/cache@11.14.0':
+    resolution: {integrity: sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==}
+
+  '@emotion/hash@0.9.2':
+    resolution: {integrity: sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==}
+
+  '@emotion/memoize@0.9.0':
+    resolution: {integrity: sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==}
+
+  '@emotion/react@11.14.0':
+    resolution: {integrity: sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: '>=16.8.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@emotion/serialize@1.3.3':
+    resolution: {integrity: sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==}
+
+  '@emotion/sheet@1.4.0':
+    resolution: {integrity: sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==}
+
+  '@emotion/unitless@0.10.0':
+    resolution: {integrity: sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==}
+
+  '@emotion/use-insertion-effect-with-fallbacks@1.2.0':
+    resolution: {integrity: sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@emotion/utils@1.4.2':
+    resolution: {integrity: sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==}
+
+  '@emotion/weak-memoize@0.4.0':
+    resolution: {integrity: sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==}
+
   '@eslint-community/eslint-utils@4.6.1':
     resolution: {integrity: sha512-KTsJMmobmbrFLe3LDh0PC2FXpcSYJt/MLjlkh/9LEnmKYLSYmT/0EW9JWANjeoemiuZrmogti0tW5Ch+qNUYDw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -1246,6 +1290,15 @@ packages:
   '@eslint/plugin-kit@0.2.8':
     resolution: {integrity: sha512-ZAoA40rNMPwSm+AeHpCq8STiNAwzWLJuP8Xv4CHIc9wv/PSuExjMrmjfYNj682vW0OOiZ1HKxzvjQr9XZIisQA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@floating-ui/core@1.7.3':
+    resolution: {integrity: sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==}
+
+  '@floating-ui/dom@1.7.4':
+    resolution: {integrity: sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==}
+
+  '@floating-ui/utils@0.2.10':
+    resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
 
   '@hapi/hoek@9.3.0':
     resolution: {integrity: sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==}
@@ -1604,6 +1657,11 @@ packages:
   '@types/react-router@5.1.20':
     resolution: {integrity: sha512-jGjmu/ZqS7FjSH6owMcD5qpq19+1RS9DeVRqfl1FeBMxTDQAGwlMWOcs52NDoXaNKyG3d1cYQFMs9rCrb88o9Q==}
 
+  '@types/react-transition-group@4.4.12':
+    resolution: {integrity: sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==}
+    peerDependencies:
+      '@types/react': '*'
+
   '@types/react@19.0.12':
     resolution: {integrity: sha512-V6Ar115dBDrjbtXSrS+/Oruobc+qVbbUxDFC1RSbRqLt5SYvxxyIDrSC85RWml54g+jfNeEMZhEj7wW07ONQhA==}
 
@@ -1929,6 +1987,10 @@ packages:
   babel-plugin-dynamic-import-node@2.3.3:
     resolution: {integrity: sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==}
 
+  babel-plugin-macros@3.1.0:
+    resolution: {integrity: sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==}
+    engines: {node: '>=10', npm: '>=6'}
+
   babel-plugin-polyfill-corejs2@0.4.12:
     resolution: {integrity: sha512-CPWT6BwvhrTO2d8QVorhTCQw9Y43zOu7G9HigcfxvepOU6b8o3tcWad6oVgZIsZCTt42FFv97aA7ZJsbM4+8og==}
     peerDependencies:
@@ -2213,6 +2275,9 @@ packages:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
 
+  convert-source-map@1.9.0:
+    resolution: {integrity: sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
@@ -2248,6 +2313,10 @@ packages:
   cosmiconfig@6.0.0:
     resolution: {integrity: sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==}
     engines: {node: '>=8'}
+
+  cosmiconfig@7.1.0:
+    resolution: {integrity: sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==}
+    engines: {node: '>=10'}
 
   cosmiconfig@8.3.6:
     resolution: {integrity: sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==}
@@ -2512,6 +2581,9 @@ packages:
 
   dom-converter@0.2.0:
     resolution: {integrity: sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==}
+
+  dom-helpers@5.2.1:
+    resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
 
   dom-serializer@1.4.1:
     resolution: {integrity: sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==}
@@ -2904,6 +2976,9 @@ packages:
   find-cache-dir@4.0.0:
     resolution: {integrity: sha512-9ZonPT4ZAK4a+1pUPVPZJapbi7O5qbbJPdYw/NOQWZZbVLdDTYM3A4R9z/DpAM08IDaFGsvPgiGZ82WEwUDWjg==}
     engines: {node: '>=14.16'}
+
+  find-root@1.1.0:
+    resolution: {integrity: sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==}
 
   find-up@3.0.0:
     resolution: {integrity: sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==}
@@ -3830,6 +3905,9 @@ packages:
   memfs@3.5.3:
     resolution: {integrity: sha512-UERzLsxzllchadvbPs5aolHh65ISpKpM+ccLbOJ8/vvpBKmAWf+la7dXFy7Mr0ySHbdHrFv5kGFCUHHe6GFEmw==}
     engines: {node: '>= 4.0.0'}
+
+  memoize-one@6.0.0:
+    resolution: {integrity: sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==}
 
   merge-descriptors@1.0.3:
     resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
@@ -4871,6 +4949,18 @@ packages:
     peerDependencies:
       react: '>=15'
 
+  react-select@5.10.2:
+    resolution: {integrity: sha512-Z33nHdEFWq9tfnfVXaiM12rbJmk+QjFEztWLtmXqQhz6Al4UZZ9xc0wiatmGtUOCCnHN0WizL3tCMYRENX4rVQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  react-transition-group@4.4.5:
+    resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
+    peerDependencies:
+      react: '>=16.6.0'
+      react-dom: '>=16.6.0'
+
   react@19.0.0:
     resolution: {integrity: sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==}
     engines: {node: '>=0.10.0'}
@@ -5251,6 +5341,10 @@ packages:
   source-map-support@0.5.21:
     resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
 
+  source-map@0.5.7:
+    resolution: {integrity: sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==}
+    engines: {node: '>=0.10.0'}
+
   source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
@@ -5386,6 +5480,9 @@ packages:
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
       postcss: ^8.4.31
+
+  stylis@4.2.0:
+    resolution: {integrity: sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==}
 
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
@@ -5647,6 +5744,15 @@ packages:
       webpack: ^4.0.0 || ^5.0.0
     peerDependenciesMeta:
       file-loader:
+        optional: true
+
+  use-isomorphic-layout-effect@1.2.1:
+    resolution: {integrity: sha512-tpZZ+EX0gaghDAiFR37hj5MgY6ZN55kLiPkJsKxBMZ6GZdOSPJXiOzPM984oPYZ5AnehYx5WQp1+ME8I/P/pRA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
         optional: true
 
   util-deprecate@1.0.2:
@@ -7773,6 +7879,70 @@ snapshots:
       - uglify-js
       - webpack-cli
 
+  '@emotion/babel-plugin@11.13.5':
+    dependencies:
+      '@babel/helper-module-imports': 7.25.9
+      '@babel/runtime': 7.28.4
+      '@emotion/hash': 0.9.2
+      '@emotion/memoize': 0.9.0
+      '@emotion/serialize': 1.3.3
+      babel-plugin-macros: 3.1.0
+      convert-source-map: 1.9.0
+      escape-string-regexp: 4.0.0
+      find-root: 1.1.0
+      source-map: 0.5.7
+      stylis: 4.2.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@emotion/cache@11.14.0':
+    dependencies:
+      '@emotion/memoize': 0.9.0
+      '@emotion/sheet': 1.4.0
+      '@emotion/utils': 1.4.2
+      '@emotion/weak-memoize': 0.4.0
+      stylis: 4.2.0
+
+  '@emotion/hash@0.9.2': {}
+
+  '@emotion/memoize@0.9.0': {}
+
+  '@emotion/react@11.14.0(@types/react@19.0.12)(react@19.0.0)':
+    dependencies:
+      '@babel/runtime': 7.28.4
+      '@emotion/babel-plugin': 11.13.5
+      '@emotion/cache': 11.14.0
+      '@emotion/serialize': 1.3.3
+      '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@19.0.0)
+      '@emotion/utils': 1.4.2
+      '@emotion/weak-memoize': 0.4.0
+      hoist-non-react-statics: 3.3.2
+      react: 19.0.0
+    optionalDependencies:
+      '@types/react': 19.0.12
+    transitivePeerDependencies:
+      - supports-color
+
+  '@emotion/serialize@1.3.3':
+    dependencies:
+      '@emotion/hash': 0.9.2
+      '@emotion/memoize': 0.9.0
+      '@emotion/unitless': 0.10.0
+      '@emotion/utils': 1.4.2
+      csstype: 3.1.3
+
+  '@emotion/sheet@1.4.0': {}
+
+  '@emotion/unitless@0.10.0': {}
+
+  '@emotion/use-insertion-effect-with-fallbacks@1.2.0(react@19.0.0)':
+    dependencies:
+      react: 19.0.0
+
+  '@emotion/utils@1.4.2': {}
+
+  '@emotion/weak-memoize@0.4.0': {}
+
   '@eslint-community/eslint-utils@4.6.1(eslint@9.25.0(jiti@1.21.7))':
     dependencies:
       eslint: 9.25.0(jiti@1.21.7)
@@ -7816,6 +7986,17 @@ snapshots:
     dependencies:
       '@eslint/core': 0.13.0
       levn: 0.4.1
+
+  '@floating-ui/core@1.7.3':
+    dependencies:
+      '@floating-ui/utils': 0.2.10
+
+  '@floating-ui/dom@1.7.4':
+    dependencies:
+      '@floating-ui/core': 1.7.3
+      '@floating-ui/utils': 0.2.10
+
+  '@floating-ui/utils@0.2.10': {}
 
   '@hapi/hoek@9.3.0': {}
 
@@ -8252,6 +8433,10 @@ snapshots:
       '@types/history': 4.7.11
       '@types/react': 19.0.12
 
+  '@types/react-transition-group@4.4.12(@types/react@19.0.12)':
+    dependencies:
+      '@types/react': 19.0.12
+
   '@types/react@19.0.12':
     dependencies:
       csstype: 3.1.3
@@ -8676,6 +8861,12 @@ snapshots:
     dependencies:
       object.assign: 4.1.7
 
+  babel-plugin-macros@3.1.0:
+    dependencies:
+      '@babel/runtime': 7.28.4
+      cosmiconfig: 7.1.0
+      resolve: 1.22.11
+
   babel-plugin-polyfill-corejs2@0.4.12(@babel/core@7.26.10):
     dependencies:
       '@babel/compat-data': 7.26.8
@@ -8991,6 +9182,8 @@ snapshots:
 
   content-type@1.0.5: {}
 
+  convert-source-map@1.9.0: {}
+
   convert-source-map@2.0.0: {}
 
   cookie-signature@1.0.6: {}
@@ -9020,6 +9213,14 @@ snapshots:
   core-util-is@1.0.3: {}
 
   cosmiconfig@6.0.0:
+    dependencies:
+      '@types/parse-json': 4.0.2
+      import-fresh: 3.3.1
+      parse-json: 5.2.0
+      path-type: 4.0.0
+      yaml: 1.10.2
+
+  cosmiconfig@7.1.0:
     dependencies:
       '@types/parse-json': 4.0.2
       import-fresh: 3.3.1
@@ -9304,6 +9505,11 @@ snapshots:
   dom-converter@0.2.0:
     dependencies:
       utila: 0.4.0
+
+  dom-helpers@5.2.1:
+    dependencies:
+      '@babel/runtime': 7.28.4
+      csstype: 3.1.3
 
   dom-serializer@1.4.1:
     dependencies:
@@ -9912,6 +10118,8 @@ snapshots:
     dependencies:
       common-path-prefix: 3.0.0
       pkg-dir: 7.0.0
+
+  find-root@1.1.0: {}
 
   find-up@3.0.0:
     dependencies:
@@ -11024,6 +11232,8 @@ snapshots:
   memfs@3.5.3:
     dependencies:
       fs-monkey: 1.0.6
+
+  memoize-one@6.0.0: {}
 
   merge-descriptors@1.0.3: {}
 
@@ -12268,6 +12478,32 @@ snapshots:
       tiny-invariant: 1.3.3
       tiny-warning: 1.0.3
 
+  react-select@5.10.2(@types/react@19.0.12)(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
+    dependencies:
+      '@babel/runtime': 7.28.4
+      '@emotion/cache': 11.14.0
+      '@emotion/react': 11.14.0(@types/react@19.0.12)(react@19.0.0)
+      '@floating-ui/dom': 1.7.4
+      '@types/react-transition-group': 4.4.12(@types/react@19.0.12)
+      memoize-one: 6.0.0
+      prop-types: 15.8.1
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+      react-transition-group: 4.4.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      use-isomorphic-layout-effect: 1.2.1(@types/react@19.0.12)(react@19.0.0)
+    transitivePeerDependencies:
+      - '@types/react'
+      - supports-color
+
+  react-transition-group@4.4.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
+    dependencies:
+      '@babel/runtime': 7.28.4
+      dom-helpers: 5.2.1
+      loose-envify: 1.4.0
+      prop-types: 15.8.1
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+
   react@19.0.0: {}
 
   readable-stream@2.3.8:
@@ -12787,6 +13023,8 @@ snapshots:
       buffer-from: 1.1.2
       source-map: 0.6.1
 
+  source-map@0.5.7: {}
+
   source-map@0.6.1: {}
 
   source-map@0.7.4: {}
@@ -12952,6 +13190,8 @@ snapshots:
       browserslist: 4.24.4
       postcss: 8.5.3
       postcss-selector-parser: 6.1.2
+
+  stylis@4.2.0: {}
 
   supports-color@7.2.0:
     dependencies:
@@ -13223,6 +13463,12 @@ snapshots:
       webpack: 5.98.0
     optionalDependencies:
       file-loader: 6.2.0(webpack@5.98.0)
+
+  use-isomorphic-layout-effect@1.2.1(@types/react@19.0.12)(react@19.0.0):
+    dependencies:
+      react: 19.0.0
+    optionalDependencies:
+      '@types/react': 19.0.12
 
   util-deprecate@1.0.2: {}
 

--- a/website/package.json
+++ b/website/package.json
@@ -30,7 +30,8 @@
     "react-dom": "^19.0.0",
     "react-ga4": "^2.1.0",
     "react-json-view-lite": "^2.3.0",
-    "marked": "^12.0.0"
+    "marked": "^12.0.0",
+    "react-select": "^5.8.0"
   },
   "browserslist": {
     "production": [

--- a/website/src/components/blueprints_docs/BlueprintImportCard.tsx
+++ b/website/src/components/blueprints_docs/BlueprintImportCard.tsx
@@ -1,11 +1,92 @@
 import Link from '@docusaurus/Link'
 import { useEffect, useState } from 'react'
 import { getBlueprintDownloads } from '../../services/supabase'
+import { changelogsContext, blueprintsContext } from '../../utils'
+import yaml from 'yaml'
+import Select from 'react-select'
+import type { StylesConfig } from 'react-select'
+
+type VersionOption = { value: string; label: string }
+
+interface ChangelogEntry {
+  date: string
+  changes: Array<{ description: string; breaking: boolean }>
+}
 
 const styles = {
-  myHomeAssistantImage: {
-    width: '100%',
-    maxWidth: 212,
+  header: {
+    marginBottom: '1.5rem',
+  },
+  title: {
+    fontSize: '1.75rem',
+    fontWeight: 700,
+    color: 'var(--ifm-color-emphasis-900)',
+    margin: 0,
+    lineHeight: 1.2,
+  },
+  downloadCountBox: {
+    height: '100%',
+  },
+  downloadCountLabel: {
+    fontSize: '0.875rem',
+    fontWeight: 500,
+    color: 'var(--ifm-color-emphasis-700)',
+  },
+  downloadCountValue: {
+    fontSize: '1.25rem',
+    fontWeight: 700,
+    color: 'var(--ifm-color-emphasis-900)',
+  },
+  versionAndButtonContainer: {},
+  versionSelector: {
+    flex: 1,
+  },
+  versionLabel: {
+    display: 'block',
+    fontSize: '0.875rem',
+    fontWeight: 500,
+    color: 'var(--ifm-color-emphasis-900)',
+    marginBottom: '0.625rem',
+  },
+  spaceY: {
+    display: 'flex',
+    flexDirection: 'column' as const,
+    gap: '1.5rem',
+  },
+  maintainersContainer: {
+    display: 'flex',
+    flexDirection: 'column' as const,
+    gap: '0.75rem',
+    height: '100%',
+  },
+  maintainersLabel: {
+    fontSize: '0.875rem',
+    fontWeight: 500,
+    color: 'var(--ifm-color-emphasis-700)',
+  },
+  maintainersList: {
+    display: 'flex',
+    flexWrap: 'wrap' as const,
+    gap: '0.75rem',
+    alignItems: 'center',
+  },
+  maintainerItem: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '0.5rem',
+  },
+  maintainerAvatar: {
+    width: '32px',
+    height: '32px',
+    borderRadius: '50%',
+    objectFit: 'cover' as const,
+  },
+  maintainerLink: {
+    fontSize: '0.875rem',
+    color: 'var(--ifm-color-primary)',
+    textDecoration: 'none',
+    fontWeight: 500,
+    transition: 'opacity 0.2s ease',
   },
 }
 
@@ -14,9 +95,144 @@ interface BlueprintImportCardProps {
   id: string
 }
 
+/**
+ * Formats download count with K/M suffixes
+ */
+function formatDownloads(num: number | null): string {
+  if (num === null) return '–'
+  if (num >= 1000000) {
+    return `${(num / 1000000).toFixed(1)}M`
+  }
+  if (num >= 1000) {
+    return `${(num / 1000).toFixed(1)}K`
+  }
+  return num.toString()
+}
+
+/**
+ * Generates a GitHub avatar URL for a GitHub username
+ * @param username - GitHub username
+ * @returns GitHub avatar URL
+ */
+function getGitHubAvatarUrl(username: string): string {
+  // GitHub provides avatars via redirect from profile URL
+  // Format: https://github.com/{username}.png
+  // This redirects to the actual avatar image hosted on GitHub's CDN
+  // Size is controlled via CSS (styles.maintainerAvatar)
+  return `https://github.com/${username}.png`
+}
+
+/**
+ * Loads and extracts maintainers from blueprint YAML
+ * @param category - Blueprint category (e.g., 'automation', 'controllers')
+ * @param id - Blueprint ID
+ * @returns Array of maintainer usernames or empty array if not found
+ */
+function loadBlueprintMaintainers(category: string, id: string): string[] {
+  try {
+    const path = `./${category}/${id}/${id}.yaml`
+    const content = blueprintsContext(path)
+    const parsed = yaml.parse(content) as {
+      variables?: { ahb_maintainers?: string[] }
+    }
+
+    if (
+      parsed?.variables?.ahb_maintainers &&
+      Array.isArray(parsed.variables.ahb_maintainers)
+    ) {
+      return parsed.variables.ahb_maintainers
+    }
+
+    return []
+  } catch {
+    // If the file is not found or any error occurs, return empty array
+    return []
+  }
+}
+
+/**
+ * Loads and extracts versions from changelog.json
+ * @param category - Blueprint category (e.g., 'automation', 'controllers')
+ * @param id - Blueprint ID
+ * @returns Object containing sorted versions array and latest version, or null if no versions found
+ */
+function loadBlueprintVersions(
+  category: string,
+  id: string,
+): { versions: string[]; latestVersion: string } | null {
+  try {
+    const path = `./${category}/${id}/changelog.json`
+    const parsed = changelogsContext(path) as unknown as ChangelogEntry[]
+
+    if (!parsed || parsed.length === 0) {
+      return null
+    }
+
+    // Extract all dates and sort them (newest first)
+    const dates = parsed.map((entry) => entry.date)
+    // Sort dates in descending order (newest first)
+    // Dates are in "YYYY.MM.DD" format, so we can sort them as strings
+    const sortedDates = [...dates].sort((a, b) => b.localeCompare(a))
+
+    return {
+      versions: sortedDates,
+      latestVersion: sortedDates[0] || 'latest',
+    }
+  } catch {
+    // If the file is not found or any error occurs, return null
+    // The error message check is not needed here since we'll handle it gracefully
+    return null
+  }
+}
+
 function BlueprintImportCard({ category, id }: BlueprintImportCardProps) {
   const [downloadCount, setDownloadCount] = useState<number | null>(null)
   const [isLoading, setIsLoading] = useState<boolean>(false)
+  const [versions, setVersions] = useState<string[]>([])
+  const [selectedVersion, setSelectedVersion] = useState<string>('latest')
+  const [isLoadingVersions, setIsLoadingVersions] = useState<boolean>(true)
+  const [maintainers, setMaintainers] = useState<string[]>([])
+  const [isLoadingMaintainers, setIsLoadingMaintainers] =
+    useState<boolean>(true)
+
+  // Load changelog to extract versions
+  useEffect(() => {
+    let isMounted = true
+
+    const result = loadBlueprintVersions(category, id)
+
+    if (!isMounted) return
+
+    if (result) {
+      setVersions(result.versions)
+      setSelectedVersion(result.latestVersion)
+    } else {
+      setVersions([])
+      setSelectedVersion('latest')
+    }
+
+    setIsLoadingVersions(false)
+
+    return () => {
+      isMounted = false
+    }
+  }, [category, id])
+
+  // Load maintainers from blueprint YAML
+  useEffect(() => {
+    let isMounted = true
+
+    const maintainersList = loadBlueprintMaintainers(category, id)
+
+    if (!isMounted) return
+
+    setMaintainers(maintainersList)
+    setIsLoadingMaintainers(false)
+
+    return () => {
+      isMounted = false
+    }
+  }, [category, id])
 
   useEffect(() => {
     let isCancelled = false
@@ -35,35 +251,244 @@ function BlueprintImportCard({ category, id }: BlueprintImportCardProps) {
       isCancelled = true
     }
   }, [category, id])
+
   // New custom URL format that will redirect to the GitHub URL
-  const blueprintUrl = `/awesome-ha-blueprints/blueprints/${category}/${id}?version=latest`
+  const blueprintUrl = `/awesome-ha-blueprints/blueprints/${category}/${id}?version=${selectedVersion}`
+
+  // Get the latest version (first in sorted array, which is newest)
+  const latestVersion = versions.length > 0 ? versions[0] : null
+
+  // Prepare options for react-select
+  const versionOptions: VersionOption[] =
+    versions.length > 0
+      ? versions.map((version) => ({
+          value: version,
+          label: version === latestVersion ? `${version} (latest)` : version,
+        }))
+      : [{ value: 'latest', label: 'latest' }]
+
+  // Custom styles for react-select
+  const selectStyles: StylesConfig<VersionOption, false> = {
+    control: (provided, state) => ({
+      ...provided,
+      padding: '0.5rem 0.75rem',
+      fontSize: '0.9375rem',
+      border: `1px solid ${
+        state.isFocused
+          ? 'var(--ifm-color-primary)'
+          : 'var(--ifm-color-emphasis-300)'
+      }`,
+      borderRadius: 'var(--ifm-global-radius)',
+      backgroundColor: 'var(--ifm-background-color)',
+      color: 'var(--ifm-color-emphasis-900)',
+      cursor: 'pointer',
+      transition: 'border-color 0.2s ease',
+      boxShadow: state.isFocused
+        ? '0 0 0 1px var(--ifm-color-primary)'
+        : 'none',
+    }),
+    valueContainer: (provided) => ({
+      ...provided,
+      backgroundColor: 'var(--ifm-background-color)',
+    }),
+    indicatorsContainer: (provided) => ({
+      ...provided,
+      backgroundColor: 'var(--ifm-background-color)',
+    }),
+    dropdownIndicator: (provided, state) => ({
+      ...provided,
+      color: state.isFocused
+        ? 'var(--ifm-color-emphasis-900)'
+        : 'var(--ifm-color-emphasis-600)',
+      ':hover': {
+        color: 'var(--ifm-color-emphasis-900)',
+      },
+    }),
+    option: (provided, state) => ({
+      ...provided,
+      backgroundColor: state.isSelected
+        ? 'var(--ifm-color-primary)'
+        : state.isFocused
+          ? 'var(--ifm-color-emphasis-100)'
+          : 'var(--ifm-background-surface-color)',
+      color: state.isSelected
+        ? 'var(--ifm-color-primary-contrast-background)'
+        : 'var(--ifm-color-emphasis-900)',
+      cursor: 'pointer',
+      padding: '0.625rem 0.875rem',
+      fontSize: '0.9375rem',
+    }),
+    singleValue: (provided) => ({
+      ...provided,
+      color: 'var(--ifm-color-emphasis-900)',
+    }),
+    menu: (provided) => ({
+      ...provided,
+      backgroundColor: 'var(--ifm-background-color)',
+      border: '1px solid var(--ifm-color-emphasis-300)',
+      borderRadius: 'var(--ifm-global-radius)',
+      boxShadow: 'var(--ifm-global-shadow-md)',
+      zIndex: 9999,
+    }),
+    menuList: (provided) => ({
+      ...provided,
+      backgroundColor: 'var(--ifm-background-color)',
+      padding: 0,
+    }),
+    input: (provided) => ({
+      ...provided,
+      color: 'var(--ifm-color-emphasis-900)',
+    }),
+    placeholder: (provided) => ({
+      ...provided,
+      color: 'var(--ifm-color-emphasis-600)',
+    }),
+  }
 
   return (
-    <div className='card item shadow--md'>
-      <div className='card__header margin-bottom--md'>
-        <h3>Import this blueprint</h3>
-        <p className='margin-top--sm'>
-          Total downloads: {isLoading ? '…' : (downloadCount ?? '–')}
-        </p>
-      </div>
-      <div className='card__body'>
-        <div className='row row--no-gutters'>
-          <div className='col col--12'>
-            <h5>My Home Assistant</h5>
-            <p>
+    <>
+      <style>{`
+        .version-and-button-container {
+          display: flex;
+          flex-direction: column;
+          gap: 1.5rem;
+        }
+        @media (min-width: 996px) {
+          .version-and-button-container {
+            flex-direction: row;
+            align-items: flex-end;
+            gap: 1rem;
+          }
+          .version-selector-wrapper {
+            flex: 1;
+          }
+          .download-button-wrapper {
+            flex: 1;
+          }
+        }
+      `}</style>
+      <div className='container'>
+        <div className='row'>
+          {/* Maintainers */}
+          {isLoadingMaintainers ? (
+            <div
+              className='col col--6 margin-bottom--md'
+              style={styles.maintainersContainer}
+            >
+              <span style={styles.maintainersLabel}>Maintainers</span>
+              <p style={{ margin: 0, color: 'var(--ifm-color-emphasis-600)' }}>
+                Loading maintainers…
+              </p>
+            </div>
+          ) : maintainers.length > 0 ? (
+            <div
+              className='col col--6 margin-bottom--md'
+              style={styles.maintainersContainer}
+            >
+              <span style={styles.maintainersLabel}>Maintainers</span>
+              <div style={styles.maintainersList}>
+                {maintainers.map((username) => (
+                  <div key={username} style={styles.maintainerItem}>
+                    <img
+                      src={getGitHubAvatarUrl(username)}
+                      alt={`${username} avatar`}
+                      style={styles.maintainerAvatar}
+                    />
+                    <a
+                      href={`https://github.com/${username}`}
+                      target='_blank'
+                      rel='noopener noreferrer'
+                      style={styles.maintainerLink}
+                      onMouseEnter={(e) => {
+                        e.currentTarget.style.opacity = '0.8'
+                      }}
+                      onMouseLeave={(e) => {
+                        e.currentTarget.style.opacity = '1'
+                      }}
+                    >
+                      {username}
+                    </a>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ) : (
+            <div className='col col--6 margin-bottom--md'></div>
+          )}
+          {/* Total Downloads */}
+          <div
+            className='col col--6 margin-bottom--md'
+            style={styles.downloadCountBox}
+          >
+            <span style={styles.downloadCountLabel}>Total Downloads</span>
+            <div
+              className='blueprint-download-value'
+              style={styles.downloadCountValue}
+            >
+              {isLoading ? '…' : formatDownloads(downloadCount)}
+            </div>
+          </div>
+        </div>
+
+        {/* Version Selector and Import Button */}
+        {isLoadingVersions ? (
+          <div className='row'>
+            <div
+              className='col col--6 margin-bottom--md'
+              style={styles.versionSelector}
+            >
+              <label htmlFor='version-select' style={styles.maintainersLabel}>
+                Download
+              </label>
+              <p style={{ margin: 0, color: 'var(--ifm-color-emphasis-600)' }}>
+                Loading versions…
+              </p>
+            </div>
+          </div>
+        ) : (
+          <div
+            className='row version-and-button-container'
+            style={styles.versionAndButtonContainer}
+          >
+            <div
+              className='col col--6 margin-bottom--md'
+              style={styles.versionSelector}
+            >
+              <label htmlFor='version-select' style={styles.maintainersLabel}>
+                Download
+              </label>
+              <Select
+                inputId='version-select'
+                value={versionOptions.find(
+                  (option) => option.value === selectedVersion,
+                )}
+                onChange={(option) => {
+                  if (option) {
+                    setSelectedVersion(option.value)
+                  }
+                }}
+                options={versionOptions}
+                styles={selectStyles}
+                isSearchable={false}
+                menuPortalTarget={
+                  typeof document !== 'undefined' ? document.body : undefined
+                }
+                menuPosition='fixed'
+              />
+            </div>
+            {/* Import Button */}
+            <div className='col col--6 download-button-wrapper margin-bottom--md'>
               <Link to={blueprintUrl}>
                 <img
                   src='https://my.home-assistant.io/badges/blueprint_import.svg'
-                  alt='Open your Home Assistant instance and show the blueprint import dialog with a specific blueprint pre-filled.'
-                  style={styles.myHomeAssistantImage}
+                  alt='Import to Home Assistant'
                 />
               </Link>
-              <br />
-            </p>
+            </div>
           </div>
-        </div>
+        )}
       </div>
-    </div>
+    </>
   )
 }
 

--- a/website/src/components/blueprints_docs/BlueprintImportCard.tsx
+++ b/website/src/components/blueprints_docs/BlueprintImportCard.tsx
@@ -188,6 +188,7 @@ function loadBlueprintVersions(
 function BlueprintImportCard({ category, id }: BlueprintImportCardProps) {
   const [downloadCount, setDownloadCount] = useState<number | null>(null)
   const [isLoading, setIsLoading] = useState<boolean>(false)
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [versions, setVersions] = useState<string[]>([])
   const [selectedVersion, setSelectedVersion] = useState<string>('latest')
   const [isLoadingVersions, setIsLoadingVersions] = useState<boolean>(true)

--- a/website/src/components/blueprints_docs/BlueprintImportCard.tsx
+++ b/website/src/components/blueprints_docs/BlueprintImportCard.tsx
@@ -205,7 +205,9 @@ function BlueprintImportCard({ category, id }: BlueprintImportCardProps) {
 
     if (result) {
       setVersions(result.versions)
-      setSelectedVersion(result.latestVersion)
+      // disabled for now. only show latest version
+      // setSelectedVersion(result.latestVersion)
+      setSelectedVersion('latest')
     } else {
       setVersions([])
       setSelectedVersion('latest')
@@ -256,16 +258,18 @@ function BlueprintImportCard({ category, id }: BlueprintImportCardProps) {
   const blueprintUrl = `/awesome-ha-blueprints/blueprints/${category}/${id}?version=${selectedVersion}`
 
   // Get the latest version (first in sorted array, which is newest)
-  const latestVersion = versions.length > 0 ? versions[0] : null
+  // const latestVersion = versions.length > 0 ? versions[0] : null
 
   // Prepare options for react-select
-  const versionOptions: VersionOption[] =
-    versions.length > 0
-      ? versions.map((version) => ({
-          value: version,
-          label: version === latestVersion ? `${version} (latest)` : version,
-        }))
-      : [{ value: 'latest', label: 'latest' }]
+  // disabled for now. only show latest version
+  // const versionOptions: VersionOption[] =
+  //   versions.length > 0
+  //     ? versions.map((version) => ({
+  //         value: version,
+  //         label: version === latestVersion ? `${version} (latest)` : version,
+  //       }))
+  //     : [{ value: 'latest', label: 'latest' }]
+  const versionOptions: VersionOption[] = [{ value: 'latest', label: 'latest' }]
 
   // Custom styles for react-select
   const selectStyles: StylesConfig<VersionOption, false> = {


### PR DESCRIPTION
Thank you for taking the time to work on a Pull Request. Your contribution is really appreciated! :tada:
**Please don't delete any part of the template**, since keeping the provided structure will help maintainers to review your work more rapidly.

Sections marked as \* are required and need to be filled in.

## Proposed change\*

This PR sets up initial work for supporting version-aware blueprint importing. 
Blueprint and author information is added to blueprints.
Such information, together with the new structured changelogs introduced in #954, allow to define a list of versions available to download.

The Blueprint Download UI in the Blueprints page has been cleaned up and updated to display author and version information:

<img width="1093" height="778" alt="image" src="https://github.com/user-attachments/assets/a76c9596-659f-4c98-b2f3-50dce878a77b" />

At the moment, the version selection dropdown only allows to select the latest version as, currently, the versioned download logic has yet to be implemented.

Moreover, we standardize Changelog entries to the YYYY.MM.DD format, matching the future version naming scheme.

## Checklist\*

- [X] I followed sections of the [Contribution Guidelines](https://github.com/EPMatt/awesome-ha-blueprints/blob/main/CONTRIBUTING.md) relevant to changes I'm proposing.
- [X] I properly tested proposed changes on my system and confirm that they are working as expected.
- [X] I formatted files with Prettier using the command `npm run format` before submitting my Pull Request.
