### PR TITLE
Improve blueprint: IKEA E2201 dimmer - Correct model name for RODRET

### DIFF
--- a/blueprints/controllers/ikea_e2201/ikea_e2201.yaml
+++ b/blueprints/controllers/ikea_e2201/ikea_e2201.yaml
@@ -46,7 +46,7 @@ blueprint:
             # source: https://github.com/zigpy/zha-device-handlers/blob/dev/zhaquirks/ikea/twobtnremote.py#L206
             - integration: zha
               manufacturer: IKEA of Sweden
-              model: RODRET Dimmer
+              model: RODRET wireless dimmer
             # source: https://github.com/dresden-elektronik/deconz-rest-plugin/blob/8ae69a976bca13f22e8002a13ebe798d1e26c086/button_maps.json#L236
             - integration: deconz
               manufacturer: IKEA of Sweden


### PR DESCRIPTION
## Proposed change\*

In my environment, with `zha`, the model name isn't `RODRET Dimmer` but rather `RODRET wireless dimmer`
Don't know if it's just me or something changed recently..

(HA 2025.11.2)

## Checklist\*

- [v] I followed sections of the [Contribution Guidelines](https://github.com/EPMatt/awesome-ha-blueprints/blob/main/CONTRIBUTING.md) relevant to changes I'm proposing.
- [v] I properly tested proposed changes on my system and confirm that they are working as expected.
- [v] I formatted files with Prettier using the command `npm run format` before submitting my Pull Request.
