### PR TITLE
fix(controllers): Fix model name for E2213 in ZHA and deconz

### DIFF
--- a/blueprints/controllers/ikea_e2213/ikea_e2213.yaml
+++ b/blueprints/controllers/ikea_e2213/ikea_e2213.yaml
@@ -48,11 +48,11 @@ blueprint:
             # source: https://github.com/zigpy/zha-device-handlers/blob/dev/zhaquirks/ikea/somrigsmartbtn.py#L149
             - integration: zha
               manufacturer: IKEA of Sweden
-              model: SOMRIG Shortcut Button
+              model: SOMRIG shortcut button
             # source: https://github.com/dresden-elektronik/deconz-rest-plugin/blob/8ae69a976bca13f22e8002a13ebe798d1e26c086/button_maps.json#L343
             - integration: deconz
               manufacturer: IKEA of Sweden
-              model: SOMRIG Shortcut Button
+              model: SOMRIG shortcut button
           multiple: false
     # inputs for custom actions
     action_button_dots1_short:


### PR DESCRIPTION
This PR fixes the capitalization of the `model` property of the E2213 blueprint for the ZHA and deconz integrations. I have tested the original form with ZHA and got "no matching models found." With only lower case `shortcut button`, the model is found. Note that that matches the `model` used for MQTT. I only *assume* that the model name is the lower-case variant in deconz as well; it may be worth checking, leaving as is, or have both variants instead.

## Breaking change

May be breaking if (1) deconz uses a different model name or (2) different devices use different model names; then the breaking change is actually a bug.

## Proposed change\*

As stated above, my model isn't found with the current blueprint using ZHA.

## Checklist\*

- [x] I followed sections of the [Contribution Guidelines](https://github.com/EPMatt/awesome-ha-blueprints/blob/main/CONTRIBUTING.md) relevant to changes I'm proposing.
- [x] I properly tested proposed changes on my system and confirm that they are working as expected.
- [x] I formatted files with Prettier using the command `npm run format` before submitting my Pull Request.
