### PR TITLE
Also allow "SONOFF" as a manufacturer for SNZB-01 Blueprint

### DIFF
--- a/blueprints/controllers/sonoff_snzb01/sonoff_snzb01.yaml
+++ b/blueprints/controllers/sonoff_snzb01/sonoff_snzb01.yaml
@@ -55,6 +55,21 @@ blueprint:
             - integration: deconz
               manufacturer: eWeLink
               model: WB01
+            # source: https://www.zigbee2mqtt.io/devices/SNZB-01.html
+            - integration: mqtt
+              manufacturer: SONOFF
+              model: Wireless button
+            # For backwards compatability with z2m 1.x. model_id is added to end of model rather than a seperate attribute in z2m 2.x
+            - integration: mqtt
+              manufacturer: SONOFF
+              model: Wireless button (SNZB-01)
+            # source: https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Supported-Devices
+            - integration: zha
+              manufacturer: SONOFF
+              model: WB01
+            - integration: deconz
+              manufacturer: SONOFF
+              model: WB01
           multiple: false
     helper_last_controller_event:
       name: (Required) Helper - Last Controller Event


### PR DESCRIPTION
## Breaking change

None

## Proposed change

I've recently got two Sonoff SNZB-01 switches and they register with the manufacturer `SONOFF` and not as `eWeLink`
. This means they werent detected by this Blueprint. I've tested only with Z2M so far but expect the manufacturer to be `SONOFF` in zha and deconz to, so I added them both too.

Payload from MQTT:
```
device:
  hw_version: 0
  identifiers:
    - zigbee2mqtt_0x00124b002a551af0
  manufacturer: SONOFF
  model: Wireless button
  model_id: SNZB-01
````

## Checklist\*

- [ ] I followed sections of the [Contribution Guidelines](https://github.com/EPMatt/awesome-ha-blueprints/blob/main/CONTRIBUTING.md) relevant to changes I'm proposing.
- [x] I properly tested proposed changes on my system and confirm that they are working as expected.
- [ ] I formatted files with Prettier using the command `npm run format` before submitting my Pull Request.
